### PR TITLE
Add `@types/leb128`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "type": "module",
   "devDependencies": {
+    "@types/leb128": "^0.0.0",
     "@types/node": "^20.0.0",
     "@types/utf-8-validate": "^5.0.0",
     "bcp-47": "^2.0.0",
@@ -31,6 +32,7 @@
     "iso-15924": "^3.0.0",
     "iso-3166": "^4.0.0",
     "iso-639-3": "^3.0.0",
+    "leb128": "^0.0.5",
     "mdast-zone": "^6.0.0",
     "prettier": "^3.0.0",
     "remark-cli": "^11.0.0",

--- a/wasm-encode.js
+++ b/wasm-encode.js
@@ -21,22 +21,15 @@
 import {Buffer} from 'node:buffer'
 import fs from 'node:fs/promises'
 import process from 'node:process'
-// @ts-expect-error: untyped.
 import {unsigned, signed} from 'leb128'
 
 const data = await fs.readFile(process.argv[2])
 
-/** @type {Buffer} */
 const size = unsigned.encode(data.length)
-/** @type {Buffer} */
 const length = signed.encode(data.length)
-/** @type {Buffer} */
 const globalL = unsigned.encode(5 + length.length)
-/** @type {Buffer} */
 const dataL = unsigned.encode(5 + size.length + data.length)
-/** @type {Buffer} */
 const memoryPages = unsigned.encode(Math.ceil(data.length / 65_536))
-/** @type {Buffer} */
 const memoryL = unsigned.encode(2 + memoryPages.length)
 
 await fs.writeFile(


### PR DESCRIPTION
There’s no need anymore to use `@ts-expect-error` for the `leb128` import, or to cast the types its functions return.