### PR TITLE
Regenerate Hungarian

### DIFF
--- a/dictionaries/hu/index.aff
+++ b/dictionaries/hu/index.aff
@@ -6,11 +6,11 @@
 # GPL/LGPL/MPL license as published by the FSF and Mozilla Foundation.
 #
 #
-# Version: May 2023, 1.8
+# Version: March 2024, 1.8.1
 #
 # Home page: http://magyarispell.sourceforge.net
 #
-# 2002-2023 (c) László Németh <nemeth@numbertext.org> and Ferenc Godó
+# 2002-2024 (c) László Németh <nemeth@numbertext.org> and Ferenc Godó
 #
 # Thanks to
 # Tamás Szántó <tszanto@mol.hu>,
@@ -30,7 +30,7 @@
 # amelyet Németh László és Godó Ferenc készített, és a GPL/LGPL/MPL licenc
 # alatt közzétett a http://magyarispell.sourceforge.net oldalon.
 #
-# Magyar Ispell 1.8, 2023-05
+# Magyar Ispell 1.8.1, 2024-03
 #
 # Köszönet illeti a következőket:
 #
@@ -52,7 +52,7 @@
 NAME Magyar Ispell helyesírási szótár
 LANG hu_HU
 HOME http://magyarispell.sourceforge.net
-VERSION Magyar 1.8
+VERSION Magyar 1.8.1
 SET UTF-8
 KEY öüó|qwertzuiopőú|asdfghjkléáű|íyxcvbnm
 TRY íóútaeslzánorhgkiédmyőpvöbucfjüűxwq-.&agrave;
@@ -157,7 +157,7 @@ ICONV &fl; fl
 # - multicharacter suggestions
 # - well-sorted suggestions
 
-REP 170
+REP 171
 REP í i
 REP i í
 REP ó o
@@ -328,6 +328,7 @@ REP ssal$ sszal
 REP ssé$ sszé
 REP ssá$ sszá
 REP ^megfed megfedd
+REP lengépszer legnépszer REP # lengépszerűbb->legnépszerűbb
 
 SFX ˙ Y 3
 SFX ˙ ö ős/ÝňÔŘCWMjcTtx" ö
@@ -6344,13 +6345,16 @@ SFX d eg gett/nňÓ×BVLjcGRt eg
 SFX d eg gett eg
 SFX d eg gesz/& eg
 SFX d eg gek eg
-SFX c Y 34
+SFX c Y 38
 SFX c 0 szerűség/nňÓ×BVLjcTtY@ [^z]
 SFX c 0 szerűség/nňÓ×BVLjcTtY@ [^s]z
 SFX c 0 szerűség/nňÓ×BVLjcTtY@ [^s]sz
 SFX c 0 szerű/ŢÔŘCWMjcHR [^z]
 SFX c 0 szerű/ŢÔŘCWMjcHR [^s]z
 SFX c 0 szerű/ŢÔŘCWMjcHR [^s]sz
+SFX c 0 szerte [^z]
+SFX c 0 szerte [^s]z
+SFX c 0 szerte [^s]sz
 SFX c 0 mentesített/nňÓ×BVLjcGRt% [^m]m
 SFX c 0 mentesített [^m]m
 SFX c 0 mentesített/nňÓ×BVLjcGRt% [^m]
@@ -6379,6 +6383,7 @@ SFX c 0 beli/ĐÓ×BVLjcGR [^b]b
 SFX c 0 beli/ĐÓ×BVLjcGR [^b]
 SFX c 0 -szerűség/nňÓ×BVLjcTtY@ ssz
 SFX c 0 -szerű/ŢÔŘCWMjcHR ssz
+SFX c 0 -szerte ssz
 SFX W Y 134
 SFX W ö őül ö
 SFX W ö őéül ö

--- a/dictionaries/hu/index.dic
+++ b/dictionaries/hu/index.dic
@@ -1,4 +1,4 @@
-96669
+96919
 üzér/VËŻj×LÓnňéčłÄäTtYc¸źl
 üzletág/UmôŇyiYcÇ	üzletágak
 üzletvezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -16,7 +16,7 @@
 üzembentartó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 üzembehelyezés-/=
 üzembe_helyezés/VËŻj×LÓnňéčłÄäTtc¸źl
-üzemanyagár/UmôŇyiYcÇ	üzemanyagárak
+üzemanyagár/UmôŇyiYcÇ	üzemanyagáraküzem|anyag||ár
 üzemanyag/UĘŽiÖKŇmôáyÇżßQSsYcť
 üzem_közbeni
 üzem_közben
@@ -133,7 +133,7 @@
 üknagyaty/uQüknagyatya
 üknagyapa/ŐAUĘŽiĎŇáyÇżßYcť	üknagyap
 üknagyap/uQüknagyapa
-üknagyanya/ŐAUĘŽiĎŇáyÇżßYcť	üknagyany
+üknagyanya/ŐAUĘŽiĎŇáyÇżßYcť	üknagyanyük||nagy|anya
 üknagyany/uQüknagyanya
 ükaty/uQükatya
 ükapa/ŐAUĘŽiĎŇáyÇżßYcť	ükap
@@ -147,7 +147,7 @@
 ügyvédség/VËŻj×LÓnňéčłÄäTtYc¸źl
 ügyvédnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 ügyvédbojtár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-ügyvéd/tVËŻj×LÓnňéčłÄäRYc¸źl
+ügyvéd/tVËŻj×LÓnňéyČŔŕRTYcź
 ügyvivő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 ügyvitel/VËŻj×LÓnňéyČŔŕTtYcź
 ügyvezetőúr/wYUmôŇçic˛k
@@ -160,7 +160,7 @@
 ügylet/VËŻj×LÓnňéčłÄäTtYc¸źl
 ügykezelés/VËŻj×LÓnňéyČŔŕTtYcź
 ügyintézés/VËŻj×LÓnňéyČŔŕTtYcź
-ügyféloldal/UmôŇyiYcÇ	ügyféloldalak
+ügyféloldal/UmôŇyiYcÇ	ügyféloldalakügy|fél||oldal
 ügyfél/VÓnňyjYcČ	ügyfelek
 ügyesítés/VËŻj×LÓnňéčłÄäTtYc¸źl
 ügyeleti/ŐBVRËŻjĐÓéčłÄäYc¸ź
@@ -257,7 +257,7 @@
 útonállás/UĘŽiÖKŇmôáyÇżßSsYcť
 úton-útfélén
 úton-útfélen
-útnyilvántartás/UĘŽiÖKŇmôáyÇżßSsYcť
+útnyilvántartás/UĘŽiÖKŇmôáyÇżßSsYcťút||nyilván|tartás
 útmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 útmutató/ŐAUQĘŽiĎŇáyÇżßYcť
 útmutatás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -361,7 +361,7 @@
 újulat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 újul
 újtestamentum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-újságírónő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+újságírónő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝újság|író||nő
 újságíró/ŐAUQĘŽiĎŇáyÇżßYcť
 újságírás/UĘŽiÖKŇmôáyÇżßSsYcť
 újságárus/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -395,7 +395,7 @@
 újrafelhasználás/UĘŽiÖKŇmôáyÇżßSsYcťújra||fel|használás
 újrafelfegyverzés/VËŻj×LÓnňéčłÄäTtYc¸źl
 újrafelfedezés/VËŻj×LÓnňéyČŔŕTtYcźújra||fel|fedezés
-újrafeldolgozás/UĘŽiÖKŇmôáyÇżßSsYcť
+újrafeldolgozás/UĘŽiÖKŇmôáyÇżßSsYcťújra||fel|dolgozás
 újrafeladás/UĘŽiÖKŇmôáyÇżßSsYcťújra||fel|adás
 újraelosztás/UĘŽiÖKŇmôáyÇżßSsYcťújra||el|osztás
 újrabejegyzés/VËŻj×LÓnňéyČŔŕTtYcźújra||be|jegyzés
@@ -482,13 +482,13 @@
 ötödikes/VËŻj×LÓnňéčłÄäTtYc¸źl
 ötödike/BVÓŐĐśöt
 ötödik/c!VÓn×Llabhöt
-ötödféltrillió/AUŐĎŇKQxcˇĂżÇ
-ötödfélszázad/AUÖmŇKkQcˇĂżÇ
-ötödfélszáz/$UŮÖmŇSscÇ
-ötödfélmillió/AUŐĎŇKQxcˇĂżÇ
-ötödfélmilliárd/AUÖmŇKkQcˇĂżÇ
-ötödfélezer/VÓn×LlTtcČ
-ötödfélbillió/AUŐĎŇKQxcˇĂżÇ
+ötödféltrillió/AUŐĎŇKQxcˇĂżÇ	ötöd|fél||trillió
+ötödfélszázad/AUÖmŇKkQcˇĂżÇ	ötöd|fél||század
+ötödfélszáz/$UŮÖmŇSscÇ	ötöd|fél||száz
+ötödfélmillió/AUŐĎŇKQxcˇĂżÇ	ötöd|fél||millió
+ötödfélmilliárd/AUÖmŇKkQcˇĂżÇ	ötöd|fél||milliárd
+ötödfélezer/VÓn×LlTtcČ	ötöd|fél||ezer
+ötödfélbillió/AUŐĎŇKQxcˇĂżÇ	ötöd|fél||billió
 ötödfél/VÓnňyjYcČötödfél	ötödfélötödfelekötödfelek
 ötödannyian
 ötödannyi/UŐĎŇ
@@ -503,24 +503,24 @@
 ötvösség/VËŻj×LÓnňéčłÄäTtYc¸źl
 ötvös/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 ötvenötödik/!VÓn×Llbhötvenöt
-ötvenöttrillióan/bötvenöttrillió
-ötvenöttrillió/ĎŇŐAUÚQbci	ötvenöttrillióan
-ötvenöttrilliárd/mÖKkUÚQbci
-ötvenötmillióan/bötvenötmillió
-ötvenötmillió/ĎŇŐAUÚQbcj	ötvenötmillióan
-ötvenötmilliárdan/bötvenötmilliárd
-ötvenötmilliárd/mÖKkUÚQbci	ötvenötmilliárdan
-ötvenötfelé
-ötvenötezres/×BŐVbötvenötezer
-ötvenötezren/bötvenötezer
-ötvenötezrek/Ibötvenötezer
-ötvenötezredik/nÓ×BVÜbötvenötezer
-ötvenötezred/BVÜbötvenötezer
-ötvenötezer/ŐnBVÜjbc	ötvenötezresötvenötezrenötvenötezrekötvenötezredikötvenötezred
+ötvenöttrillióan/bötvenöttrillió	ötven|öt||trillióan
+ötvenöttrillió/ĎŇŐAUÚQbci	ötvenöttrillióan	ötven|öt||trillió
+ötvenöttrilliárd/mÖKkUÚQbci	ötven|öt||trilliárd
+ötvenötmillióan/bötvenötmillió	ötven|öt||millióan
+ötvenötmillió/ĎŇŐAUÚQbcj	ötvenötmillióan	ötven|öt||millió
+ötvenötmilliárdan/bötvenötmilliárd	ötven|öt||milliárdan
+ötvenötmilliárd/mÖKkUÚQbci	ötvenötmilliárdan	ötven|öt||milliárd
+ötvenötfeléötven|öt||felé
+ötvenötezres/×BŐVbötvenötezer	ötven|öt||ezres
+ötvenötezren/bötvenötezer	ötven|öt||ezren
+ötvenötezrek/Ibötvenötezer	ötven|öt||ezrek
+ötvenötezredik/nÓ×BVÜbötvenötezer	ötven|öt||ezredik
+ötvenötezred/BVÜbötvenötezer	ötven|öt||ezred
+ötvenötezer/ŐnBVÜjbc	ötvenötezresötvenötezrenötvenötezrekötvenötezredikötvenötezred	ötven|öt||ezer
 ötvenöten/bhötvenöt
-ötvenötbillióan/bötvenötbillió
-ötvenötbillió/ĎŇŐAUÚQbci	ötvenötbillióan
-ötvenötbilliárd/mÖKkUÚQbci
+ötvenötbillióan/bötvenötbillió	ötven|öt||billióan
+ötvenötbillió/ĎŇŐAUÚQbci	ötvenötbillióan	ötven|öt||billió
+ötvenötbilliárd/mÖKkUÚQbci	ötven|öt||billiárd
 ötvenöt/ÝWŰMRbhc	ötvenötödikötvenöten
 ötvenóránként
 ötvenórai
@@ -528,6 +528,12 @@
 ötvenévente
 ötvenévenként
 ötvenzłotys/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+ötvenvalahánymillió/ĎŇŐAUÚQbcj	ötven|valahány||millió
+ötvenvalahánymilliárd/mÖKkUÚQbci	ötven|valahány||milliárd
+ötvenvalahányfeléötven|valahány||felé
+ötvenvalahányezres/×BŐVbötvenvalahányezer	ötven|valahány||ezres
+ötvenvalahányezren/bötvenvalahányezer	ötven|valahány||ezren
+ötvenvalahányezer/ŐnBVÜjbc	ötvenvalahányezresötvenvalahányezren	ötven|valahány||ezer
 ötvenvalahányan/bh)ötvenvalahány
 ötvenvalahányan/bh)
 ötvenvalahányadikak/nI)ötvenvalahány
@@ -540,46 +546,46 @@
 ötvenrubeles/VËŻj×LÓnňéčłÄäTtYc¸źl
 ötvenpercenként
 ötvenpennys/VËŻj×LÓnňéčłÄäTtYc¸źlöt-ven|pen-nys
-ötvennégytrillióan/bötvennégytrillió
-ötvennégytrillió/ĎŇŐAUÚQbci	ötvennégytrillióan
-ötvennégytrilliárd/mÖKkUÚQbci
-ötvennégymillióan/bötvennégymillió
-ötvennégymillió/ĎŇŐAUÚQbcj	ötvennégymillióan
-ötvennégymilliárdan/bötvennégymilliárd
-ötvennégymilliárd/mÖKkUÚQbci	ötvennégymilliárdan
-ötvennégyfelé
-ötvennégyezres/×BŐVbötvennégyezer
-ötvennégyezren/bötvennégyezer
-ötvennégyezrek/Ibötvennégyezer
-ötvennégyezredik/nÓ×BVÜbötvennégyezer
-ötvennégyezred/BVÜbötvennégyezer
-ötvennégyezer/ŐnBVÜjbc	ötvennégyezresötvennégyezrenötvennégyezrekötvennégyezredikötvennégyezred
+ötvennégytrillióan/bötvennégytrillió	ötven|négy||trillióan
+ötvennégytrillió/ĎŇŐAUÚQbci	ötvennégytrillióan	ötven|négy||trillió
+ötvennégytrilliárd/mÖKkUÚQbci	ötven|négy||trilliárd
+ötvennégymillióan/bötvennégymillió	ötven|négy||millióan
+ötvennégymillió/ĎŇŐAUÚQbcj	ötvennégymillióan	ötven|négy||millió
+ötvennégymilliárdan/bötvennégymilliárd	ötven|négy||milliárdan
+ötvennégymilliárd/mÖKkUÚQbci	ötvennégymilliárdan	ötven|négy||milliárd
+ötvennégyfeléötven|négy||felé
+ötvennégyezres/×BŐVbötvennégyezer	ötven|négy||ezres
+ötvennégyezren/bötvennégyezer	ötven|négy||ezren
+ötvennégyezrek/Ibötvennégyezer	ötven|négy||ezrek
+ötvennégyezredik/nÓ×BVÜbötvennégyezer	ötven|négy||ezredik
+ötvennégyezred/BVÜbötvennégyezer	ötven|négy||ezred
+ötvennégyezer/ŐnBVÜjbc	ötvennégyezresötvennégyezrenötvennégyezrekötvennégyezredikötvennégyezred	ötven|négy||ezer
 ötvennégyen/bhötvennégy
-ötvennégybillióan/bötvennégybillió
-ötvennégybillió/ĎŇŐAUÚQbci	ötvennégybillióan
-ötvennégybilliárd/mÖKkUÚQbci
+ötvennégybillióan/bötvennégybillió	ötven|négy||billióan
+ötvennégybillió/ĎŇŐAUÚQbci	ötvennégybillióan	ötven|négy||billió
+ötvennégybilliárd/mÖKkUÚQbci	ötven|négy||billiárd
 ötvennégy/nVÜLlTtbhc	ötvennégyenötvennegyedik
-ötvennyolctrillióan/bötvennyolctrillió
-ötvennyolctrillió/ĎŇŐAUÚQbci	ötvennyolctrillióan
-ötvennyolctrilliárd/mÖKkUÚQbci
-ötvennyolcmillióan/bötvennyolcmillió
-ötvennyolcmillió/ĎŇŐAUÚQbcj	ötvennyolcmillióan
-ötvennyolcmilliárdan/bötvennyolcmilliárd
-ötvennyolcmilliárd/mÖKkUÚQbci	ötvennyolcmilliárdan
-ötvennyolcfelé
-ötvennyolcezres/×BŐVbötvennyolcezer
-ötvennyolcezren/bötvennyolcezer
-ötvennyolcezrek/Ibötvennyolcezer
-ötvennyolcezredik/nÓ×BVÜbötvennyolcezer
-ötvennyolcezred/BVÜbötvennyolcezer
-ötvennyolcezer/ŐnBVÜjbc	ötvennyolcezresötvennyolcezrenötvennyolcezrekötvennyolcezredikötvennyolcezred
-ötvennyolcbillióan/bötvennyolcbillió
-ötvennyolcbillió/ĎŇŐAUÚQbci	ötvennyolcbillióan
-ötvennyolcbilliárd/mÖKkUÚQbci
-ötvennyolcan/bhötvennyolc
-ötvennyolcadikak/nIötvennyolc
-ötvennyolcadik/!AUÖmŇŮKkbhötvennyolc
-ötvennyolc/môA$UÚSsbhc	ötvennyolcanötvennyolcadikakötvennyolcadik
+ötvennyolctrillióan/bötvennyolctrillió	ötven|nyolc||trillióan
+ötvennyolctrillió/ĎŇŐAUÚQbci	ötvennyolctrillióan	ötven|nyolc||trillió
+ötvennyolctrilliárd/mÖKkUÚQbci	ötven|nyolc||trilliárd
+ötvennyolcmillióan/bötvennyolcmillió	ötven|nyolc||millióan
+ötvennyolcmillió/ĎŇŐAUÚQbcj	ötvennyolcmillióan	ötven|nyolc||millió
+ötvennyolcmilliárdan/bötvennyolcmilliárd	ötven|nyolc||milliárdan
+ötvennyolcmilliárd/mÖKkUÚQbci	ötvennyolcmilliárdan	ötven|nyolc||milliárd
+ötvennyolcfeléötven|nyolc||felé
+ötvennyolcezres/×BŐVbötvennyolcezer	ötven|nyolc||ezres
+ötvennyolcezren/bötvennyolcezer	ötven|nyolc||ezren
+ötvennyolcezrek/Ibötvennyolcezer	ötven|nyolc||ezrek
+ötvennyolcezredik/nÓ×BVÜbötvennyolcezer	ötven|nyolc||ezredik
+ötvennyolcezred/BVÜbötvennyolcezer	ötven|nyolc||ezred
+ötvennyolcezer/ŐnBVÜjbc	ötvennyolcezresötvennyolcezrenötvennyolcezrekötvennyolcezredikötvennyolcezred	ötven|nyolc||ezer
+ötvennyolcbillióan/bötvennyolcbillió	ötven|nyolc||billióan
+ötvennyolcbillió/ĎŇŐAUÚQbci	ötvennyolcbillióan	ötven|nyolc||billió
+ötvennyolcbilliárd/mÖKkUÚQbci	ötven|nyolc||billiárd
+ötvennyolcan/bhötvennyolc	ötven|nyolcan
+ötvennyolcadikak/nIötvennyolc	ötven|nyolcadikak
+ötvennyolcadik/!AUÖmŇŮKkbhötvennyolc	ötven|nyolcadik
+ötvennyolc/môA$UÚSsbhc	ötvennyolcanötvennyolcadikakötvennyolcadik	ötven|nyolc
 ötvennegyedik/!VÓn×Llbhötvennégy
 ötvennaponta
 ötvennaponként
@@ -588,99 +594,99 @@
 ötvenmillió/ĎŇŐAUÚQbcj	ötvenmillióan
 ötvenmilliárdan/bötvenmilliárd
 ötvenmilliárd/mÖKkUÚQbci	ötvenmilliárdan
-ötvenkéttrillióan/bötvenkéttrillió
-ötvenkéttrillió/ĎŇŐAUÚQbci	ötvenkéttrillióan
-ötvenkéttrilliárd/mÖKkUÚQbci
-ötvenkétmillióan/bötvenkétmillió
-ötvenkétmillió/ĎŇŐAUÚQbcj	ötvenkétmillióan
-ötvenkétmilliárdan/bötvenkétmilliárd
-ötvenkétmilliárd/mÖKkUÚQbci	ötvenkétmilliárdan
-ötvenkétfelé
-ötvenkétezres/×BŐVbötvenkétezer
-ötvenkétezren/bötvenkétezer
-ötvenkétezrek/Ibötvenkétezer
-ötvenkétezredik/nÓ×BVÜbötvenkétezer
-ötvenkétezred/BVÜbötvenkétezer
-ötvenkétezer/ŐnBVÜjbc	ötvenkétezresötvenkétezrenötvenkétezrekötvenkétezredikötvenkétezred
-ötvenkétbillióan/bötvenkétbillió
-ötvenkétbillió/ĎŇŐAUÚQbci	ötvenkétbillióan
-ötvenkétbilliárd/mÖKkUÚQbci
+ötvenkéttrillióan/bötvenkéttrillió	ötven|két||trillióan
+ötvenkéttrillió/ĎŇŐAUÚQbci	ötvenkéttrillióan	ötven|két||trillió
+ötvenkéttrilliárd/mÖKkUÚQbci	ötven|két||trilliárd
+ötvenkétmillióan/bötvenkétmillió	ötven|két||millióan
+ötvenkétmillió/ĎŇŐAUÚQbcj	ötvenkétmillióan	ötven|két||millió
+ötvenkétmilliárdan/bötvenkétmilliárd	ötven|két||milliárdan
+ötvenkétmilliárd/mÖKkUÚQbci	ötvenkétmilliárdan	ötven|két||milliárd
+ötvenkétfeléötven|két||felé
+ötvenkétezres/×BŐVbötvenkétezer	ötven|két||ezres
+ötvenkétezren/bötvenkétezer	ötven|két||ezren
+ötvenkétezrek/Ibötvenkétezer	ötven|két||ezrek
+ötvenkétezredik/nÓ×BVÜbötvenkétezer	ötven|két||ezredik
+ötvenkétezred/BVÜbötvenkétezer	ötven|két||ezred
+ötvenkétezer/ŐnBVÜjbc	ötvenkétezresötvenkétezrenötvenkétezrekötvenkétezredikötvenkétezred	ötven|két||ezer
+ötvenkétbillióan/bötvenkétbillió	ötven|két||billióan
+ötvenkétbillió/ĎŇŐAUÚQbci	ötvenkétbillióan	ötven|két||billió
+ötvenkétbilliárd/mÖKkUÚQbci	ötven|két||billiárd
 ötvenkét/bÜhc
-ötvenkilenctrillióan/bötvenkilenctrillió
-ötvenkilenctrillió/ĎŇŐAUÚQbci	ötvenkilenctrillióan
-ötvenkilenctrilliárd/mÖKkUÚQbci
-ötvenkilencmillióan/bötvenkilencmillió
-ötvenkilencmillió/ĎŇŐAUÚQbcj	ötvenkilencmillióan
-ötvenkilencmilliárdan/bötvenkilencmilliárd
-ötvenkilencmilliárd/mÖKkUÚQbci	ötvenkilencmilliárdan
-ötvenkilencfelé
-ötvenkilencezres/×BŐVbötvenkilencezer
-ötvenkilencezren/bötvenkilencezer
-ötvenkilencezrek/Ibötvenkilencezer
-ötvenkilencezredik/nÓ×BVÜbötvenkilencezer
-ötvenkilencezred/BVÜbötvenkilencezer
-ötvenkilencezer/ŐnBVÜjbc	ötvenkilencezresötvenkilencezrenötvenkilencezrekötvenkilencezredikötvenkilencezred
+ötvenkilenctrillióan/bötvenkilenctrillió	ötven|kilenc||trillióan
+ötvenkilenctrillió/ĎŇŐAUÚQbci	ötvenkilenctrillióan	ötven|kilenc||trillió
+ötvenkilenctrilliárd/mÖKkUÚQbci	ötven|kilenc||trilliárd
+ötvenkilencmillióan/bötvenkilencmillió	ötven|kilenc||millióan
+ötvenkilencmillió/ĎŇŐAUÚQbcj	ötvenkilencmillióan	ötven|kilenc||millió
+ötvenkilencmilliárdan/bötvenkilencmilliárd	ötven|kilenc||milliárdan
+ötvenkilencmilliárd/mÖKkUÚQbci	ötvenkilencmilliárdan	ötven|kilenc||milliárd
+ötvenkilencfeléötven|kilenc||felé
+ötvenkilencezres/×BŐVbötvenkilencezer	ötven|kilenc||ezres
+ötvenkilencezren/bötvenkilencezer	ötven|kilenc||ezren
+ötvenkilencezrek/Ibötvenkilencezer	ötven|kilenc||ezrek
+ötvenkilencezredik/nÓ×BVÜbötvenkilencezer	ötven|kilenc||ezredik
+ötvenkilencezred/BVÜbötvenkilencezer	ötven|kilenc||ezred
+ötvenkilencezer/ŐnBVÜjbc	ötvenkilencezresötvenkilencezrenötvenkilencezrekötvenkilencezredikötvenkilencezred	ötven|kilenc||ezer
 ötvenkilencen/bhötvenkilenc
 ötvenkilencedik/!VÓn×Llbhötvenkilenc
-ötvenkilencbillióan/bötvenkilencbillió
-ötvenkilencbillió/ĎŇŐAUÚQbci	ötvenkilencbillióan
-ötvenkilencbilliárd/mÖKkUÚQbci
+ötvenkilencbillióan/bötvenkilencbillió	ötven|kilenc||billióan
+ötvenkilencbillió/ĎŇŐAUÚQbci	ötvenkilencbillióan	ötven|kilenc||billió
+ötvenkilencbilliárd/mÖKkUÚQbci	ötven|kilenc||billiárd
 ötvenkilenc/nňVÜLlTtbhc	ötvenkilencenötvenkilencedik
-ötvenkettőtrillióan/bötvenkettőtrillió
-ötvenkettőtrillió/ĎŇŐAUÚQbci	ötvenkettőtrillióan
-ötvenkettőtrilliárd/mÖKkUÚQbci
-ötvenkettőmillióan/bötvenkettőmillió
-ötvenkettőmillió/ĎŇŐAUÚQbcj	ötvenkettőmillióan
-ötvenkettőmilliárdan/bötvenkettőmilliárd
-ötvenkettőmilliárd/mÖKkUÚQbci	ötvenkettőmilliárdan
-ötvenkettőfelé
-ötvenkettőezres/×BŐVbötvenkettőezer
-ötvenkettőezren/bötvenkettőezer
-ötvenkettőezrek/Ibötvenkettőezer
-ötvenkettőezredik/nÓ×BVÜbötvenkettőezer
-ötvenkettőezred/BVÜbötvenkettőezer
-ötvenkettőezer/ŐnBVÜjbc	ötvenkettőezresötvenkettőezrenötvenkettőezrekötvenkettőezredikötvenkettőezred
-ötvenkettőbillióan/bötvenkettőbillió
-ötvenkettőbillió/ĎŇŐAUÚQbci	ötvenkettőbillióan
-ötvenkettőbilliárd/mÖKkUÚQbci
+ötvenkettőtrillióan/bötvenkettőtrillió	ötven|kettő||trillióan
+ötvenkettőtrillió/ĎŇŐAUÚQbci	ötvenkettőtrillióan	ötven|kettő||trillió
+ötvenkettőtrilliárd/mÖKkUÚQbci	ötven|kettő||trilliárd
+ötvenkettőmillióan/bötvenkettőmillió	ötven|kettő||millióan
+ötvenkettőmillió/ĎŇŐAUÚQbcj	ötvenkettőmillióan	ötven|kettő||millió
+ötvenkettőmilliárdan/bötvenkettőmilliárd	ötven|kettő||milliárdan
+ötvenkettőmilliárd/mÖKkUÚQbci	ötvenkettőmilliárdan	ötven|kettő||milliárd
+ötvenkettőfeléötven|kettő||felé
+ötvenkettőezres/×BŐVbötvenkettőezer	ötven|kettő||ezres
+ötvenkettőezren/bötvenkettőezer	ötven|kettő||ezren
+ötvenkettőezrek/Ibötvenkettőezer	ötven|kettő||ezrek
+ötvenkettőezredik/nÓ×BVÜbötvenkettőezer	ötven|kettő||ezredik
+ötvenkettőezred/BVÜbötvenkettőezer	ötven|kettő||ezred
+ötvenkettőezer/ŐnBVÜjbc	ötvenkettőezresötvenkettőezrenötvenkettőezrekötvenkettőezredikötvenkettőezred	ötven|kettő||ezer
+ötvenkettőbillióan/bötvenkettőbillió	ötven|kettő||billióan
+ötvenkettőbillió/ĎŇŐAUÚQbci	ötvenkettőbillióan	ötven|kettő||billió
+ötvenkettőbilliárd/mÖKkUÚQbci	ötven|kettő||billiárd
 ötvenkettő/ŢWŰMRbhc	ötvenkettenötvenkettedik
 ötvenketten/bhötvenkettő
 ötvenkettedik/!VÓn×Llbhötvenkettő
-ötvenhéttrillióan/bötvenhéttrillió
-ötvenhéttrillió/ĎŇŐAUÚQbci	ötvenhéttrillióan
-ötvenhéttrilliárd/mÖKkUÚQbci
-ötvenhétmillióan/bötvenhétmillió
-ötvenhétmillió/ĎŇŐAUÚQbcj	ötvenhétmillióan
-ötvenhétmilliárdan/bötvenhétmilliárd
-ötvenhétmilliárd/mÖKkUÚQbci	ötvenhétmilliárdan
-ötvenhétfelé
-ötvenhétezres/×BŐVbötvenhétezer
-ötvenhétezren/bötvenhétezer
-ötvenhétezrek/Ibötvenhétezer
-ötvenhétezredik/nÓ×BVÜbötvenhétezer
-ötvenhétezred/BVÜbötvenhétezer
-ötvenhétezer/ŐnBVÜjbc	ötvenhétezresötvenhétezrenötvenhétezrekötvenhétezredikötvenhétezred
-ötvenhétbillióan/bötvenhétbillió
-ötvenhétbillió/ĎŇŐAUÚQbci	ötvenhétbillióan
-ötvenhétbilliárd/mÖKkUÚQbci
+ötvenhéttrillióan/bötvenhéttrillió	ötven|hét||trillióan
+ötvenhéttrillió/ĎŇŐAUÚQbci	ötvenhéttrillióan	ötven|hét||trillió
+ötvenhéttrilliárd/mÖKkUÚQbci	ötven|hét||trilliárd
+ötvenhétmillióan/bötvenhétmillió	ötven|hét||millióan
+ötvenhétmillió/ĎŇŐAUÚQbcj	ötvenhétmillióan	ötven|hét||millió
+ötvenhétmilliárdan/bötvenhétmilliárd	ötven|hét||milliárdan
+ötvenhétmilliárd/mÖKkUÚQbci	ötvenhétmilliárdan	ötven|hét||milliárd
+ötvenhétfeléötven|hét||felé
+ötvenhétezres/×BŐVbötvenhétezer	ötven|hét||ezres
+ötvenhétezren/bötvenhétezer	ötven|hét||ezren
+ötvenhétezrek/Ibötvenhétezer	ötven|hét||ezrek
+ötvenhétezredik/nÓ×BVÜbötvenhétezer	ötven|hét||ezredik
+ötvenhétezred/BVÜbötvenhétezer	ötven|hét||ezred
+ötvenhétezer/ŐnBVÜjbc	ötvenhétezresötvenhétezrenötvenhétezrekötvenhétezredikötvenhétezred	ötven|hét||ezer
+ötvenhétbillióan/bötvenhétbillió	ötven|hét||billióan
+ötvenhétbillió/ĎŇŐAUÚQbci	ötvenhétbillióan	ötven|hét||billió
+ötvenhétbilliárd/mÖKkUÚQbci	ötven|hét||billiárd
 ötvenhét/nVÜbhc	ötvenhetenötvenhetekötvenhetedik
-ötvenháromtrillióan/bötvenháromtrillió
-ötvenháromtrillió/ĎŇŐAUÚQbci	ötvenháromtrillióan
-ötvenháromtrilliárd/mÖKkUÚQbci
-ötvenhárommillióan/bötvenhárommillió
-ötvenhárommillió/ĎŇŐAUÚQbcj	ötvenhárommillióan
-ötvenhárommilliárdan/bötvenhárommilliárd
-ötvenhárommilliárd/mÖKkUÚQbci	ötvenhárommilliárdan
-ötvenháromfelé
-ötvenháromezres/×BŐVbötvenháromezer
-ötvenháromezren/bötvenháromezer
-ötvenháromezrek/Ibötvenháromezer
-ötvenháromezredik/nÓ×BVÜbötvenháromezer
-ötvenháromezred/BVÜbötvenháromezer
-ötvenháromezer/ŐnBVÜjbc	ötvenháromezresötvenháromezrenötvenháromezrekötvenháromezredikötvenháromezred
-ötvenhárombillióan/bötvenhárombillió
-ötvenhárombillió/ĎŇŐAUÚQbci	ötvenhárombillióan
-ötvenhárombilliárd/mÖKkUÚQbci
+ötvenháromtrillióan/bötvenháromtrillió	ötven|három||trillióan
+ötvenháromtrillió/ĎŇŐAUÚQbci	ötvenháromtrillióan	ötven|három||trillió
+ötvenháromtrilliárd/mÖKkUÚQbci	ötven|három||trilliárd
+ötvenhárommillióan/bötvenhárommillió	ötven|három||millióan
+ötvenhárommillió/ĎŇŐAUÚQbcj	ötvenhárommillióan	ötven|három||millió
+ötvenhárommilliárdan/bötvenhárommilliárd	ötven|három||milliárdan
+ötvenhárommilliárd/mÖKkUÚQbci	ötvenhárommilliárdan	ötven|három||milliárd
+ötvenháromfeléötven|három||felé
+ötvenháromezres/×BŐVbötvenháromezer	ötven|három||ezres
+ötvenháromezren/bötvenháromezer	ötven|három||ezren
+ötvenháromezrek/Ibötvenháromezer	ötven|három||ezrek
+ötvenháromezredik/nÓ×BVÜbötvenháromezer	ötven|három||ezredik
+ötvenháromezred/BVÜbötvenháromezer	ötven|három||ezred
+ötvenháromezer/ŐnBVÜjbc	ötvenháromezresötvenháromezrenötvenháromezrekötvenháromezredikötvenháromezred	ötven|három||ezer
+ötvenhárombillióan/bötvenhárombillió	ötven|három||billióan
+ötvenhárombillió/ĎŇŐAUÚQbci	ötvenhárombillióan	ötven|három||billió
+ötvenhárombilliárd/mÖKkUÚQbci	ötven|három||billiárd
 ötvenhárom/mUÚbhc	ötvenhármanötvenhármakötvenharmadikakötvenharmadik
 ötvenhárman/bhötvenhárom
 ötvenhármak/Ibhötvenhárom
@@ -693,25 +699,25 @@
 ötvenhavonta
 ötvenhavonként
 ötvenhavi
-ötvenhattrillióan/bötvenhattrillió
-ötvenhattrillió/ĎŇŐAUÚQbci	ötvenhattrillióan
-ötvenhattrilliárd/mÖKkUÚQbci
+ötvenhattrillióan/bötvenhattrillió	ötven|hat||trillióan
+ötvenhattrillió/ĎŇŐAUÚQbci	ötvenhattrillióan	ötven|hat||trillió
+ötvenhattrilliárd/mÖKkUÚQbci	ötven|hat||trilliárd
 ötvenhatodikak/nIötvenhat
 ötvenhatodik/!AUÖmŇŮKkbhötvenhat
-ötvenhatmillióan/bötvenhatmillió
-ötvenhatmillió/ĎŇŐAUÚQbcj	ötvenhatmillióan
-ötvenhatmilliárdan/bötvenhatmilliárd
-ötvenhatmilliárd/mÖKkUÚQbci	ötvenhatmilliárdan
-ötvenhatfelé
-ötvenhatezres/×BŐVbötvenhatezer
-ötvenhatezren/bötvenhatezer
-ötvenhatezrek/Ibötvenhatezer
-ötvenhatezredik/nÓ×BVÜbötvenhatezer
-ötvenhatezred/BVÜbötvenhatezer
-ötvenhatezer/ŐnBVÜjbc	ötvenhatezresötvenhatezrenötvenhatezrekötvenhatezredikötvenhatezred
-ötvenhatbillióan/bötvenhatbillió
-ötvenhatbillió/ĎŇŐAUÚQbci	ötvenhatbillióan
-ötvenhatbilliárd/mÖKkUÚQbci
+ötvenhatmillióan/bötvenhatmillió	ötven|hat||millióan
+ötvenhatmillió/ĎŇŐAUÚQbcj	ötvenhatmillióan	ötven|hat||millió
+ötvenhatmilliárdan/bötvenhatmilliárd	ötven|hat||milliárdan
+ötvenhatmilliárd/mÖKkUÚQbci	ötvenhatmilliárdan	ötven|hat||milliárd
+ötvenhatfeléötven|hat||felé
+ötvenhatezres/×BŐVbötvenhatezer	ötven|hat||ezres
+ötvenhatezren/bötvenhatezer	ötven|hat||ezren
+ötvenhatezrek/Ibötvenhatezer	ötven|hat||ezrek
+ötvenhatezredik/nÓ×BVÜbötvenhatezer	ötven|hat||ezredik
+ötvenhatezred/BVÜbötvenhatezer	ötven|hat||ezred
+ötvenhatezer/ŐnBVÜjbc	ötvenhatezresötvenhatezrenötvenhatezrekötvenhatezredikötvenhatezred	ötven|hat||ezer
+ötvenhatbillióan/bötvenhatbillió	ötven|hat||billióan
+ötvenhatbillió/ĎŇŐAUÚQbci	ötvenhatbillióan	ötven|hat||billió
+ötvenhatbilliárd/mÖKkUÚQbci	ötven|hat||billiárd
 ötvenhatan/bhötvenhat
 ötvenhat/mUÚKkbhc	ötvenhatodikakötvenhatodikötvenhatan
 ötvenharmadikak/nIötvenhárom
@@ -734,25 +740,25 @@
 ötvenes/VËŻj×LÓnňéčłÄäTtYc¸źlDGabh
 ötvenes/VËŻj×LÓnňéčłÄäTtYc¸źlDGabh
 ötvenen/bhötven
-ötvenegytrillióan/bötvenegytrillió
-ötvenegytrillió/ĎŇŐAUÚQbci	ötvenegytrillióan
-ötvenegytrilliárd/mÖKkUÚQbci
-ötvenegymillióan/bötvenegymillió
-ötvenegymillió/ĎŇŐAUÚQbcj	ötvenegymillióan
-ötvenegymilliárdan/bötvenegymilliárd
-ötvenegymilliárd/mÖKkUÚQbci	ötvenegymilliárdan
-ötvenegyfelé
-ötvenegyezres/×BŐVbötvenegyezer
-ötvenegyezren/bötvenegyezer
-ötvenegyezrek/Ibötvenegyezer
-ötvenegyezredik/nÓ×BVÜbötvenegyezer
-ötvenegyezred/BVÜbötvenegyezer
-ötvenegyezer/ŐnBVÜjbc	ötvenegyezresötvenegyezrenötvenegyezrekötvenegyezredikötvenegyezred
+ötvenegytrillióan/bötvenegytrillió	ötven|egy||trillióan
+ötvenegytrillió/ĎŇŐAUÚQbci	ötvenegytrillióan	ötven|egy||trillió
+ötvenegytrilliárd/mÖKkUÚQbci	ötven|egy||trilliárd
+ötvenegymillióan/bötvenegymillió	ötven|egy||millióan
+ötvenegymillió/ĎŇŐAUÚQbcj	ötvenegymillióan	ötven|egy||millió
+ötvenegymilliárdan/bötvenegymilliárd	ötven|egy||milliárdan
+ötvenegymilliárd/mÖKkUÚQbci	ötvenegymilliárdan	ötven|egy||milliárd
+ötvenegyfeléötven|egy||felé
+ötvenegyezres/×BŐVbötvenegyezer	ötven|egy||ezres
+ötvenegyezren/bötvenegyezer	ötven|egy||ezren
+ötvenegyezrek/Ibötvenegyezer	ötven|egy||ezrek
+ötvenegyezredik/nÓ×BVÜbötvenegyezer	ötven|egy||ezredik
+ötvenegyezred/BVÜbötvenegyezer	ötven|egy||ezred
+ötvenegyezer/ŐnBVÜjbc	ötvenegyezresötvenegyezrenötvenegyezrekötvenegyezredikötvenegyezred	ötven|egy||ezer
 ötvenegyen/bhötvenegy
 ötvenegyedik/VÓn×Llbhötvenegy
-ötvenegybillióan/bötvenegybillió
-ötvenegybillió/ĎŇŐAUÚQbci	ötvenegybillióan
-ötvenegybilliárd/mÖKkUÚQbci
+ötvenegybillióan/bötvenegybillió	ötven|egy||billióan
+ötvenegybillió/ĎŇŐAUÚQbci	ötvenegybillióan	ötven|egy||billió
+ötvenegybilliárd/mÖKkUÚQbci	ötven|egy||billiárd
 ötvenegy/nVÜLlbhc	ötvenegyenötvenegyedik
 ötvenedszerre/bhötvenedszer
 ötvenedszeri/bh
@@ -781,9 +787,9 @@
 ötszázmárkás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ötszázforintos/UĘŽiÖKŇmôáç˛ĂăSscˇťk
 ötszázfontos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-ötszázfelé
-ötszázezres/×BŐV
-ötszázezrek/Iötszázezer
+ötszázfeléöt|száz||felé
+ötszázezres/×BŐV	öt|száz||ezres
+ötszázezrek/Iötszázezer	öt|száz||ezrek
 ötszázeurós/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ötszázdolláros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ötszázas/UĘŽiÖKŇmôáç˛ĂăSsYcˇťkAFÚötszáz
@@ -791,7 +797,7 @@
 ötszázanötszáz
 ötszázadik/mŇŮAUÚötszáz
 ötszázad/AUÚötszáz
-ötszáz/$UŮÖmŇSscÚ	ötszázasötszázanötszázadikötszázadötszázasötszázadikötszázad
+ötszáz/$UŮÖmŇSscÚ	ötszázasötszázanötszázadikötszázad
 ötrubeles/VËŻj×LÓnňéčłÄäTtYc¸źl
 ötpróba/ŐAUQĘŽiĎŇáyÇżßYcť
 ötpercenként
@@ -831,7 +837,7 @@
 ötezerschillinges/VËŻj×LÓnňéčłÄäTtYc¸źl
 ötezerrubeles/VËŻj×LÓnňéčłÄäTtYc¸źl
 ötezerforintos/UĘŽiÖKŇmôáç˛ĂăSscˇťk
-ötezerfelé
+ötezerfeléöt|ezer||felé
 ötezer/ŐnBVÜjbcÓ×LlTts	ötezresötezrenötezrekötezredikötezred
 öteurós/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ötesztendőnként
@@ -842,7 +848,7 @@
 ötbillióan/bötbillió
 ötbillió/ĎŇŐAUÚQbci	ötbillióan
 ötbilliárd/mÖKkUÚQbci
-öt-hatmillió/ĎŇŐAUÚQbcw
+öt-hatmillió/ĎŇŐAUÚQbcw	öt-hat|millió
 öt/ÝWŰMRbhcÔŘma	ötükötödikiötödikeötödikötödötenötöd
 öszvér/VËŻj×LÓnňéyČŔŕRTtYcź
 ösztönzőleg
@@ -855,7 +861,7 @@
 ösztöke/ŐBVRËŻjĐÓéčłÄäYc¸ź
 ösztrogén/VËŻj×LÓnňéčłÄäRYc¸źl
 ösvény/VËŻj×LÓnňéčłÄäTtYc¸źl
-összóraszám/UĘŽiÖKŇmôáyÇżßSsYcť
+összóraszám/UĘŽiÖKŇmôáyÇżßSsYcťössz||óra|szám
 összóra/ŐAUQĘŽiĎŇáyÇżßYcť
 összérték/VËŻj×LÓnňéyČŔŕTtYcź
 összébb
@@ -888,14 +894,14 @@
 összteljesítmény/VËŻj×LÓnňéyČŔŕTtYcź
 össztartozás/UĘŽiÖKŇmôáyÇżßSsYcť
 összsúly/UĘŽiÖKŇmôáyÇżßSsYcť
-összpéldányszám/UĘŽiÖKŇmôáyÇżßSsYcť
+összpéldányszám/UĘŽiÖKŇmôáyÇżßSsYcťössz||példány|szám
 összpróba/ŐAUQĘŽiĎŇáyÇżßYcť
-összpontszám/UĘŽiÖKŇmôáyÇżßSsYcť
+összpontszám/UĘŽiÖKŇmôáyÇżßSsYcťössz||pont|szám
 összpontosul
 összoldalszám/UĘŽiÖKŇmôáyÇżßSsYcťössz||oldal|szám
 össznövekedés/VËŻj×LÓnňéyČŔŕTtYcź
 össznézőszám/UĘŽiÖKŇmôáyÇżßSsYcťössz||néző|szám
-össznévérték/VËŻj×LÓnňéyČŔŕTtYcź
+össznévérték/VËŻj×LÓnňéyČŔŕTtYcźössz||név|érték
 össznépesség/VËŻj×LÓnňéyČŔŕTtYcź
 össznyomás/UĘŽiÖKŇmôáyÇżßSsYcť
 össznyereség/VËŻj×LÓnňéyČŔŕTtYcź
@@ -909,13 +915,13 @@
 összminta/ŐAUQĘŽiĎŇáyÇżßYcť
 összmennyiség/VËŻj×LÓnňéyČŔŕTtYcź
 összmenetidő/ŐCWĚŻjŢÔíyČÁ˙Yc˝	összmenetidejössz||menet|idő
-összmenetidej/uxytT¸összmenetidő
+összmenetidej/uxytT¸összmenetidő	össz||menet|idő
 összmemória/ŐAUQĘŽiĎŇáyÇżßYcť
 összmegjelenés/VËŻj×LÓnňéyČŔŕTtYcźössz||meg|jelenés
 összmagyarság/UĘŽiÖKŇmôáyÇżßSsYcť
 összmagasság/UĘŽiÖKŇmôáyÇżßSsYcť
 összlökettérfogat/UĘŽiÖKŇmôáyÇżßSsYcťössz||löket||tér|fogat
-összlétszám/UĘŽiÖKŇmôáyÇżßSsYcť
+összlétszám/UĘŽiÖKŇmôáyÇżßSsYcťössz||lét|szám
 összlet/VËŻj×LÓnňéčłÄäTtYc¸źl
 összlakosság/UĘŽiÖKŇmôáyÇżßSsYcť
 összközmű/WŢŘÔyjYcČR	összközművekössz||köz|mű
@@ -934,8 +940,8 @@
 összkiadás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 összkezesség/VËŻj×LÓnňéyČŔŕTtYcź
 összkerület/VËŻj×LÓnňéyČŔŕTtYcź
-összkerékmeghajtás/UĘŽiÖKŇmôáyÇżßSsYc
-összkerékhajtás/UĘŽiÖKŇmôáyÇżßSsYcť
+összkerékmeghajtás/UĘŽiÖKŇmôáyÇżßSsYcössz|kerék||meghajtás
+összkerékhajtás/UĘŽiÖKŇmôáyÇżßSsYcťössz|kerék||hajtás
 összkeret/VËŻj×LÓnňéyČŔŕTtYcź
 összkereslet/VËŻj×LÓnňéyČŔŕTtYcź
 összkapitalizáció/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -958,7 +964,7 @@
 összhang/UĘŽiÖKŇmôáyÇżßQYcť
 összhalálozás/UĘŽiÖKŇmôáyÇżßSsYcť
 összhaderő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝	összhaderejössz||had|erő
-összhaderej/uxyT¸összhaderő
+összhaderej/uxyT¸összhaderő	össz||had|erő
 összfényesség/VËŻj×LÓnňéyČŔŕTtYcź
 összforrás/UĘŽiÖKŇmôáyÇżßSsYcť
 összforgalom/UmôyiYcŽ	összforgalmak
@@ -1068,7 +1074,7 @@
 örökszép/VËŻj×LÓnňéčłÄäRYc¸źl
 örökrész/VËŻj×LÓnňéyČŔŕTtYcź
 örökre
-öröknaptár/UmôŇyiYcÇ	öröknaptárak
+öröknaptár/UmôŇyiYcÇ	öröknaptárakörök||nap|tár
 örökmécses/VËŻj×LÓnňéčłÄäTtYc¸źl
 örökmécs/VËŻj×LÓnňéčłÄäTtYc¸źl
 örökmozgó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -1144,7 +1150,7 @@
 öregany/uQöreganya
 ördögűzés/VËŻj×LÓnňéyČŔŕTtYcź
 ördögszem/VËŻj×LÓnňéyČŔŕTtYcź
-ördögharaptafű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ördögharaptafüvek
+ördögharaptafű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ördögharaptafüvekördög|harapta||fű
 ördögfajzat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ördögadta
 ördög/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
@@ -1152,7 +1158,7 @@
 önérvényesítés/VËŻj×LÓnňéyČŔŕTtYcź
 önértékelés/VËŻj×LÓnňéyČŔŕTtYcź
 önérdek/VËŻj×LÓnňéyČŔŕTtYcź
-önéletrajz/UĘŽiÖKŇmôáyÇżßSsYcť
+önéletrajz/UĘŽiÖKŇmôáyÇżßSsYcťön||élet|rajz
 önátadás/UĘŽiÖKŇmôáyÇżßSsYcť
 önámítás/UĘŽiÖKŇmôáyÇżßSsYcť
 önáltatás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -1173,7 +1179,7 @@
 öntörvényűség/VËŻj×LÓnňéčłÄäTtYc¸źl
 öntömörödés/VËŻj×LÓnňéyČŔŕTtYcź
 öntöde/ŐBVRËŻjĐÓéčłÄäYc¸ź
-öntőműhely/VËŻj×LÓnňéyČŔŕTtYcź
+öntőműhely/VËŻj×LÓnňéyČŔŕTtYcźöntő||mű|hely
 öntőminta/ŐAUQĘŽiĎŇáyÇżßYcť
 öntőforma/ŐAUQĘŽiĎŇáyÇżßYcť
 öntészet/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -1236,7 +1242,7 @@
 önképzőkör/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ön|képző||kör
 önképzés/VËŻj×LÓnňéyČŔŕTtYcź
 önkép/VËŻj×LÓnňéyČŔŕTtYcź
-önkényuralom/UmôyiYcŽ	önkényuralmak
+önkényuralom/UmôyiYcŽ	önkényuralmakön|kény||uralom
 önkény/VËŻj×LÓnňéyČŔŕTtYcź
 önkéntes/VËŻj×LÓnňéčłÄäTtYc¸źl
 önként
@@ -1296,7 +1302,7 @@
 önbevallás/UĘŽiÖKŇmôáyÇżßSsYcťön||be|vallás
 önbecsülés/VËŻj×LÓnňéyČŔŕTtYcź
 önbecsapás/UĘŽiÖKŇmôáyÇżßSsYcťön||be|csapás
-önarckép/VËŻj×LÓnňéyČŔŕTtYcź
+önarckép/VËŻj×LÓnňéyČŔŕTtYcźön||arc|kép
 önalkotta
 önadózás/UĘŽiÖKŇmôáyÇżßSsYcť
 ön/WĚŻjŘMÝňÔíčłĹĺRc¸˝v
@@ -1332,7 +1338,7 @@
 ököriga/ŐAUQĘŽiĎŇáyÇżßYcť
 ökörhajcsár/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ökörgúzs/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-ökörfarkkóró/ŐAUQĘŽiĎŇáyÇżßYcť
+ökörfarkkóró/ŐAUQĘŽiĎŇáyÇżßYcťökör|fark||kóró
 ökörfark/UĘŽiÖKŇmôáyÇżßQYcť
 ökör/WÝčjYcŻl	ökrök
 ökölvívó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -1432,7 +1438,7 @@
 őszike/ŐBVRËŻjĐÓéčłÄäYc¸ź
 őszibarack/UĘŽiÖKŇmôáyÇżßQYcť
 ősziaraszoló/ŐAUQĘŽiĎŇáyÇżßYcť
-őszi-fésűsbagoly/UmôyiYcŽ	őszi-fésűsbaglyok
+őszi-fésűsbagoly/UmôyiYcŽ	őszi-fésűsbaglyokőszi-fésűs|bagoly
 őszes/VËŻj×LÓnňéčłÄäTtYc¸źl
 őszerintük/)
 őszerinte/)
@@ -1447,12 +1453,12 @@
 őstermelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 őstehetség/VËŻj×LÓnňéyČŔŕTtYcź
 ősszülő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝	ősszüleitekősszüleinkősszüleimősszüleikősszüleidősszüleiős|szü-lő
-ősszüleitek/VnÓ×ősszülő
-ősszüleink/VnÓ×ősszülő
-ősszüleim/VnÓ×ősszülő
-ősszüleik/VnÓ×ősszülő
-ősszüleid/VnÓ×ősszülő
-ősszülei/VĐÓ×ősszülő
+ősszüleitek/VnÓ×ősszülő	ős|szülő
+ősszüleink/VnÓ×ősszülő	ős|szülő
+ősszüleim/VnÓ×ősszülő	ős|szülő
+ősszüleik/VnÓ×ősszülő	ős|szülő
+ősszüleid/VnÓ×ősszülő	ős|szülő
+ősszülei/VĐÓ×ősszülő	ős|szülő
 őssejt/VËŻj×LÓnňéyČŔŕRYcź
 ősrobbanás/UĘŽiÖKŇmôáyÇżßSsYcť
 őspark/UĘŽiÖKŇmôáyÇżßQYcť
@@ -1462,7 +1468,7 @@
 ősmaradvány/UĘŽiÖKŇmôáyÇżßSsYcť
 ősmag/UĘŽiÖKŇmôáyÇżßQYcť
 ősló/UĎÖŇyiYcÇ	őslovak
-őslénytan/UĘŽiÖKŇmôáyÇżßSsYcť
+őslénytan/UĘŽiÖKŇmôáyÇżßSsYcťős|lény||tan
 őslény/VËŻj×LÓnňéyČŔŕTtYcź
 ősláp/UĘŽiÖKŇmôáyÇżßQYcť
 őslakó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -1487,7 +1493,7 @@
 ősember/VËŻj×LÓnňéyČŔŕTtYcź
 őselv/VËŻj×LÓnňéyČŔŕTtYcź
 őselem/VËŻj×LÓnňéyČŔŕTtYcź
-ősegyház/UmôŇyiYcÇ	ősegyházak
+ősegyház/UmôŇyiYcÇ	ősegyházakős||egy|ház
 ősbűn/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 ősbemutató/ŐAUQĘŽiĎŇáyÇżßYcťős||be|mutató
 ősatya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ősaty
@@ -1742,7 +1748,7 @@
 órazseb/VËŻj×LÓnňéyČŔŕTtYcź
 óratok/UĘŽiÖKŇmôáyÇżßQYcť
 óratartó/ŐAUQĘŽiĎŇáyÇżßYcť
-óraszámlap/UĘŽiÖKŇmôáyÇżßQYcť
+óraszámlap/UĘŽiÖKŇmôáyÇżßQYcťóra||szám|lap
 órarend/VËŻj×LÓnňéyČŔŕRYcź
 óraműves/VËŻj×LÓnňéyČŔŕTtYcź
 óramű/WŢŘÔyjYcČ	óraművek
@@ -1863,7 +1869,7 @@
 írüldözés/VËŻj×LÓnňéyČŔŕTtYcź
 íróvessző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 írótoll/UmôŇyiYcÇ	írótollak
-írószerszám/UĘŽiÖKŇmôáyÇżßQSsYcť
+írószerszám/UĘŽiÖKŇmôáyÇżßQSsYcťíró||szer|szám
 írószer/VËŻj×LÓnňéyČŔŕTtYcź
 írósvaj/UmôŇyiYcÇ	írósvajak
 írópapír/UĘŽiÖKŇmôáyÇżßQYcť
@@ -1871,7 +1877,7 @@
 írómappa/ŐAUQĘŽiĎŇáyÇżßYcť
 írólap/UĘŽiÖKŇmôáyÇżßQYcť
 íróka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-írógéphenger/VËŻj×LÓnňéyČŔŕTtYcź
+írógéphenger/VËŻj×LÓnňéyČŔŕTtYcźíró|gép||henger
 írógép/VËŻj×LÓnňéyČŔŕRTtYcź
 íróasztalka/ŐAUQĘŽiĎŇáyÇżßYcť
 íróasztal/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -1936,7 +1942,7 @@
 évmilliárd/UĘŽiÖKŇmôáyÇżßQYcť
 évmegnyitó/ŐAUQĘŽiĎŇáyÇżßYcť
 évkör/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
-évkönyvvezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+évkönyvvezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝év|könyv||vezető
 évkönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
 évkihagyás/UĘŽiÖKŇmôáyÇżßSsYcť
 évkezdet/VËŻj×LÓnňéyČŔŕTtYcź
@@ -1959,7 +1965,7 @@
 év_közben
 év/VËŻj×LÓnňéčłÄäTtYc¸ź
 étvágytalanság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-étvágygerjesztő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+étvágygerjesztő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ét|vágy||gerjesztő
 étvágy/UmôŇyiYcÇ	étvágyak
 étterembelső/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ét|terem||belső
 étterem/VnňyjYcŻ	éttermek
@@ -2091,7 +2097,7 @@
 érzéklet/VËŻj×LÓnňéčłÄäTtYc¸źl
 érzékfeletti/ŐBVRËŻjĐÓéčłÄäYc¸ź
 érzékenyül
-érzékelőrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+érzékelőrendszer/VËŻj×LÓnňéyČŔŕTtYcźérzékelő||rend|szer
 érzékcsalódás/UĘŽiÖKŇmôáyÇżßSsYcť
 érzék/VËŻj×LÓnňéčłÄäTtYc¸źl
 érzet/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -2108,7 +2114,7 @@
 érvényesül
 érvény/VËŻj×LÓnňéčłÄäTtYc¸źl
 érvágás/UĘŽiÖKŇmôáyÇżßSsYcť
-érverésmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+érverésmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ér|verés||mérő
 érverés/VËŻj×LÓnňéyČŔŕTtYcź
 érvel
 érv/VËŻj×LÓnňéčłÄäTtYc¸ź
@@ -2137,7 +2143,7 @@
 érszűkület/VËŻj×LÓnňéyČŔŕTtYcź
 érsekség/VËŻj×LÓnňéčłÄäTtYc¸źl
 érsek/VËŻj×LÓnňéčłÄäTtYc¸źl
-érrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+érrendszer/VËŻj×LÓnňéyČŔŕTtYcźér||rend|szer
 érpár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 érmészet/VËŻj×LÓnňéčłÄäTtYc¸źl
 érmész/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -2163,7 +2169,7 @@
 érettedérette
 éretteérette	őérettükőéretteérettünkérettükérettetekérettemérettedéretteénérettemérettetekérettedérettünk
 érem/VnňčjYcŻl	érmek
-érelzáródás/UĘŽiÖKŇmôáyÇżßSsYcť
+érelzáródás/UĘŽiÖKŇmôáyÇżßSsYcťér||el|záródás
 érelmeszesedés/VËŻj×LÓnňéyČŔŕTtYcźér||el|meszesedés
 érdestinóru/ŐAUQĘŽiĎŇáyÇżßYcť
 érdemrend/VËŻj×LÓnňéyČŔŕRYcź
@@ -2390,7 +2396,7 @@
 élettan/UĘŽiÖKŇmôáyÇżßSsYcť
 életszükséglet/VËŻj×LÓnňéyČŔŕTtYcź
 életrend/VËŻj×LÓnňéyČŔŕRYcź
-életrajzíró/ŐAUQĘŽiĎŇáyÇżßYcť
+életrajzíró/ŐAUQĘŽiĎŇáyÇżßYcťélet|rajz||író
 életrajz/UĘŽiÖKŇmôáyÇżßSsYcť
 életpálya/ŐAUQĘŽiĎŇáyÇżßYcť
 életnedv/VËŻj×LÓnňéyČŔŕTtYcź
@@ -2412,7 +2418,7 @@
 életforma/ŐAUQĘŽiĎŇáyÇżßYcť
 életfogytiglan/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 életfogytig/VËŻj×LÓnňéčłÄäRYc¸źl
-életfenntartás/UĘŽiÖKŇmôáyÇżßSsYcť
+életfenntartás/UĘŽiÖKŇmôáyÇżßSsYcťélet||fenn|tartás
 életfa/ŐAUQĘŽiĎŇáyÇżßYcť
 életerő/ŐCWĚŻjŢÔíyČÁ˙Yc˝	életerej
 életerej/uxyT¸életerő
@@ -2426,18 +2432,18 @@
 élesztő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 élestöltény/VËŻj×LÓnňéyČŔŕTtYcź
 élessásos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-élesmosófű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	élesmosófüvek
+élesmosófű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	élesmosófüvekéles|mosó||fű
 éleslövészet/VËŻj×LÓnňéyČŔŕTtYcź
-éleslőszer/VËŻj×LÓnňéyČŔŕTtYcź
+éleslőszer/VËŻj×LÓnňéyČŔŕTtYcźéles||lő|szer
 éleslátás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 élesit/w
 éleselméjűség/VËŻj×LÓnňéčłÄäTtYc¸źl
-élelmiszerüzlet/VËŻj×LÓnňéyČŔŕTtYcź
-élelmiszerárus/UĘŽiÖKŇmôáyÇżßSsYcť
-élelmiszeráru/ŐAUQĘŽiĎŇáyÇżßYcť
-élelmiszercsomag/UĘŽiÖKŇmôáyÇżßQYcť
-élelmiszerbolt/UĘŽiÖKŇmôáyÇżßQYcť
-élelmiszeradag/UĘŽiÖKŇmôáyÇżßQYcť
+élelmiszerüzlet/VËŻj×LÓnňéyČŔŕTtYcźélelmi|szer||üzlet
+élelmiszerárus/UĘŽiÖKŇmôáyÇżßSsYcťélelmi|szer||árus
+élelmiszeráru/ŐAUQĘŽiĎŇáyÇżßYcťélelmi|szer||áru
+élelmiszercsomag/UĘŽiÖKŇmôáyÇżßQYcťélelmi|szer||csomag
+élelmiszerbolt/UĘŽiÖKŇmôáyÇżßQYcťélelmi|szer||bolt
+élelmiszeradag/UĘŽiÖKŇmôáyÇżßQYcťélelmi|szer||adag
 élelmiszer-adalék_anyag/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 élelmiszer/VËŻj×LÓnňéyČŔŕTtYcź
 élelmianyag/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -2455,8 +2461,8 @@
 ékverő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 ékszerészbolt/UĘŽiÖKŇmôáyÇżßQYcť
 ékszerész/VËŻj×LÓnňéčłÄäTtYc¸źl
-ékszerládika/ŐAUQĘŽiĎŇáyÇżßYcť
-ékszerdoboz/UĘŽiÖKŇmôáyÇżßSsYcť
+ékszerládika/ŐAUQĘŽiĎŇáyÇżßYcťék|szer||ládika
+ékszerdoboz/UĘŽiÖKŇmôáyÇżßSsYcťék|szer||doboz
 ékszer/VËŻj×LÓnňéyČŔŕTtYcź
 ékkő/WŢŘÔyjYcČ	ékkövek
 ékit/w
@@ -2499,8 +2505,6 @@
 éhhalál/UĘŽiÖKŇmôáyÇżßSsYcť
 éhgyomor/UmôyiYcŽ	éhgyomrok
 éhezik
-éhes/VËŻj×LÓnňéčłÄäTtYc¸źl
-éhenkórász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 éhenhalás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 éhen-szomjan
 éhbér/VËŻj×LÓnňéyČŔŕTtYcź
@@ -2531,12 +2535,12 @@
 édesvíz/VÓnňyjYcČ	édesvizek
 édestestvér/VËŻj×LÓnňéčłÄäTtYc¸źl
 édességbolt/UĘŽiÖKŇmôáyÇżßQYcť
-édesszüleitek/VnÓ×édesszülő
-édesszüleink/VnÓ×édesszülő
-édesszüleim/VnÓ×édesszülő
-édesszüleik/VnÓ×édesszülő
-édesszüleid/VnÓ×édesszülő
-édesszülei/VĐÓ×édesszülő
+édesszüleitek/VnÓ×édesszülő	édes|szülő
+édesszüleink/VnÓ×édesszülő	édes|szülő
+édesszüleim/VnÓ×édesszülő	édes|szülő
+édesszüleik/VnÓ×édesszülő	édes|szülő
+édesszüleid/VnÓ×édesszülő	édes|szülő
+édesszülei/VĐÓ×édesszülő	édes|szülő
 édesszüle/ŐBVRËŻjĐÓéyČŔŕYcźé=des|szü-le
 édeslánya/UŇŐĎ
 édeskömény/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -2711,7 +2715,7 @@
 áspis/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 árúk/w
 árzuhanás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-árvízkárosult/UĘŽi$sŇmôáyÇżßQxcť
+árvízkárosult/UĘŽi$sŇmôáyÇżßQxcťár|víz||károsult
 árvíz/VÓnňyjYcČ	árvizek
 árvédelem/VnňyjYcŻË×LÓéČŔŕTtź	árvédelmek
 árváltozás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -2743,7 +2747,7 @@
 árus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 árurendelés/VËŻj×LÓnňéyČŔŕTtYcź
 árurejtegetés/VËŻj×LÓnňéyČŔŕTtYcź
-áruraktár/UmôŇyiYcÇ	áruraktárak
+áruraktár/UmôŇyiYcÇ	áruraktárakáru||rak|tár
 árumennyiség/VËŻj×LÓnňéyČŔŕTtYcź
 árukészlet/VËŻj×LÓnňéyČŔŕTtYcź
 árukiszolgáltató/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -2771,7 +2775,7 @@
 árterület/VËŻj×LÓnňéčłÄäTtYc¸źl
 ártalom/UmôçiYcŽk	ártalmak
 ársáv/UĘŽiÖKŇmôáyÇżßQYcť
-árszínvonal/UmôŇyiYcÇ	árszínvonalak
+árszínvonal/UmôŇyiYcÇ	árszínvonalakár||szín|vonal
 árszint/VËŻj×LÓnňéyČŔŕRYcź
 árszabó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 árszabás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -2781,7 +2785,7 @@
 árrögzítés/VËŻj×LÓnňéčłÄäTtYc¸źl
 árrés/VËŻj×LÓnňéyČŔŕTtYcź
 árrobbanás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-árrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+árrendszer/VËŻj×LÓnňéyČŔŕTtYcźár||rend|szer
 árreform/UĘŽiÖKŇmôáyÇżßQYcť
 árpádsáv/UĘŽiÖKŇmôáyÇżßQYcť
 árpolitika/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -2833,8 +2837,8 @@
 árkád/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 árkusztangens/VËŻj×LÓnňéyČŔŕTtYcź
 árkuszszinusz/UĘŽiÖKŇmôáyÇżßSsYcť
-árkuszkotangens/VËŻj×LÓnňéyČŔŕTtYcź
-árkuszkoszinusz/UĘŽiÖKŇmôáyÇżßSsYcť
+árkuszkotangens/VËŻj×LÓnňéyČŔŕTtYcźárkusz||ko|tangens
+árkuszkoszinusz/UĘŽiÖKŇmôáyÇżßSsYcťárkusz||ko||szinusz
 árkuszfüggvény/VËŻj×LÓnňéyČŔŕTtYcź
 árkus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 árkiegészítés/VËŻj×LÓnňéyČŔŕTtYcźár||ki|egészítés
@@ -2863,7 +2867,7 @@
 árhullám/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 árgyélus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 árgrafikon/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-árfolyamjegyzék/VËŻj×LÓnňéyČŔŕTtYcź
+árfolyamjegyzék/VËŻj×LÓnňéyČŔŕTtYcźár|folyam||jegyzék
 árfolyam/UĘŽiÖKŇmôáyÇżßSsYcť
 árfluktuáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 árfelügyelet/VËŻj×LÓnňéyČŔŕTtYcź
@@ -2959,6 +2963,7 @@
 álöltözék/VËŻj×LÓnňéčłÄäTtYc¸źl
 álöltözet/VËŻj×LÓnňéyČŔŕTtYcź
 álérv/VËŻj×LÓnňéyČŔŕTtYcź
+álvita/ŐAUQĘŽiĎŇáyÇżßYcť
 áltört/WĚŻjŘMÝňÔíyČÁ˙RYc˝
 áltípus/UĘŽiÖKŇmôáyÇżßSsYcť
 áltudós/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -2991,6 +2996,7 @@
 álszakáll/UmôŇyiYcÇ	álszakállak
 álruha/ŐAUQĘŽiĎŇáyÇżßYcť
 álromantika/ŐAUQĘŽiĎŇáyÇżßYcť
+álrendőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ál||rend|őr
 álpátosz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 álpróféta/ŐAUQĘŽiĎŇáyÇżßYcť
 álprofil/UĘŽiÖKŇmôáyÇżßQYcť
@@ -3006,7 +3012,7 @@
 álokoskodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 álok/UĘŽiÖKŇmôáyÇżßSsYcť
 álnév/VÓnňyjYcČ	álnevek
-álmoskönyv/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
+álmoskönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
 álmodozás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 álmodozik
 álmennyezet/VËŻj×LÓnňéyČŔŕRYcź
@@ -3017,7 +3023,7 @@
 állótőke/ŐBVRËŻjĐÓéyČŔŕYcź
 állórész/VËŻj×LÓnňéyČŔŕTtYcź
 állórajt/UĘŽiÖKŇmôáyÇżßQYcť
-állónaptár/UmôŇyiYcÇ	állónaptárak
+állónaptár/UmôŇyiYcÇ	állónaptárakálló||nap|tár
 állómotor/UĘŽiÖKŇmôáyÇżßQYcť
 állólétra/ŐAUQĘŽiĎŇáyÇżßYcť
 állólámpa/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -3030,7 +3036,7 @@
 állóhely/VËŻj×LÓnňéyČŔŕTtYcź
 állóharc/UĘŽiÖKŇmôáyÇżßSsYcť
 állógallér/UĘŽiÖKŇmôáyÇżßQYcť
-állófénykép/VËŻj×LÓnňéyČŔŕTtYcź
+állófénykép/VËŻj×LÓnňéyČŔŕTtYcźálló||fény|kép
 állófogadás/UĘŽiÖKŇmôáyÇżßSsYcť
 állóeszköz/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 állócsillag/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -3039,7 +3045,7 @@
 állítólag
 állítmánykiegészítő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 állítmány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-állásszerző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ál-lás|szer-ző
+állásszerző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ál-lás|szer-zőállás|szerző
 álláspont/UĘŽiÖKŇmôáyÇżßQYcť
 állásfoglalás/UĘŽiÖKŇmôáyÇżßSsYcť
 állás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -3103,13 +3109,14 @@
 államosítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 államkötvény/VËŻj×LÓnňéyČŔŕTtYcź
 államköltség/VËŻj×LÓnňéyČŔŕTtYcź
-államkincstár/UmôŇyiYcÇ	államkincstárak
+államkincstár/UmôŇyiYcÇ	államkincstárakállam||kincs|tár
 államkapitalista/ŐAUQĘŽiĎŇáyÇżßYcť
 államhatalom/UmôyiYcŽ	államhatalmak
 államfő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 államférfiú/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 államférfiak/UmŇŮállamférfi
-államférfi/ŐBVRËŻjĐÓéyČŔŕYcź	államférfiak
+államférfiaink/UmŮŇállamférfi
+államférfi/ŐBVRËŻjĐÓéyČŔŕYcź	államférfiakállamférfiaink
 államforma/ŐAUQĘŽiĎŇáyÇżßYcťállamformaváltás>
 államfelforgató/ŐAUQĘŽiĎŇáyÇżßYcť
 államberendezkedés/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -3128,7 +3135,7 @@
 álhír/VËŻj×LÓnňéyČŔŕTtYcź
 álhumánum/UĘŽiÖKŇmôáyÇżßSsYcť
 álhernyó/ŐAUQĘŽiĎŇáyÇżßYcť
-álhazafi/ŐAUQĘŽiĎŇáyÇżßYcť
+álhazafi/ŐAUQĘŽiĎŇáyÇżßYcťál||haza|fi
 álhalál/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 álhaj/UmôŇyiYcÇ	álhajak
 álfront/UĘŽiÖKŇmôáyÇżßQYcť
@@ -3176,7 +3183,7 @@
 ágypárna/ŐAUQĘŽiĎŇáyÇżßYcť
 ágynemű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 ágyikó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-ágyelő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
+ágyelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 ágybavizelés/VËŻj×LÓnňéčłÄäTtYc¸źl
 ágyazat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ágyas/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -3494,7 +3501,7 @@
 Ágota/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Ágoston/UĘŽiÖKŇmôqÇżßQ,ˇk÷
 Ágost/UĘŽiÖKŇmôqÇżßQ,ˇk÷
-Ágnes/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl÷ř
+Ágnes/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl÷ř
 Ágner/VËŻj×LÓnňqČŔŕR,¸l
 Ágika/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Ági/ŐAUQĘŽiĎŇqÇżß,ˇ÷
@@ -3516,14 +3523,14 @@
 Ádler/VËŻj×LÓnňqČŔŕR,¸l
 Ádika/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Ádi/ŐAUQĘŽiĎŇqÇżß,ˇ÷
-Áder/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl
+Áder/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl
 Ácsteszér/VËŻj×LÓnňqśR,¸l
 Ács/UĘŽiÖKŇmôqľSs,ˇ
 Áchim/VËŻj×LÓnňqČŔŕTt,¸l
 Ábrahámhegy/VËŻj×LÓnňqśTt,¸l
 Ábrahám/UĘŽiÖKŇmôqÇżßSs,ˇk÷
 Ábrabám/UĘŽiÖKŇmôqÇżßSs,ˇk
-Ábel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl÷ř
+Ábel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl÷ř
 ÁVO-váÁVO
 ÁVO-valÁVO
 ÁVO-s/ŇŮmAFUKQÁVO
@@ -3599,6 +3606,7 @@ zöldtető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 zöldterület/VËŻj×LÓnňéyČŔŕTtYcź
 zöldtakarmány/UĘŽiÖKŇmôáyÇżßSsYcť
 zöldséges/VËŻj×LÓnňéčłÄäTtYc¸źl
+zöldségburger/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRTtYcťź
 zöldség/VËŻj×LÓnňéčłÄäTtYc¸źl
 zöldszám/UĘŽiÖKŇmôáyÇżßSsYcť
 zöldszilváni/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -3620,7 +3628,7 @@ zöldhitel/VËŻj×LÓnňéyČŔŕTtYcź
 zöldhatár/UĘŽiÖKŇmôáyÇżßQYcť
 zöldhagyma/ŐAUQĘŽiĎŇáyÇżßYcť
 zöldgálic/UĘŽiÖKŇmôáyÇżßSsYcť
-zöldfűszer/VËŻj×LÓnňéyČŔŕRTtYcź
+zöldfűszer/VËŻj×LÓnňéyČŔŕRTtYcźöld||fű|szer
 zöldfőzelék/VËŻj×LÓnňéyČŔŕRYcź
 zöldfolyosó/ŐAUQĘŽiĎŇáyÇżßYcť
 zöldfelület/VËŻj×LÓnňéyČŔŕTtYcź
@@ -3905,7 +3913,7 @@ zsellérség/VËŻj×LÓnňéčłÄäTtYc¸źl
 zsellér/VËŻj×LÓnňéčłÄäRTtYc¸źl
 zselatinosodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 zselatin/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-zsebóratok/UĘŽiÖKŇmôáyÇżßQYcť
+zsebóratok/UĘŽiÖKŇmôáyÇżßQYcťóra||tok
 zsebóra/ŐAUQĘŽiĎŇáyÇżßYcť
 zsebtolvaj/UĘŽiÖKŇmôáyÇżßSsYcť
 zsebpénz/VËŻj×LÓnňéyČŔŕTtYcź
@@ -4138,7 +4146,7 @@ w-vel/)
 w-/BVRĐŃŐj&)
 w	é
 vörösérzékenység/VËŻj×LÓnňéčłÄäTtYc¸źl
-vörösvértest/VËŻj×LÓnňéyČŔŕRTtYcź
+vörösvértest/VËŻj×LÓnňéyČŔŕRTtYcźörös||vér|test
 vörösvérsejtszám/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 vörösvérsejt/VËŻj×LÓnňéčłÄäRYc¸źl
 vörösvasérc/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -4150,7 +4158,7 @@ vörösmoszat/UĘŽiÖKŇmôáyÇżßQYcť
 vöröskereszt/VËŻj×LÓnňéyČŔŕRYcź
 vöröskatona/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 vörösiszap/UĘŽiÖKŇmôáyÇżßQYcť
-vöröshangyaboly/UĘŽiÖKŇmôáyÇżßSsYcť
+vöröshangyaboly/UĘŽiÖKŇmôáyÇżßSsYcťörös|hangya||boly
 vöröshangya/ŐAUQĘŽiĎŇáyÇżßYcť
 vöröshagyma/ŐAUQĘŽiĎŇáyÇżßYcť
 vörösgárdista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -4159,7 +4167,7 @@ vörösfoszfor/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 vörösfenyő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 vörösezüstérc/VËŻj×LÓnňéyČŔŕTtYcź
 vöröseltolódás/UĘŽiÖKŇmôáyÇżßSsYcť
-vörösborospohár/UmôŇyiYcÇ	örösborospoharak
+vörösborospohár/UmôŇyiYcÇ	örösborospoharakörös|boros||pohár
 vörösbor/UĘŽiÖKŇmôáyÇżßSsYcť
 vörösbegy/VËŻj×LÓnňéyČŔŕTtYcź
 vörösagyag/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -4189,7 +4197,7 @@ vízóra/ŐAUQĘŽiĎŇáyÇżßYcť
 vízér/VÓnňyjYcČ	ízerek
 vízátvezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 vízár/UmôŇyiYcÇ	ízárak
-vízállásmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+vízállásmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝íz|állás||mérő
 vízállás/UĘŽiÖKŇmôáyÇżßSsYcť
 vízválasztó/ŐAUQĘŽiĎŇáyÇżßYcť
 vízvonal/UmôŇyiYcÇ	ízvonalak
@@ -4208,12 +4216,12 @@ vízszintező/ŐCWRĚŻjŢÔíyČÁ˙Yc˝íz|szin-te-ző
 vízszint/VËŻj×LÓnňéyČŔŕRYcźíz|szint
 vízszerzés/VËŻj×LÓnňéyČŔŕTtYcźíz|szer-zés
 vízsugár/UmôŇyiYcÇ	ízsugarakíz|su-gár
-vízrendszer/VËŻj×LÓnňéyČŔŕRYcź
+vízrendszer/VËŻj×LÓnňéyČŔŕRYcźíz||rend|szer
 vízrajz/UĘŽiÖKŇmôáyÇżßSsYcť
 vízpart/UĘŽiÖKŇmôáyÇżßQYcť
-víznyomócső/WŢŘÔyjYcČ	íznyomócsövek
+víznyomócső/WŢŘÔyjYcČ	íznyomócsövekíz||nyomó|cső
 víznyomás/UĘŽiÖKŇmôáyÇżßSsYcť
-víznyelőakna/ŐAUQĘŽiĎŇáyÇżßYcť
+víznyelőakna/ŐAUQĘŽiĎŇáyÇżßYcťíz|nyelő||akna
 víznyelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 vízmű/WŢŘÔyjYcČR	ízművek
 vízmosás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -4294,8 +4302,8 @@ vízhűtő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 vízhólyag/UĘŽiÖKŇmôáyÇżßQYcť
 vízhozam/UĘŽiÖKŇmôáyÇżßSsYcť
 vízhordó/ŐAUQĘŽiĎŇáyÇżßYcť
-vízgyűjtőterület/wYVËŻj×LÓnňéyČŔŕTtcź
-vízgyűjtőgödör/WÝyjYcŻ	ízgyűjtőgödrök
+vízgyűjtőterület/wYVËŻj×LÓnňéyČŔŕTtcźíz|gyűjtő||terület
+vízgyűjtőgödör/WÝyjYcŻ	ízgyűjtőgödrökíz|gyűjtő||gödör
 vízgyűjtő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 vízgyógyászat/UĘŽiÖKŇmôáyÇżßSsYcť
 vízfürdő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -4365,7 +4373,7 @@ vértő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	értövek
 vértolulás/UĘŽiÖKŇmôáyÇżßSsYcť
 vértisztító/ŐAUQĘŽiĎŇáyÇżßYcť
 vértezet/VËŻj×LÓnňéčłÄäTtYc¸źl
-vértest/VËŻj×LÓnňéyČŔŕTtYcźértestszáma>
+vértest/VËŻj×LÓnňéyČŔŕRTtYcźértestszáma>
 vértanúság/UĘŽiÖKŇmôáyÇżßSsYcť
 vértanú/ŐAUQĘŽiĎŇáyÇżßYcť
 vért/VËŻj×LÓnňéčłÄäRYc¸ź
@@ -4378,7 +4386,7 @@ vérrokonság/UĘŽiÖKŇmôáyÇżßSsYcť
 vérrokon/UĘŽiÖKŇmôáyÇżßSsYcť
 vérprofi/ŐAUQĘŽiĎŇáyÇżßYcť
 vérpad/UĘŽiÖKŇmôáyÇżßQSsYcťérpadáról>
-vérontófű/WŢŘÔyjYcČ	érontófüvek
+vérontófű/WŢŘÔyjYcČ	érontófüvekér|ontó||fű
 vérontás/UĘŽiÖKŇmôáyÇżßSsYcť
 vérnyomásmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 vérnyomás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -4415,7 +4423,7 @@ vénuszdomb/UĘŽiÖKŇmôáyÇżßQYcť
 vénlány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 vénleány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 vénkorában
-vénkisasszony/UĘŽiÖKŇmôáyÇżßSsYcť
+vénkisasszony/UĘŽiÖKŇmôáyÇżßSsYcťén||kis|asszony
 vénicfa/ŐAUQĘŽiĎŇáyÇżßYcť
 vénember/VËŻj×LÓnňéyČŔŕTtYcź
 véndely/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -4560,7 +4568,7 @@ végeredményeképpen
 végeredmény/VËŻj×LÓnňéyČŔŕTtYcź
 végelgyengülés/VËŻj×LÓnňéyČŔŕTtYcź
 végeladás/UĘŽiÖKŇmôáyÇżßSsYcť
-végbélnyílás/UĘŽiÖKŇmôáyÇżßSsYcť
+végbélnyílás/UĘŽiÖKŇmôáyÇżßSsYcťég|bél||nyílás
 végbél/VÓnňyjYcČ	égbelek
 vég/VËŻj×LÓnňéčłÄäRTtYc¸ź
 védőüveg/VËŻj×LÓnňéyČŔŕRTtYcź
@@ -4641,7 +4649,6 @@ váró/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 vártorony/UmôyiYcŽ	ártornyok
 várta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 várostrom/UĘŽiÖKŇmôáyÇżßSsYcť
-városszerteáros|szerte
 városnézés/VËŻj×LÓnňéyČŔŕTtYcź
 városnegyed/VËŻj×LÓnňéyČŔŕTtYcź
 városka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -4770,7 +4777,7 @@ vájling/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 vájkál
 vájdling/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 vájat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-vágószerszám/UĘŽiÖKŇmôáyÇżßSsYcť
+vágószerszám/UĘŽiÖKŇmôáyÇżßSsYcťágó||szer|szám
 vágóhíd/UŇmôyiYcÇQ	ágóhidak
 vágó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 vágányzat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -4883,15 +4890,18 @@ volfrám/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 volframát/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 volframit/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 volatilitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+vokál/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 voksol
 voks/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
 vokalizálás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 vokalista/ŐAUQĘŽiĎŇáç˛Ăăvcˇť
 vok/UĘŽiÖKŇmôáç˛ĂăQvcˇť	ph:wok
 voil&agrave;
+vodkásüveg/VËŻj×LÓnňéyČŔŕRTtYcź
 vodka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 vodafone-os/ŇŮmAFUKQ)
 vlog/UĘŽiÖKŇmôáç˛ĂăQYcˇť
+vizuáltechnika/ŐAUQĘŽiĎŇáyÇżßYcť
 vizualizáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 vizualitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 vizsla/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -4928,7 +4938,7 @@ vivátoz
 vivát/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 viviszekció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 vitézvirág/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-vitézsereg/VËŻj×LÓnňéyČŔŕTtYcźéz|se-reg
+vitézsereg/VËŻj×LÓnňéyČŔŕTtYcźéz|se-regéz|sereg
 vitézlő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 vitézkötés/VËŻj×LÓnňéčłÄäTtYc¸źl
 vitézkosbor/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -5048,6 +5058,7 @@ viszontlássa/)át
 viszontláss/)át
 viszontlásd/)át
 viszontkereset/VËŻj×LÓnňéyČŔŕTtYcź
+viszonthallásra
 viszontgarancia/ŐAUQĘŽiĎŇáyÇżßYcť
 viszonteladó/ŐAUQĘŽiĎŇáyÇżßYcť
 viszonteladás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -5220,7 +5231,6 @@ világtáj/UmôŇyiYcÇ	ágtájak
 világtenger/VËŻj×LÓnňéyČŔŕRYcź
 világszépe/ŐBVRËŻjĐÓéčłÄäYc¸ź
 világsztár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-világszerte
 világrész/VËŻj×LÓnňéyČŔŕTtYcź
 világrajövetel/VËŻj×LÓnňéčłÄäTtYc¸źl
 világrahozatal/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -5255,7 +5265,7 @@ villanófény/VËŻj×LÓnňéyČŔŕTtYcź
 villanyáram/UĘŽiÖKŇmôáyÇżßSsYcť
 villanyzsinór/UĘŽiÖKŇmôáyÇżßQYcť
 villanyzongora/ŐAUQĘŽiĎŇáyÇżßYcť
-villanyrendőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
+villanyrendőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝őr
 villanyozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 villanyosság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 villanykörte/ŐBVRËŻjĐÓéyČŔŕYcź
@@ -5263,7 +5273,7 @@ villanykapcsoló/ŐAUQĘŽiĎŇáyÇżßYcť
 villanydrót/UĘŽiÖKŇmôáyÇżßQYcť
 villany/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 villantózik
-villamosmegálló/ŐAUQĘŽiĎŇáyÇżßYcť
+villamosmegálló/ŐAUQĘŽiĎŇáyÇżßYcťálló
 villamoskocsi/ŐAUQĘŽiĎŇáyÇżßYcť
 villamosit/w
 villamos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -5323,7 +5333,7 @@ vidék/VËŻj×LÓnňéčłÄäTtYc¸źl
 vidámul
 vidámpark/UĘŽiÖKŇmôáyÇżßQYcť
 vidul
-vidrakeserűfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	űfüvek
+vidrakeserűfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	űfüvekű|fű
 vidrafű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvek
 vidra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 vidit/w
@@ -5332,7 +5342,7 @@ videótelefon/UĘŽiÖKŇmôáyÇżßQYcť
 videószerkesztő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 videórészlet/VËŻj×LÓnňéyČŔŕTtYcź
 videóreklám/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-videóműsor/UĘŽiÖKŇmôáyÇżßSsYcť
+videóműsor/UĘŽiÖKŇmôáyÇżßSsYcťó||mű|sor
 videómegosztó/ŐAUQĘŽiĎŇáyÇżßYcťó||meg|osztó
 videómagnó/ŐAUQĘŽiĎŇáyÇżßYcť
 videókölcsönző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -5378,7 +5388,7 @@ vicket-vackot
 vicispán/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 vicinális/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 vicik-vacak/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-viceházmester/VËŻj×LÓnňéyČŔŕTtYcź
+viceházmester/VËŻj×LÓnňéyČŔŕTtYcźáz|mester
 vice_versa
 vicc/VËŻj×LÓnňéčłÄäTtYc¸ź
 vibrátor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -5403,7 +5413,7 @@ vezérürü/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 vezérsík/UĘŽiÖKŇmôáyÇżßQYcť
 vezérség/VËŻj×LÓnňéčłÄäTtYc¸źl
 vezérszerep/VËŻj×LÓnňéyČŔŕTtYcź
-vezérműtengely/VËŻj×LÓnňéyČŔŕTtYcź
+vezérműtengely/VËŻj×LÓnňéyČŔŕTtYcźér|mű||tengely
 vezérmű/WŢŘÔyjYcČ	érművek
 vezérlőutasítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 vezérlőrendszer/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -5424,7 +5434,6 @@ vezérfonal/UĘŽiÖKŇmôáyÇżßSsYcť
 vezérelés/XVËŻj×LÓnňéčłÄäTtYc¸źl
 vezéregyéniség/VËŻj×LÓnňéyČŔŕTtYcź
 vezércsillag/UĘŽiÖKŇmôáyÇżßSsYcť
-vezércikkstílus/UĘŽiÖKŇmôáyÇżßSsYcť
 vezércikk/VËŻj×LÓnňéyČŔŕTtYcź
 vezéralak/UĘŽiÖKŇmôáyÇżßQYcť
 vezér/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -5605,8 +5614,8 @@ vendégoldal/UmôŇyiYcÇ	égoldalak
 vendéglőhelyiség/VËŻj×LÓnňéyČŔŕTtYcź
 vendéglő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 vendéglátós/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-vendéglátóipar/UĘŽiÖKŇmôáyÇżßSsYcť
-vendéglátóhely/VËŻj×LÓnňéyČŔŕTtYcź
+vendéglátóipar/UĘŽiÖKŇmôáyÇżßSsYcťég|látó||ipar
+vendéglátóhely/VËŻj×LÓnňéyČŔŕTtYcźég|látó||hely
 vendégház/UmôŇyiYcÇ	égházak
 vendéghallgató/ŐAUQĘŽiĎŇáyÇżßYcť
 vendég/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -5732,7 +5741,7 @@ vaspát/UĘŽiÖKŇmôáyÇżßQYcť
 vaspor/UĘŽiÖKŇmôáyÇżßSsYcť
 vasoxid/UĘŽiÖKŇmôáyÇżßQYcť
 vasolvasztó/ŐAUQĘŽiĎŇáyÇżßYcť
-vasnyílvessző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+vasnyílvessző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝íl|vessző
 vasművesség/VËŻj×LÓnňéčłÄäTtYc¸źl
 vasmű/WŢŘÔyjYcČR	űvek
 vasmedve/ŐBVRËŻjĐÓéyČŔŕYcź
@@ -5839,7 +5848,7 @@ valőr/WĚŻjŘMÝňÔíčłĹĺRTtYc¸˝l
 valósággal
 valóság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 valószínűsíthetőleg
-valószínűségszámítás/UĘŽiÖKŇmôáyÇżßSsYcť
+valószínűségszámítás/UĘŽiÖKŇmôáyÇżßSsYcťó|színűség||számítás
 valószínűség-számítás/wYUĘŽiÖKŇmôáç˛ĂăSscˇťk
 valószínűleg	ph:valszeg
 valósul
@@ -5902,10 +5911,11 @@ valamerre
 valamennyiünk/WÔ×Ý)
 valamennyiük/WÔ×Ý)
 valamennyiőtök/WÔ×Ý)
+valamennyiőnk/WÔ×Ý)
 valamennyiőjük/WÔ×Ý)
 valamennyiszer
 valamennyien/)
-valamennyi/BVĐÓŐLRÜ	ünkükőtökőjük
+valamennyi/BVĐÓŐLRÜ	ünkükőtökőnkőjük
 valamelyikünk/WÔ×Ý)
 valamelyikük/WÔ×Ý)
 valamelyikőtök/WÔ×Ý)
@@ -5922,8 +5932,16 @@ valakik/VÓ×nL)
 valaki/BVĐÓŐLR
 valahára
 valahányszázan/))ányszáz
+valahányszáz/$UŮÖmŇSscÇ	ányszázan
 valahányszor
+valahánymillió/ĎŇŐAUÚQbcjKxˇĂżÇ
+valahánymilliárd/mÖKkUÚQbci
 valahányfelé
+valahányezres/×BŐVb)ányezer
+valahányezren/b)ányezer
+valahányezren/b
+valahányezer/ŐnBVÜjbcÓ×LlTtČ	ányezresányezren
+valahánybillió/ĎŇŐAUÚQbci
 valahányas/AmôŇŮŐUSs
 valahányan/))ány
 valahányadiki/AUŇŐĎľ))ány
@@ -5948,6 +5966,7 @@ vakul
 vaku/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 vaktában
 vakság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+vakszórás/UĘŽiÖKŇmôáyÇżßSsYcť
 vakszik/VËŻj×LÓnňéčłÄäRYc¸źl
 vaksz/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
 vakrémület/VËŻj×LÓnňéyČŔŕTtYcź
@@ -5958,8 +5977,8 @@ vakolókanál/UmôŇyiYcÇ	ókanalak
 vakolat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 vakit/w
 vakcina/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-vakbélműtét/VËŻj×LÓnňéyČŔŕRYcź
-vakbélgyulladás/UĘŽiÖKŇmôáyÇżßSsYcť
+vakbélműtét/VËŻj×LÓnňéyČŔŕRYcźél||műtét
+vakbélgyulladás/UĘŽiÖKŇmôáyÇżßSsYcťél||gyulladás
 vakbél/VÓnňyjYcČ
 vakarózik
 vakarókés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -6010,7 +6029,7 @@ vadásztudomány/UĘŽiÖKŇmôáyÇżßSsYcť
 vadászterület/VËŻj×LÓnňéyČŔŕTtYcź
 vadászsólyom/UmôyiYcŽ	ászsólymok
 vadászsapka/ŐAUQĘŽiĎŇáyÇżßYcť
-vadászrepülőgép/VËŻj×LÓnňéyČŔŕRTtYcź
+vadászrepülőgép/VËŻj×LÓnňéyČŔŕRTtYcźász||repülő|gép
 vadászpuska/ŐAUQĘŽiĎŇáyÇżßYcť
 vadászmenyét/VËŻj×LÓnňéyČŔŕRYcź
 vadászlak/UĘŽiÖKŇmôáyÇżßQYcť
@@ -6155,11 +6174,11 @@ utófájdalom/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 utófinanszírozás/UĘŽiÖKŇmôáyÇżßSsYcť
 utófenék/VÓnňyjYcČ	ófenekek
 utófeldolgozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-utófeldolgozás/UĘŽiÖKŇmôáyÇżßSsYcť
+utófeldolgozás/UĘŽiÖKŇmôáyÇżßSsYcťó||fel|dolgozás
 utóerjedés/VËŻj×LÓnňéyČŔŕTtYcź
 utóellenőrzés/VËŻj×LÓnňéčłÄäTtYc¸źl
 utódlás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-utódenitrifikáció/ŐAUQĘŽiĎŇáyÇżßYcť
+utódenitrifikáció/ŐAUQĘŽiĎŇáyÇżßYcťó||de|nitrifikáció
 utód/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 utócsapat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 utóbél/VÓnňčjYcłl
@@ -6209,7 +6228,6 @@ utolszor/D
 utoljára/D
 utolj/uSsˇ˛)
 utilitarizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-utcaszerte
 utcaseprő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 utcakő/WŢŘÔyjYcČ	övek
 utca/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -6277,7 +6295,7 @@ untig
 unottság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 unos-untig
 unos-untalan
-unokatestvér/VËŻj×LÓnňéyČŔŕTtYcź
+unokatestvér/VËŻj×LÓnňéyČŔŕTtYcźér
 unokabáty/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 unoka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 unka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -6569,7 +6587,6 @@ tűzrendészeti/ŐBVRËŻjĐÓéčłÄäYc¸ź
 tűzrendészet/VËŻj×LÓnňéčłÄäTtYc¸źl
 tűzpiros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 tűzoltóság/UĘŽiÖKŇmôáyÇżßSsYcť
-tűzoltóhajó/ŐAUQĘŽiĎŇáyÇżßYcť
 tűzoltó/ŐAUQĘŽiĎŇáyÇżßYcť
 tűzoltás/UĘŽiÖKŇmôáyÇżßSsYcť
 tűzokádó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -6731,7 +6748,7 @@ törölés/XVËŻj×LÓnňéčłÄäTtYc¸źl
 törölgető/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 törökülés/VËŻj×LÓnňéyČŔŕTtYcź
 töröküldözés/VËŻj×LÓnňéyČŔŕTtYcź
-törökvörösolaj/UmôŇyiYcÇĘŽÖKáżßSsť	örökvörösolajak
+törökvörösolaj/UmôŇyiYcÇĘŽÖKáżßSsť	örökvörösolajakörök|vörös||olaj
 törökverő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 töröktanítás/UĘŽiÖKŇmôáyÇżßSsYcť
 törökrózsa/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -6895,7 +6912,7 @@ tömegesül
 tömegelosztás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 tömeg/VËŻj×LÓnňéčłÄäTtYc¸źl
 tömedék/VËŻj×LÓnňéčłÄäTtYc¸źl
-tömbmegbízott/UĘŽi$sŇmôáyÇżßQxcť
+tömbmegbízott/UĘŽi$sŇmôáyÇżßQxcťömb||meg|bízott
 tömbbelső/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 tömb/WĚŻjŘMÝňÔíčłĹĺRYc¸˝
 töltögető/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
@@ -6915,8 +6932,8 @@ töltény/VËŻj×LÓnňéčłÄäTtYc¸źl
 töltet/VËŻj×LÓnňéčłÄäTtYc¸źl
 töltelék/VËŻj×LÓnňéčłÄäRTtYc¸źl
 tölgymakk/UĘŽiÖKŇmôáyÇżßQYcť
-tölgyfagubacs/UĘŽiÖKŇmôáyÇżßSsYcť
-tölgyfaajtó/ŐAUQĘŽiĎŇáyÇżßYcť
+tölgyfagubacs/UĘŽiÖKŇmôáyÇżßSsYcťölgy|fa||gubacs
+tölgyfaajtó/ŐAUQĘŽiĎŇáyÇżßYcťölgy|fa||ajtó
 tölgyfa/ŐAUQĘŽiĎŇáyÇżßYcť
 tölgyes/VËŻj×LÓnňéčłÄäTtYc¸źl
 tölgyerdő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -6955,7 +6972,7 @@ többször/ÁD
 többszínnyomás/UĘŽiÖKŇmôáyÇżßSsYcťöbb|szín||nyo-más
 többszínnyomat/UĘŽiÖKŇmôáyÇżßSsYcťöbb|szín||nyo-mat
 többszázas/AUÖmôŇDFSs
-többpártrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+többpártrendszer/VËŻj×LÓnňéyČŔŕTtYcźöbb|párt||rendszer
 többpercenként
 többnyire
 többnaponta
@@ -6966,7 +6983,7 @@ többmilliárdos/AUÖmôŇDFSs
 többletterhelés/VËŻj×LÓnňéyČŔŕTtYcź
 többletadó/ŐAUQĘŽiĎŇáyÇżßYcť
 többlet/VËŻj×LÓnňéčłÄäTtYc¸źl
-többistenhit/VËŻj×LÓnňéyČŔŕTtYcź
+többistenhit/VËŻj×LÓnňéyČŔŕTtYcźöbb|isten||hit
 többiek/VÓ×n)öbbi
 többi/BĐÓŐLVR	öbbiek
 többheti
@@ -7007,7 +7024,7 @@ tőzsdézik
 tőzsde/ŐBVRËŻjĐÓéčłÄäYc¸ź
 tőzike/ŐBVRËŻjĐÓéčłÄäYc¸ź
 tőzegpáfrány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-tőzegmohaláp/UĘŽiÖKŇmôáyÇżßQYcť
+tőzegmohaláp/UĘŽiÖKŇmôáyÇżßQYcťőzeg|moha||láp
 tőzegmoha/ŐAUQĘŽiĎŇáyÇżßYcť
 tőzeges/VËŻj×LÓnňéčłÄäTtYc¸źl
 tőzegeper/VËŻj×LÓnňéčłÄäRYc¸źl
@@ -7046,7 +7063,7 @@ tósztozik
 tószt/UĘŽiÖKŇmôáç˛ĂăQYcˇť	ph:toast
 tórusz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 tórium/UĘŽiÖKŇmôáç˛ĂăSsvcˇťk
-tórendszer/VËŻj×LÓnňéyČŔŕTtYcź
+tórendszer/VËŻj×LÓnňéyČŔŕTtYcźó||rend|szer
 tóra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 tópart/UĘŽiÖKŇmôáyÇżßQYcť
 tónus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -7128,7 +7145,7 @@ tézis/VËŻj×LÓnňéčłÄäTtYc¸źl
 tévút/UmôŇyiYcÇQ	évutak
 tévő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 tévítélet/VËŻj×LÓnňéyČŔŕTtYcź
-tévéműsor/UĘŽiÖKŇmôáyÇżßSsYcť
+tévéműsor/UĘŽiÖKŇmôáyÇżßSsYcťévé||mű|sor
 tévéjáték/UĘŽiÖKŇmôáyÇżßSsYcť
 tévé/ŐBVRËŻjĐÓéčłÄäYc¸ź
 tévtanító/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -7168,11 +7185,11 @@ térköz/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 térkő/WŢŘÔyjYcČ	érkövek
 térképészet/VËŻj×LÓnňéčłÄäTtYc¸źl
 térképész/VËŻj×LÓnňéčłÄäTtYc¸źl
-térképgyűjtemény/VËŻj×LÓnňéyČŔŕTtYcź
+térképgyűjtemény/VËŻj×LÓnňéyČŔŕTtYcźér|kép||gyűjtemény
 térkép/VËŻj×LÓnňéyČŔŕTtYcź
 térkitöltő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 térjmegutca/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-térfogatmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+térfogatmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ér|fogat||mérő
 térfogat/UĘŽiÖKŇmôáyÇżßSsYcť
 térerő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝	érerej
 térerej/uxyT¸)érerő
@@ -7285,7 +7302,7 @@ távirat/UĘŽiÖKŇmôáyÇżßSsYcť
 távhő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 távgyalogló/ŐAUQĘŽiĎŇáyÇżßYcť
 távfényképezés/VËŻj×LÓnňéyČŔŕTtYcź
-távcsőtükör/WÝyjYcŻ	ávcsőtükrök
+távcsőtükör/WÝyjYcŻ	ávcsőtükrökáv|cső||tükör
 távcső/WŢŘÔyjYcČ	ávcsövek
 távbeszélő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 távbeszélés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -7303,6 +7320,7 @@ társul
 társaság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 társasutazás/UĘŽiÖKŇmôáyÇżßSsYcť
 társastánc/UĘŽiÖKŇmôáyÇżßSsYcť
+társasnyelvészet/VËŻj×LÓnňéyČŔŕTtYcź
 társaskör/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 társaskáptalan/UĘŽiÖKŇmôáyÇżßQYcť
 társasjáték/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -7524,7 +7542,7 @@ turistaút/UmôŇyiYcÇQ
 turistakirándulás/UĘŽiÖKŇmôáyÇżßSsYcť
 turistacipő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 turista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-turi/ŐBVRËŻjĐÓéčłÄäYc¸ź
+turi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 turha/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 turgor/UĘŽiÖKŇmôáç˛ĂăSsvcˇťk
 turfa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -7757,7 +7775,7 @@ trigonometria/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 trigger/VËŻj×LÓnňéčłÄäRTtYc¸źl
 trifluorid/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 tridimit/VËŻj×LÓnňéčłÄäRvc¸źl
-tridekánsav/UmôŇyiYcÇQ	ánsavak
+tridekánsav/UmôŇyiYcÇQ	ánsavakán||sav
 triciklovegyület/VËŻj×LÓnňéčłÄäTtYc¸źl
 tricikli/ŐBVRËŻjĐÓéčłÄäYc¸ź
 trichotómia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -7817,6 +7835,7 @@ transzláció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 transzlokáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 transzkripció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 transzilvanizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+transzfóbia/ŐAUQĘŽiĎŇáyÇżßYcť
 transzformátor/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 transzformált/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 transzformáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -7907,7 +7926,7 @@ toszkánabb/mAD$UŮŇQ
 toszkán/UĘŽiÖKŇmôáçĂăQck
 torzó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 torzul
-torzszülött/VNËŻj×LÝňÔéyČŔŕRTtYcźü-lött
+torzszülött/VNËŻj×LÝňÔéyČŔŕRTtYcźü-löttülött
 torzszülemény/VËŻj×LÓnňéyČŔŕTtYcźülemény
 torzsokszög/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ög
 torzsikaboglárka/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -8110,26 +8129,33 @@ tiáltalatokáltalaáltal)
 tizenötödiki/BVÓŐĐś)öt
 tizenötödike/BVÓŐĐś)öt
 tizenötödik/!VÓn×Llbh)öt
-tizenöttrillióan/b)öttrillió
-tizenöttrillió/ĎŇŐAUÚQbci	öttrillióan
-tizenöttrilliárd/mÖKkUÚQbci
-tizenötmillióan/b)ötmillió
-tizenötmillió/ĎŇŐAUÚQbcj	ötmillióan
-tizenötmilliárdan/b)ötmilliárd
-tizenötmilliárd/mÖKkUÚQbci	ötmilliárdan
-tizenötfelé
-tizenötezres/×BŐVb)ötezer
-tizenötezren/b)ötezer
-tizenötezrek/Ib)ötezer
-tizenötezredik/nÓ×BVÜb)ötezer
-tizenötezred/BVÜb)ötezer
-tizenötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred
+tizenöttrillióan/b)öttrillió	öt||trillióan
+tizenöttrillió/ĎŇŐAUÚQbci	öttrillióan	öt||trillió
+tizenöttrilliárd/mÖKkUÚQbci	öt||trilliárd
+tizenötmillióan/b)ötmillió	öt||millióan
+tizenötmillió/ĎŇŐAUÚQbcj	ötmillióan	öt||millió
+tizenötmilliárdan/b)ötmilliárd	öt||milliárdan
+tizenötmilliárd/mÖKkUÚQbci	ötmilliárdan	öt||milliárd
+tizenötfeléöt||felé
+tizenötezres/×BŐVb)ötezer	öt||ezres
+tizenötezren/b)ötezer	öt||ezren
+tizenötezrek/Ib)ötezer	öt||ezrek
+tizenötezredik/nÓ×BVÜb)ötezer	öt||ezredik
+tizenötezred/BVÜb)ötezer	öt||ezred
+tizenötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred	öt||ezer
 tizenöten/bh)öt
-tizenötbillióan/b)ötbillió
-tizenötbillió/ĎŇŐAUÚQbci	ötbillióan
-tizenötbilliárd/mÖKkUÚQbci
+tizenötbillióan/b)ötbillió	öt||billióan
+tizenötbillió/ĎŇŐAUÚQbci	ötbillióan	öt||billió
+tizenötbilliárd/mÖKkUÚQbci	öt||billiárd
 tizenöt/ÝWŰMRbhc	ötödikiötödikeötödiköten
 tizenéves/VËŻj×LÓnňéčłÄäTtYc¸źl
+tizenéve
+tizenvalahánymillió/ĎŇŐAUÚQbcj	ány||millió
+tizenvalahánymilliárd/mÖKkUÚQbci	ány||milliárd
+tizenvalahányfeléány||felé
+tizenvalahányezres/×BŐVb)ányezer	ány||ezres
+tizenvalahányezren/b)ányezer	ány||ezren
+tizenvalahányezer/ŐnBVÜjbc	ányezresányezren	ány||ezer
 tizenvalahányan/bh))ány
 tizenvalahányan/bh)
 tizenvalahányadiki/AUŇŐĎľ))ány
@@ -8138,42 +8164,42 @@ tizenvalahányadika/AUŇŐĎľ))ány
 tizenvalahányadik/!AUÖmŇŮKkbh))ány
 tizenvalahány/môA$UÚSsbhcŇŮ	ányanányadikiányadikakányadikaányadik
 tizenvalahány/môA$UÚSsbhcŇŮ	ányanányadikiányadikakányadikaányadik
-tizennégytrillióan/b)égytrillió
-tizennégytrillió/ĎŇŐAUÚQbci	égytrillióan
-tizennégytrilliárd/mÖKkUÚQbci
-tizennégymillióan/b)égymillió
-tizennégymillió/ĎŇŐAUÚQbcj	égymillióan
-tizennégymilliárdan/b)égymilliárd
-tizennégymilliárd/mÖKkUÚQbci	égymilliárdan
-tizennégyfelé
-tizennégyezres/×BŐVb)égyezer
-tizennégyezren/b)égyezer
-tizennégyezrek/Ib)égyezer
-tizennégyezredik/nÓ×BVÜb)égyezer
-tizennégyezred/BVÜb)égyezer
-tizennégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred
+tizennégytrillióan/b)égytrillió	égy||trillióan
+tizennégytrillió/ĎŇŐAUÚQbci	égytrillióan	égy||trillió
+tizennégytrilliárd/mÖKkUÚQbci	égy||trilliárd
+tizennégymillióan/b)égymillió	égy||millióan
+tizennégymillió/ĎŇŐAUÚQbcj	égymillióan	égy||millió
+tizennégymilliárdan/b)égymilliárd	égy||milliárdan
+tizennégymilliárd/mÖKkUÚQbci	égymilliárdan	égy||milliárd
+tizennégyfeléégy||felé
+tizennégyezres/×BŐVb)égyezer	égy||ezres
+tizennégyezren/b)égyezer	égy||ezren
+tizennégyezrek/Ib)égyezer	égy||ezrek
+tizennégyezredik/nÓ×BVÜb)égyezer	égy||ezredik
+tizennégyezred/BVÜb)égyezer	égy||ezred
+tizennégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred	égy||ezer
 tizennégyen/bh)égy
-tizennégybillióan/b)égybillió
-tizennégybillió/ĎŇŐAUÚQbci	égybillióan
-tizennégybilliárd/mÖKkUÚQbci
+tizennégybillióan/b)égybillió	égy||billióan
+tizennégybillió/ĎŇŐAUÚQbci	égybillióan	égy||billió
+tizennégybilliárd/mÖKkUÚQbci	égy||billiárd
 tizennégy/nVÜLlTtbhc	égyen
-tizennyolctrillióan/b)ó
-tizennyolctrillió/ĎŇŐAUÚQbci	óan
-tizennyolctrilliárd/mÖKkUÚQbci
-tizennyolcmillióan/b)ó
-tizennyolcmillió/ĎŇŐAUÚQbcj	óan
-tizennyolcmilliárdan/b)árd
-tizennyolcmilliárd/mÖKkUÚQbci	árdan
-tizennyolcfelé
+tizennyolctrillióan/b)ó	óan
+tizennyolctrillió/ĎŇŐAUÚQbci	óan	ó
+tizennyolctrilliárd/mÖKkUÚQbci	árd
+tizennyolcmillióan/b)ó	óan
+tizennyolcmillió/ĎŇŐAUÚQbcj	óan	ó
+tizennyolcmilliárdan/b)árd	árdan
+tizennyolcmilliárd/mÖKkUÚQbci	árdan	árd
+tizennyolcfeléé
 tizennyolcezres/×BŐVb)
 tizennyolcezren/b)
 tizennyolcezrek/Ib)
 tizennyolcezredik/nÓ×BVÜb)
 tizennyolcezred/BVÜb)
 tizennyolcezer/ŐnBVÜjbc
-tizennyolcbillióan/b)ó
-tizennyolcbillió/ĎŇŐAUÚQbci	óan
-tizennyolcbilliárd/mÖKkUÚQbci
+tizennyolcbillióan/b)ó	óan
+tizennyolcbillió/ĎŇŐAUÚQbci	óan	ó
+tizennyolcbilliárd/mÖKkUÚQbci	árd
 tizennyolcan/bh)
 tizennyolcadiki/AUŇŐĎľ)
 tizennyolcadikak/nI)
@@ -8181,37 +8207,35 @@ tizennyolcadika/AUŇŐĎľ)
 tizennyolcadik/!AUÖmŇŮKkbh)
 tizennyolc/mô$AUÚSsbhc
 tizennegyediki/BVÓŐĐś)égy
-tizennegyediki/BVÓŐĐś)
 tizennegyedike/BVÓŐĐś)égy
-tizennegyedike/BVÓŐĐś)
 tizennegyedik/!VÓn×Llbh)égy
-tizenkéttrillióan/b)éttrillió
-tizenkéttrillió/ĎŇŐAUÚQbci	éttrillióan
-tizenkéttrilliárd/mÖKkUÚQbci
-tizenkétszög/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
-tizenkétmillióan/b)étmillió
-tizenkétmillió/ĎŇŐAUÚQbcj	étmillióan
-tizenkétmilliárdan/b)étmilliárd
-tizenkétmilliárd/mÖKkUÚQbci	étmilliárdan
-tizenkétfelé
-tizenkétezres/×BŐVb)étezer
-tizenkétezren/b)étezer
-tizenkétezrek/Ib)étezer
-tizenkétezredik/nÓ×BVÜb)étezer
-tizenkétezred/BVÜb)étezer
-tizenkétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-tizenkétbillióan/b)étbillió
-tizenkétbillió/ĎŇŐAUÚQbci	étbillióan
-tizenkétbilliárd/mÖKkUÚQbci
+tizenkéttrillióan/b)éttrillió	ét||trillióan
+tizenkéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+tizenkéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+tizenkétszög/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ét||szög
+tizenkétmillióan/b)étmillió	ét||millióan
+tizenkétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+tizenkétmilliárdan/b)étmilliárd	ét||milliárdan
+tizenkétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+tizenkétfeléét||felé
+tizenkétezres/×BŐVb)étezer	ét||ezres
+tizenkétezren/b)étezer	ét||ezren
+tizenkétezrek/Ib)étezer	ét||ezrek
+tizenkétezredik/nÓ×BVÜb)étezer	ét||ezredik
+tizenkétezred/BVÜb)étezer	ét||ezred
+tizenkétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+tizenkétbillióan/b)étbillió	ét||billióan
+tizenkétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+tizenkétbilliárd/mÖKkUÚQbci	ét||billiárd
 tizenkét/bhcÜ
-tizenkilenctrillióan/b)ó
-tizenkilenctrillió/ĎŇŐAUÚQbci	óan
-tizenkilenctrilliárd/mÖKkUÚQbci
-tizenkilencmillióan/b)ó
-tizenkilencmillió/ĎŇŐAUÚQbcj	óan
-tizenkilencmilliárdan/b)árd
-tizenkilencmilliárd/mÖKkUÚQbci	árdan
-tizenkilencfelé
+tizenkilenctrillióan/b)ó	óan
+tizenkilenctrillió/ĎŇŐAUÚQbci	óan	ó
+tizenkilenctrilliárd/mÖKkUÚQbci	árd
+tizenkilencmillióan/b)ó	óan
+tizenkilencmillió/ĎŇŐAUÚQbcj	óan	ó
+tizenkilencmilliárdan/b)árd	árdan
+tizenkilencmilliárd/mÖKkUÚQbci	árdan	árd
+tizenkilencfeléé
 tizenkilencezres/×BŐVb)
 tizenkilencezren/b)
 tizenkilencezrek/Ib)
@@ -8222,68 +8246,68 @@ tizenkilencen/bh)
 tizenkilencediki/BVÓŐĐś)
 tizenkilencedike/BVÓŐĐś)
 tizenkilencedik/!VÓn×Llbh)
-tizenkilencbillióan/b)ó
-tizenkilencbillió/ĎŇŐAUÚQbci	óan
-tizenkilencbilliárd/mÖKkUÚQbci
+tizenkilencbillióan/b)ó	óan
+tizenkilencbillió/ĎŇŐAUÚQbci	óan	ó
+tizenkilencbilliárd/mÖKkUÚQbci	árd
 tizenkilenc/nňVÜLlTtbhc
-tizenkettőtrillióan/b)őtrillió
-tizenkettőtrillió/ĎŇŐAUÚQbci	őtrillióan
-tizenkettőtrilliárd/mÖKkUÚQbci
-tizenkettőmillióan/b)őmillió
-tizenkettőmillió/ĎŇŐAUÚQbcj	őmillióan
-tizenkettőmilliárdan/b)őmilliárd
-tizenkettőmilliárd/mÖKkUÚQbci	őmilliárdan
-tizenkettőfelé
-tizenkettőezres/×BŐVb)őezer
-tizenkettőezren/b)őezer
-tizenkettőezrek/Ib)őezer
-tizenkettőezredik/nÓ×BVÜb)őezer
-tizenkettőezred/BVÜb)őezer
-tizenkettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred
-tizenkettőbillióan/b)őbillió
-tizenkettőbillió/ĎŇŐAUÚQbci	őbillióan
-tizenkettőbilliárd/mÖKkUÚQbci
+tizenkettőtrillióan/b)őtrillió	ő||trillióan
+tizenkettőtrillió/ĎŇŐAUÚQbci	őtrillióan	ő||trillió
+tizenkettőtrilliárd/mÖKkUÚQbci	ő||trilliárd
+tizenkettőmillióan/b)őmillió	ő||millióan
+tizenkettőmillió/ĎŇŐAUÚQbcj	őmillióan	ő||millió
+tizenkettőmilliárdan/b)őmilliárd	ő||milliárdan
+tizenkettőmilliárd/mÖKkUÚQbci	őmilliárdan	ő||milliárd
+tizenkettőfeléő||felé
+tizenkettőezres/×BŐVb)őezer	ő||ezres
+tizenkettőezren/b)őezer	ő||ezren
+tizenkettőezrek/Ib)őezer	ő||ezrek
+tizenkettőezredik/nÓ×BVÜb)őezer	ő||ezredik
+tizenkettőezred/BVÜb)őezer	ő||ezred
+tizenkettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred	ő||ezer
+tizenkettőbillióan/b)őbillió	ő||billióan
+tizenkettőbillió/ĎŇŐAUÚQbci	őbillióan	ő||billió
+tizenkettőbilliárd/mÖKkUÚQbci	ő||billiárd
 tizenkettő/ŢWŰMRbhc
 tizenketten/bh)ő
 tizenkettediki/BVÓŐĐś)ő
 tizenkettedikes/VËŻj×LÓnňéčłÄäTtYc¸źl
 tizenkettedike/BVÓŐĐś)ő
 tizenkettedik/!VÓn×Llbh)ő
-tizenhéttrillióan/b)éttrillió
-tizenhéttrillió/ĎŇŐAUÚQbci	éttrillióan
-tizenhéttrilliárd/mÖKkUÚQbci
-tizenhétmillióan/b)étmillió
-tizenhétmillió/ĎŇŐAUÚQbcj	étmillióan
-tizenhétmilliárdan/b)étmilliárd
-tizenhétmilliárd/mÖKkUÚQbci	étmilliárdan
-tizenhétfelé
-tizenhétezres/×BŐVb)étezer
-tizenhétezren/b)étezer
-tizenhétezrek/Ib)étezer
-tizenhétezredik/nÓ×BVÜb)étezer
-tizenhétezred/BVÜb)étezer
-tizenhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-tizenhétbillióan/b)étbillió
-tizenhétbillió/ĎŇŐAUÚQbci	étbillióan
-tizenhétbilliárd/mÖKkUÚQbci
+tizenhéttrillióan/b)éttrillió	ét||trillióan
+tizenhéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+tizenhéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+tizenhétmillióan/b)étmillió	ét||millióan
+tizenhétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+tizenhétmilliárdan/b)étmilliárd	ét||milliárdan
+tizenhétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+tizenhétfeléét||felé
+tizenhétezres/×BŐVb)étezer	ét||ezres
+tizenhétezren/b)étezer	ét||ezren
+tizenhétezrek/Ib)étezer	ét||ezrek
+tizenhétezredik/nÓ×BVÜb)étezer	ét||ezredik
+tizenhétezred/BVÜb)étezer	ét||ezred
+tizenhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+tizenhétbillióan/b)étbillió	ét||billióan
+tizenhétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+tizenhétbilliárd/mÖKkUÚQbci	ét||billiárd
 tizenhét/nVÜbhc
-tizenháromtrillióan/b)áromtrillió
-tizenháromtrillió/ĎŇŐAUÚQbci	áromtrillióan
-tizenháromtrilliárd/mÖKkUÚQbci
-tizenhárommillióan/b)árommillió
-tizenhárommillió/ĎŇŐAUÚQbcj	árommillióan
-tizenhárommilliárdan/b)árommilliárd
-tizenhárommilliárd/mÖKkUÚQbci	árommilliárdan
-tizenháromfelé
-tizenháromezres/×BŐVb)áromezer
-tizenháromezren/b)áromezer
-tizenháromezrek/Ib)áromezer
-tizenháromezredik/nÓ×BVÜb)áromezer
-tizenháromezred/BVÜb)áromezer
-tizenháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred
-tizenhárombillióan/b)árombillió
-tizenhárombillió/ĎŇŐAUÚQbci	árombillióan
-tizenhárombilliárd/mÖKkUÚQbci
+tizenháromtrillióan/b)áromtrillió	árom||trillióan
+tizenháromtrillió/ĎŇŐAUÚQbci	áromtrillióan	árom||trillió
+tizenháromtrilliárd/mÖKkUÚQbci	árom||trilliárd
+tizenhárommillióan/b)árommillió	árom||millióan
+tizenhárommillió/ĎŇŐAUÚQbcj	árommillióan	árom||millió
+tizenhárommilliárdan/b)árommilliárd	árom||milliárdan
+tizenhárommilliárd/mÖKkUÚQbci	árommilliárdan	árom||milliárd
+tizenháromfeléárom||felé
+tizenháromezres/×BŐVb)áromezer	árom||ezres
+tizenháromezren/b)áromezer	árom||ezren
+tizenháromezrek/Ib)áromezer	árom||ezrek
+tizenháromezredik/nÓ×BVÜb)áromezer	árom||ezredik
+tizenháromezred/BVÜb)áromezer	árom||ezred
+tizenháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred	árom||ezer
+tizenhárombillióan/b)árombillió	árom||billióan
+tizenhárombillió/ĎŇŐAUÚQbci	árombillióan	árom||billió
+tizenhárombilliárd/mÖKkUÚQbci	árom||billiárd
 tizenhárom/mUÚbhc	ármanármak
 tizenhárman/bh)árom
 tizenhármak/Ibh)árom
@@ -8292,41 +8316,41 @@ tizenhetek/Ibh)ét
 tizenhetediki/BVÓŐĐś)ét
 tizenhetedike/BVÓŐĐś)ét
 tizenhetedik/!VÓn×Llbh)ét
-tizenhattrillióan/b)ó
-tizenhattrillió/ĎŇŐAUÚQbci	óan
-tizenhattrilliárd/mÖKkUÚQbci
+tizenhattrillióan/b)ó	óan
+tizenhattrillió/ĎŇŐAUÚQbci	óan	ó
+tizenhattrilliárd/mÖKkUÚQbci	árd
 tizenhatodiki/AUŇŐĎľ)
 tizenhatodikak/nI)
 tizenhatodika/AUŇŐĎľ)
 tizenhatodik/!AUÖmŇŮKkbh)
-tizenhatmillióan/b)ó
-tizenhatmillió/ĎŇŐAUÚQbcj	óan
-tizenhatmilliárdan/b)árd
-tizenhatmilliárd/mÖKkUÚQbci	árdan
-tizenhatfelé
+tizenhatmillióan/b)ó	óan
+tizenhatmillió/ĎŇŐAUÚQbcj	óan	ó
+tizenhatmilliárdan/b)árd	árdan
+tizenhatmilliárd/mÖKkUÚQbci	árdan	árd
+tizenhatfeléé
 tizenhatezres/×BŐVb)
 tizenhatezren/b)
 tizenhatezrek/Ib)
 tizenhatezredik/nÓ×BVÜb)
 tizenhatezred/BVÜb)
 tizenhatezer/ŐnBVÜjbc
-tizenhatbillióan/b)ó
-tizenhatbillió/ĎŇŐAUÚQbci	óan
-tizenhatbilliárd/mÖKkUÚQbci
+tizenhatbillióan/b)ó	óan
+tizenhatbillió/ĎŇŐAUÚQbci	óan	ó
+tizenhatbilliárd/mÖKkUÚQbci	árd
 tizenhatan/bh)
 tizenhat/mUÚKkbhc
 tizenharmadiki/AUŇŐĎľ)árom
 tizenharmadikak/nI)árom
 tizenharmadika/AUŇŐĎľ)árom
 tizenharmadik/!AUÖmŇŮKkbh)árom
-tizenegytrillióan/b)ó
-tizenegytrillió/ĎŇŐAUÚQbci	óan
-tizenegytrilliárd/mÖKkUÚQbci
-tizenegymillióan/b)ó
-tizenegymillió/ĎŇŐAUÚQbcj	óan
-tizenegymilliárdan/b)árd
-tizenegymilliárd/mÖKkUÚQbci	árdan
-tizenegyfelé
+tizenegytrillióan/b)ó	óan
+tizenegytrillió/ĎŇŐAUÚQbci	óan	ó
+tizenegytrilliárd/mÖKkUÚQbci	árd
+tizenegymillióan/b)ó	óan
+tizenegymillió/ĎŇŐAUÚQbcj	óan	ó
+tizenegymilliárdan/b)árd	árdan
+tizenegymilliárd/mÖKkUÚQbci	árdan	árd
+tizenegyfeléé
 tizenegyezres/×BŐVb)
 tizenegyezren/b)
 tizenegyezrek/Ib)
@@ -8335,12 +8359,15 @@ tizenegyezred/BVÜb)
 tizenegyezer/ŐnBVÜjbc
 tizenegyes/VËŻj×LÓnňéyČŔŕTtvcź
 tizenegyen/bh)
+tizenegyediki/BVÓŐĐś)
 tizenegyedikes/VËŻj×LÓnňéčłÄäTtYc¸źl
+tizenegyedike/BVÓŐĐś)
 tizenegyedik/VÓn×Llbh)
-tizenegybillióan/b)ó
-tizenegybillió/ĎŇŐAUÚQbci	óan
-tizenegybilliárd/mÖKkUÚQbci
+tizenegybillióan/b)ó	óan
+tizenegybillió/ĎŇŐAUÚQbci	óan	ó
+tizenegybilliárd/mÖKkUÚQbci	árd
 tizenegy/nVÜLlbhc
+tizen-huszonéves/VËŻj×LÓnňéyČŔŕTtcźéves
 tizen-egynéhány
 tizedíziglen
 tizedízben
@@ -8350,18 +8377,18 @@ tizedszeri/bh
 tizedszer
 tizedrész/VËŻj×LÓnňéyČŔŕTtYcź
 tizednap/UĘŽiÖKŇmôáyÇżßQYcť
-tizedmásodperc/VËŻj×LÓnňéyČŔŕTtYcź
+tizedmásodperc/VËŻj×LÓnňéyČŔŕTtYcźásod|perc
 tizediki/BVÓŐĐś)íz
 tizedikes/VËŻj×LÓnňéčłÄäTtYc¸źl
 tizedike/BVÓŐĐś)íz
 tizedik/c!VÓn×Llbh)íz
-tizedféltrillió/AUŐĎŇKQxcˇĂżÇ
-tizedfélszázad/AUÖmŇKkQcˇĂżÇ
-tizedfélszáz/$UŮÖmŇSscÇ
-tizedfélmillió/AUŐĎŇKQxcˇĂżÇ
-tizedfélmilliárd/AUÖmŇKkQcˇĂżÇ
-tizedfélezer/VÓn×LlTtcČ
-tizedfélbillió/AUŐĎŇKQxcˇĂżÇ
+tizedféltrillió/AUŐĎŇKQxcˇĂżÇ	él||trillió
+tizedfélszázad/AUÖmŇKkQcˇĂżÇ	él||század
+tizedfélszáz/$UŮÖmŇSscÇ	él||száz
+tizedfélmillió/AUŐĎŇKQxcˇĂżÇ	él||millió
+tizedfélmilliárd/AUÖmŇKkQcˇĂżÇ	él||milliárd
+tizedfélezer/VÓn×LlTtcČ	él||ezer
+tizedfélbillió/AUŐĎŇKQxcˇĂżÇ	él||billió
 tizedfél/VÓnňyjYcČ)él	él
 tizedesvessző/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 tizedespont/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -8387,9 +8414,9 @@ titkárság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 titkárnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 titkár/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 titkosírás/UĘŽiÖKŇmôáyÇżßSsYcť
-titkosszolgálat/UĘŽiÖKŇmôáyÇżßSsYcťá-lat
+titkosszolgálat/UĘŽiÖKŇmôáyÇżßSsYcťá-latálat
 titkosszolga/ŐAUQĘŽiĎŇáyÇżßYcť
-titkosrendőrség/VËŻj×LÓnňéyČŔŕTtYcź
+titkosrendőrség/VËŻj×LÓnňéyČŔŕTtYcźőrség
 titkosrendőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 titkolózás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 titkolózik
@@ -8413,7 +8440,7 @@ tisztiszolga/ŐAUQĘŽiĎŇáyÇżßYcť
 tisztiorvos/UĘŽiÖKŇmôáyÇżßSsYcť
 tisztikereszt/VËŻj×LÓnňéyČŔŕRYcź
 tisztikar/UĘŽiÖKŇmôáyÇżßSsYcť
-tisztifőorvos/UĘŽiÖKŇmôáyÇżßSsYcť
+tisztifőorvos/UĘŽiÖKŇmôáyÇżßSsYcťő|orvos
 tisztességtudás/UĘŽiÖKŇmôáyÇżßSsYcť
 tisztesfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvek
 tisztes/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -8609,7 +8636,6 @@ textil/VËŻj×LÓnňéčłÄäRYc¸źl
 tevés/XVËŻj×LÓnňéčłÄäTtYc¸źl)Ás_PROCESS/RESULT_noun
 tevéled/)éle
 tevékenység/VËŻj×LÓnňéčłÄäTtYc¸źl
-teveszőrszövet/VËŻj×LÓnňéyČŔŕRTtYcź
 teveszőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 teveled/)
 teve/ŐBVRËŻjĐÓéčłÄäYc¸ź
@@ -8748,7 +8774,7 @@ testvéröccse/VĐÓ×)éröcs
 testvéréék/VnÓ×)ér
 testvérpár/UĘŽiÖKŇmôáyÇżßQYcťér||pár
 testvérke/ŐBVRËŻjĐÓéčłÄäYc¸ź
-testvérgyilkosság/UĘŽiÖKŇmôáyÇżßSsYcť
+testvérgyilkosság/UĘŽiÖKŇmôáyÇżßSsYcťér||gyilkosság
 testvérbátya/
 testvérbáty/UĘŽiÖKŇmôáyÇżßSsYcťQ)érbáty	érbáty
 testvérbáty/UĘŽiÖKŇmôáyÇżßSsYcťQ	érbáty
@@ -9047,7 +9073,7 @@ tenger/VËŻj×LÓnňéčłÄäTtYc¸źl
 tengelytávolság/UĘŽiÖKŇmôáyÇżßSsYcť
 tengelyszög/VNËŻj×LÝňÔéyČŔŕTtYcź
 tengelykapcsoló/ŐAUQĘŽiĎŇáyÇżßYcť
-tengelycsapágy/UmôŇyiYcÇ	ágyak
+tengelycsapágy/UmôŇyiYcÇ	ágyakágy
 tengely/VËŻj×LÓnňéčłÄäTtYc¸źl
 tengelic/VËŻj×LÓnňéčłÄäTtYc¸źl
 tenesszium/UĘŽiÖKŇmôáç˛ĂăSsvcˇťk
@@ -9130,7 +9156,7 @@ teleportáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 telephely/×VËŻjLÓnňéyČŔŕTtYcź
 telep/VËŻj×LÓnňéčłÄäRTtYc¸źl
 teleológia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-teleobjektív/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRYcťź
+teleobjektív/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
 telente
 telemetria/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 telemechanika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -9159,7 +9185,7 @@ telefónia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 telefonérme/ŐBVRËŻjĐÓéyČŔŕYcź
 telefonállomás/UĘŽiÖKŇmôáyÇżßSsYcť
 telefonoz
-telefonközpont/UĘŽiÖKŇmôáyÇżßQYcť
+telefonközpont/UĘŽiÖKŇmôáyÇżßQYcťöz|pont
 telefonközel/VËŻj×LÓnňéyČŔŕTtYcź
 telefonkönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
 telefonkagyló/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -9218,7 +9244,7 @@ tekercselő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 tekercs/VËŻj×LÓnňéčłÄäTtYc¸źl
 tekepálya/ŐAUQĘŽiĎŇáyÇżßYcť
 teke/ŐBVRËŻjĐÓéčłÄäYc¸ź
-tejútrendszer/VËŻj×LÓnňéyČŔŕRYcź
+tejútrendszer/VËŻj×LÓnňéyČŔŕRYcźút||rend|szer
 tejút/UmôŇyiYcÇQ
 tejár/UmôŇyiYcÇ	árak
 tejzsír/UĘŽiÖKŇmôáyÇżßQYcť
@@ -9287,7 +9313,7 @@ tehermentesül
 teherkocsi/ŐAUQĘŽiĎŇáyÇżßYcť
 teherhordó/ŐAUQĘŽiĎŇáyÇżßYcť
 teherhajó/ŐAUQĘŽiĎŇáyÇżßYcť
-tehergépkocsi/ŐAUQĘŽiĎŇáyÇżßYcť
+tehergépkocsi/ŐAUQĘŽiĎŇáyÇżßYcťép|kocsi
 teherelosztó/ŐAUQĘŽiĎŇáyÇżßYcť
 teherautó/ŐAUQĘŽiĎŇáyÇżßYcť
 teher/VnňčjYcŻl
@@ -9385,7 +9411,7 @@ taverna/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 tavaszikabát/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 tavaszidő/ŐCWĚŻjŢÔíyČÁ˙Yc˝
 tavaszidej/uxytT¸)ő
-tavaszi-fésűsbagoly/UmôyiYcŽ	ésűsbaglyok
+tavaszi-fésűsbagoly/UmôyiYcŽ	ésűsbaglyokésűs|bagoly
 tavaszelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 tavasz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 tavalyelőttkor/w
@@ -9531,8 +9557,8 @@ tanítónő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 tanító_néni/ŐBVRËŻjĐÓéčłÄäYc¸ź
 tanítványság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 tanítvány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-tanévzáró/ŐAUQĘŽiĎŇáyÇżßYcť
-tanévzárás/UĘŽiÖKŇmôáyÇżßSsYcť
+tanévzáró/ŐAUQĘŽiĎŇáyÇżßYcťév||záró
+tanévzárás/UĘŽiÖKŇmôáyÇżßSsYcťév||zárás
 tanév/VËŻj×LÓnňéyČŔŕTtYcź
 tanárúr/wYUmôŇçic˛k
 tanárság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -9675,7 +9701,7 @@ talajmélyedés/VËŻj×LÓnňéyČŔŕTtYcź
 talajmelioráció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 talajmegmunkáló/ŐAUQĘŽiĎŇáyÇżßYcť
 talajlazító/ŐAUQĘŽiĎŇáyÇżßYcť
-talajfelszín/VËŻj×LÓnňéyČŔŕTtYcź
+talajfelszín/VËŻj×LÓnňéyČŔŕTtYcźín
 talajerózió/ŐAUQĘŽiĎŇáyÇżßYcť
 talaj/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 takácsmácsonya/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -9694,7 +9720,7 @@ takaródzik
 takaró/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 takarítónő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 takarító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-takaréktűzhely/×VËŻjLÓnňéyČŔŕTtYcź
+takaréktűzhely/×VËŻjLÓnňéyČŔŕTtYcźék||tűz|hely
 takarékbetét/VËŻj×LÓnňéyČŔŕRYcź
 takarék/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 takarodó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -9786,8 +9812,7 @@ sürögök/w
 sürögöd/w
 sürgönyző/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X)ürgönyözÓ_PRESPART_adj
 sürgönyzés/XVËŻj×LÓnňéčłÄäTtYc¸źl)ürgönyözÁs_PROCESS/RESULT_noun
-sürgönystílus/UĘŽiÖKŇmôáyÇżßSsYcť
-sürgönypózna/ŐAUQĘŽiĎŇáyÇżßYcť
+sürgönypózna/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 sürgöny/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 sürgő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X)ürögÓ_PRESPART_adj
 sürgés/XVËŻj×LÓnňéčłÄäTtYc¸źl)ürögÁs_PROCESS/RESULT_noun
@@ -9808,7 +9833,6 @@ sündörögök/w
 sündörögöd/w
 sündörgő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X)ündörögÓ_PRESPART_adj
 sündörgés/XVËŻj×LÓnňéčłÄäTtYc¸źl)ündörögÁs_PROCESS/RESULT_noun
-sündisznóállás/UĘŽiÖKŇmôáyÇżßSsYcť
 sündisznó/ŐAUQĘŽiĎŇáyÇżßYcť
 sün/WĚŻjŘMÝňÔíčłĹĺRYc¸˝
 süly/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝
@@ -9952,7 +9976,7 @@ sírásó/ŐAUQĘŽiĎŇáyÇżßYcť
 sírnivaló/ŐAUQĘŽiĎŇáyÇżßYcť
 sírkő/WŢŘÔyjYcČ	írkövek
 sírhely/×VËŻjLÓnňéyČŔŕTtYcź
-sírfelirat/UĘŽiÖKŇmôáyÇżßSsYcť
+sírfelirat/UĘŽiÖKŇmôáyÇżßSsYcťír||fel|irat
 síremlék/VËŻj×LÓnňéyČŔŕTtYcź
 sírdomb/UĘŽiÖKŇmôáyÇżßQYcť
 sírdogál
@@ -10025,7 +10049,7 @@ sík/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 síjon-ríjon
 síita/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 síház/UmôŇyiYcÇ	íházak
-sífutónő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+sífutónő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝í|futó||nő
 sífutó/ŐAUQĘŽiĎŇáyÇżßYcť
 sífutás/UĘŽiÖKŇmôáyÇżßSsYcť
 síel
@@ -10068,7 +10092,7 @@ sátánfajzat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 sátán/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 sátoroz
 sátoros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-sátorlapfedő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+sátorlapfedő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝átor|lap||fedő
 sátorfenék/VÓnňyjYcČ	átorfenekek
 sátorfedél/VÓnňyjYcČ	átorfedelek
 sátorcövek/VËŻj×LÓnňéyČŔŕTtYcź
@@ -10146,9 +10170,10 @@ szürkület/VËŻj×LÓnňéčłÄäTtYc¸źl
 szürkül
 szürkeöntvény/VËŻj×LÓnňéyČŔŕTtYcź
 szürkeállomány/UĘŽiÖKŇmôáyÇżßSsYcť
+szürkevíz/VÓnňyjYcČ	ürkevizek
 szürkeszennyvíz/VÓnňyjYcČ	ürkeszennyvizekürke||szenny|víz
 szürkepenész/VËŻj×LÓnňéyČŔŕTtYcź
-szürkenyersvas/UĘŽiÖKŇmôáyÇżßSsYcť
+szürkenyersvas/UĘŽiÖKŇmôáyÇżßSsYcťürke||nyers|vas
 szürkekáka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szürkegazdaság/UĘŽiÖKŇmôáyÇżßSsYcť
 szürkebegy/VËŻj×LÓnňéyČŔŕTtYcź
@@ -10290,6 +10315,7 @@ szörf/WĚŻjŘMÝňÔíčłĹĺRYc¸˝	ph:surf
 szömörcsög/WĚŻjŘMÝňÔíčłĹĺRYc¸˝l
 szömörcefa/ŐAUQĘŽiĎŇáyÇżßYcť
 szömörce/ŐBVRËŻjĐÓéčłÄäYc¸ź
+szökőévente
 szökőév/VËŻj×LÓnňéyČŔŕTtYcź
 szökőár/UmôŇyiYcÇQ	ökőárak
 szökőnap/UĘŽiÖKŇmôáyÇżßQYcť
@@ -10316,8 +10342,8 @@ szőrösszívű/ŐCWRĚŻjŢÔíčłĹĺYc¸˝ő-rös|szí-vű
 szőrén-szálán
 szőrzet/VËŻj×LÓnňéčłÄäTtYc¸źl
 szőrtelenítő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
-szőrszálhasogató/ŐAUQĘŽiĎŇáyÇżßYcť
-szőrszálhasogatás/UĘŽiÖKŇmôáyÇżßSsYcť
+szőrszálhasogató/ŐAUQĘŽiĎŇáyÇżßYcťőr|szál||hasogató
+szőrszálhasogatás/UĘŽiÖKŇmôáyÇżßSsYcťőr|szál||hasogatás
 szőrmók/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 szőrmésbolt/UĘŽiÖKŇmôáyÇżßQYcť
 szőrmeáru/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -10362,7 +10388,7 @@ szóvirág/UĘŽiÖKŇmôáyÇżßQSsYcť
 szóval
 szótő/WŢŘÔyjYcČR	ótövek
 szótér/VÓnňyjYcČ	óterek
-szótárírás/UĘŽiÖKŇmôáyÇżßSsYcť
+szótárírás/UĘŽiÖKŇmôáyÇżßSsYcťó|tár||írás
 szótár/UmôŇyiYcÇ	ótárak
 szótag/UĘŽiÖKŇmôáyÇżßQYcť
 szószóló/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -10432,9 +10458,9 @@ szófecsérlés/VËŻj×LÓnňéčłÄäTtYc¸źl
 szófaj/UĘŽiÖKŇmôáyÇżßSsYcť
 szófa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szódásüveg/VËŻj×LÓnňéyČŔŕTtYcź
-szódásszifon/UĘŽiÖKŇmôáyÇżßQYcťó-dás|szi-fon
+szódásszifon/UĘŽiÖKŇmôáyÇżßQYcťó-dás|szi-fonódás|szifon
 szódásló/UĎÖŇyiYcÇ	ódáslovak
-szódavízgyártó/ŐAUQĘŽiĎŇáyÇżßYcť
+szódavízgyártó/ŐAUQĘŽiĎŇáyÇżßYcťóda|víz||gyártó
 szódavíz/VÓnňyjYcČ	ódavizek
 szódabikarbóna/ŐAUQĘŽiĎŇáyÇżßYcť
 szódabikarbonát/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -10444,7 +10470,7 @@ szócikk/VËŻj×LÓnňéyČŔŕTtYcź
 szóbokor/UmôyiYcŽ	óbokrok
 szóbeszéd/VËŻj×LÓnňéyČŔŕRTtYcź
 szóbelizik
-szóbeli/ŐBVRËŻjĐÓéyČŔŕYcź
+szóbeli/ŐBVRËŻjĐÓéčłÄäYc¸ź
 szóalkotás/UĘŽiÖKŇmôáyÇżßSsYcť
 szóalak/UĘŽiÖKŇmôáyÇżßQYcť
 szó/ŐAUQĘŽiĎŇç˛ĂăYcˇťÖ
@@ -10495,9 +10521,9 @@ színtartó/ŐAUQĘŽiĎŇáyÇżßYcť
 színrevitel/VËŻj×LÓnňéčłÄäTtYc¸źl
 színrehozatal/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 színpad/UĘŽiÖKŇmôáyÇżßQSsYcť
-színművésznő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+színművésznő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ín|művész||nő
 színművészet/VËŻj×LÓnňéyČŔŕTtYcź
-színműirodalom/UmôyiYcŽ	ínműirodalmak
+színműirodalom/UmôyiYcŽ	ínműirodalmakín|mű||irodalom
 színmű/WŢŘÔyjYcČ	ínművek
 színmagyarüldözés/VËŻj×LÓnňéyČŔŕTtYcź
 színmagyartanítás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -10511,7 +10537,7 @@ színmagyarabb/mAD$UŮŇQ
 színmagyar/UĘŽiÖKŇmôáçĂăQck
 színleg
 színlap/UĘŽiÖKŇmôáyÇżßQYcť
-színképelemzés/VËŻj×LÓnňéyČŔŕTtYcź
+színképelemzés/VËŻj×LÓnňéyČŔŕTtYcźín|kép||elemzés
 színkép/VËŻj×LÓnňéyČŔŕTtYcź
 színjátszás/UĘŽiÖKŇmôáyÇżßSsYcť
 színitanoda/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -10523,7 +10549,6 @@ színigaz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 színielőadás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 színibírálat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 színiakadémia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-színházhajó/ŐAUQĘŽiĎŇáyÇżßYcť
 színház/UmôŇyiYcÇ	ínházak
 színhely/×VËŻjLÓnňéyČŔŕTtYcź
 színfolt/UĘŽiÖKŇmôáyÇżßQYcť
@@ -10577,8 +10602,7 @@ szépnem/VËŻj×LÓnňéčłÄäTtYc¸źl
 szépnagyaty/uQ)épnagyatya
 szépnagyapa/	épnagyap
 szépnagyap/uQ)épnagyapa
-szépnagyanya/	épnagyany
-szépnagyany/uQ)épnagyanya
+szépnagyanya/
 szépművészet/VËŻj×LÓnňéyČŔŕTtYcź
 széplélek/VnňyjYcŻ	éplelkek
 szépirodalom/UmôyiYcŽ	épirodalmak
@@ -10649,6 +10673,7 @@ szélsőség/VËŻj×LÓnňéčłÄäTtYc¸źl
 szélsőjáték/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szélsőjobboldal/UmôŇyiYcÇ	élsőjobboldalak
 szélsőjobb/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+szélsőhátvéd/VËŻj×LÓnňéyČŔŕRTtYcźélső||hát|véd
 szélsőbaloldal/UmôŇyiYcÇ	élsőbaloldalak
 szélső/ŐŢÔWCRD
 szélszorulás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -10656,8 +10681,8 @@ szélrózsa/ŐAUQĘŽiĎŇáyÇżßYcť
 szélrács/UĘŽiÖKŇmôáyÇżßSsYcť
 szélroham/UĘŽiÖKŇmôáyÇżßSsYcť
 széloldal/UmôŇyiYcÇ	éloldalak
-szélmalomszárny/UmôŇyiYcÇ	élmalomszárnyak
-szélmalomkerék/VÓnňyjYcČ	élmalomkerekek
+szélmalomszárny/UmôŇyiYcÇ	élmalomszárnyakél|malom||szárny
+szélmalomkerék/VÓnňyjYcČ	élmalomkerekekél|malom||kerék
 szélmalom/UmôyiYcŽ	élmalmok
 széllökés/VËŻj×LÓnňéyČŔŕTtYcź
 szélláda/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -10665,7 +10690,6 @@ szélkerék/VÓnňyjYcČ	élkerekek
 szélkelep/VËŻj×LÓnňéčłÄäTtYc¸źl
 szélkakas/UĘŽiÖKŇmôáyÇżßSsYcť
 széljegyzet/VËŻj×LÓnňéyČŔŕTtYcź
-szélirányjelző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 szélirány/UĘŽiÖKŇmôáyÇżßSsYcť
 szélhűdés/VËŻj×LÓnňéyČŔŕTtYcź
 szélhámosság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -10697,13 +10721,12 @@ székház/UmôŇyiYcÇ	ékházak
 székhely/×VËŻjLÓnňéyČŔŕTtYcź
 székfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ékfüvek
 székesfőváros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-székesegyház/UmôŇyiYcÇ	ékesegyházak
+székesegyház/UmôŇyiYcÇ	ékesegyházakékes||egy|ház
 székelység/VËŻj×LÓnňéčłÄäTtYc¸źl
 székely/VËŻj×LÓnňéčłÄäTtYc¸źl
 székel
 szék/VËŻj×LÓnňéčłÄäTtYc¸ź
 széjjelebb
-széjjeldörzsölés/VËŻj×LÓnňéyČŔŕTtYcź
 szégyenül
 szégyenpír/UĘŽiÖKŇmôáyÇżßQYcť
 szégyenlő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X)égyenelÓ_PRESPART_adj
@@ -10736,6 +10759,7 @@ százévi
 százévente
 százévenként
 százzłotys/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+százvalahányfeléáz|valahány||felé
 százvalahányan
 százvalahány/UmŇŮÚ
 százszámraáz|szám-ra
@@ -10779,7 +10803,7 @@ századszor	ázadszorra
 századrész/VËŻj×LÓnňéyČŔŕTtYcź
 századparancsnok/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 százados/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-századmásodperc/VËŻj×LÓnňéyČŔŕTtYcź
+századmásodperc/VËŻj×LÓnňéyČŔŕTtYcźázad||másod|perc
 századikak/nI)áz
 századik/mŇŮAUÚc!ÖKk)áz
 századforduló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -10790,7 +10814,7 @@ század/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťkAz!Ú)áz
 század/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťkAz!Ú)áz
 század/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťkAz!Ú
 száz-egynéhány
-száz/$UŮÖmŇSscçÚ	ázasázanázanázadikakázadikázadázadázasázadikázadázad
+száz/$UŮÖmŇSscçÚ	ázasázanázanázadikakázadikázadázadázad
 szászság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szárító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szárítkozik
@@ -10816,7 +10840,7 @@ szárny/UmôŇçiYc˛	árnyak
 származékszó/ŐAUQĘŽiĎŇáyÇżßYcťÖ	ármazékszavak
 származék/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 származik
-szárkapocscsont/UĘŽiÖKŇmôáyÇżßQYcť
+szárkapocscsont/UĘŽiÖKŇmôáyÇżßQYcťár|kapocs||csont
 szárcsa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szárazáru/ŐAUQĘŽiĎŇáyÇżßYcť
 szárazvölgy/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
@@ -10876,13 +10900,13 @@ számára
 számvitel/VËŻj×LÓnňéyČŔŕTtYcź
 számvevőség/VËŻj×LÓnňéčłÄäTtYc¸źl
 számum/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
-számtanpélda/ŐAUQĘŽiĎŇáyÇżßYcť
+számtanpélda/ŐAUQĘŽiĎŇáyÇżßYcťám|tan||példa
 számtan/UĘŽiÖKŇmôáyÇżßSsYcť
 számtalanszor
 számszerűleg
 számszeríj/UŇmôyiYcÇ	ámszeríjak
 számsor/UĘŽiÖKŇmôáyÇżßSsYcť
-számrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+számrendszer/VËŻj×LÓnňéyČŔŕTtYcźám||rend|szer
 számra
 számpár/UĘŽiÖKŇmôáyÇżßQYcť
 számottevően
@@ -10918,11 +10942,7 @@ számadol
 szám/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
 szálosztályozó/ŐAUQĘŽiĎŇáyÇżßYcť
 szálló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-szállítószalag/UĘŽiÖKŇmôáyÇżßQYcť
-szállítókocsi/ŐAUQĘŽiĎŇáyÇżßYcť
-szállítóeszköz/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
-szállítócsille/ŐBVRËŻjĐÓéyČŔŕYcź
-szállítóberendezés/VËŻj×LÓnňéyČŔŕTtYcź
+szállítószalag/UĘŽiÖKŇmôáyÇżßSsYcť
 szállító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szállítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szállítmányozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -10933,7 +10953,6 @@ szállingózik
 szálldogál
 szálkaperje/ŐBVRËŻjĐÓéčłÄäYc¸ź
 szálka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-szálfatorlódás/UĘŽiÖKŇmôáyÇżßSsYcť
 szálfa/ŐAUQĘŽiĎŇáyÇżßYcť
 szálastakarmány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szálasanyag/UĘŽiÖKŇmôáyÇżßQSsYcť
@@ -11018,16 +11037,17 @@ szupernehezen/)éz
 szupernehezek/n×ÓI)éz
 szupermodell/VËŻj×LÓnňéyČŔŕRYcź
 szupermartingál/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-szupermarket/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRTtYcťź
+szupermarket/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRTtYcťź
 szupermaraton/UĘŽiÖKŇmôáyÇżßQYcť
 szuperliga/ŐAUQĘŽiĎŇáyÇżßYcť
 szuperlektor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szuperlatívusz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szuperkórház/UmôŇyiYcÇ	órházakór|ház
 szuperkészülék/VËŻj×LÓnňéčłÄäTtYc¸źl
+szuperképesség/VËŻj×LÓnňéyČŔŕTtYcź
 szuperkém/VËŻj×LÓnňéyČŔŕRTtYcź
 szuperkupa/ŐAUQĘŽiĎŇáyÇżßYcť
-szuperkiszolgáló/ŐAUQĘŽiĎŇáyÇżßYcť
+szuperkiszolgáló/ŐAUQĘŽiĎŇáyÇżßYcťáló
 szuperjektivitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szuperintendens/VËŻj×LÓnňéčłÄäTtYc¸źl
 szuperhős/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
@@ -11110,6 +11130,7 @@ szuahélicentrikusság/UĘŽiÖKŇmôáyÇżßSsYcť
 szuahélibarátság/UĘŽiÖKŇmôáyÇżßSsYcť
 szuahéli/ŐBVRËŻjĐÓéčłÄäc¸ź
 sztúpa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+sztóma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 sztélé/ŐBVRËŻjĐÓéčłÄäYc¸ź
 szték/VËŻj×LÓnňéčłÄäRYc¸ź
 sztárság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -11430,7 +11451,6 @@ szivárgás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk)árogÁs_PROCESS/RESULT_noun
 szivárgás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szivornya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szivattyús/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-szivattyúramács/UĘŽiÖKŇmôáyÇżßSsYcť
 szivattyúmotor/UĘŽiÖKŇmôáyÇżßQYcť
 szivattyú/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szivarzseb/VËŻj×LÓnňéyČŔŕTtYcź
@@ -11493,7 +11513,7 @@ szintézer/VËŻj×LÓnňéčłÄäRTtYc¸źl
 szintén
 szintén
 szintéjre/w
-szintvonaljelzés/VËŻj×LÓnňéyČŔŕTtYcź
+szintvonaljelzés/VËŻj×LÓnňéyČŔŕTtYcźés
 szintvonal/UmôŇyiYcÇ
 szintolyan/AmŇŐUKQ
 szintilyen/BnÓŐVLR
@@ -11597,10 +11617,10 @@ szilencium/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szilajpásztorkodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szila/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szil/VËŻj×LÓnňéčłÄäRYc¸ź
-sziksófű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ófüvek
+sziksófű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ófüvekó||fű
 sziksó/ŐAUQĘŽiĎŇáyÇżßYcť
 szikrázik
-szikratávirat/UĘŽiÖKŇmôáyÇżßSsYcť
+szikratávirat/UĘŽiÖKŇmôáyÇżßSsYcťáv|irat
 szikraköz/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 szikrafogó/ŐAUQĘŽiĎŇáyÇżßYcť
 szikra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -11730,6 +11750,7 @@ szervizkönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
 szerviz/VËŻj×LÓnňéčłÄäTtYc¸źl	ph:service*
 szervita/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szervilizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+szerveznivaló/ŐAUQĘŽiĎŇáyÇżßYcť
 szervezettség/VËŻj×LÓnňéčłÄäTtYc¸źl
 szervezet/VËŻj×LÓnňéčłÄäTtYc¸źl
 szervetlenkémia/ŐAUQĘŽiĎŇáç˛Ăăcˇťw
@@ -11745,14 +11766,13 @@ szertornász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szertorna/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szerteszét
 szerteszéjjel
-szertelenkedés/VËŻj×LÓnňéyČŔŕTtYcź
 szerte
 szertartáskönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
 szertartás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-szerszámtáska/ŐAUQĘŽiĎŇáyÇżßYcť
-szerszámosláda/ŐAUQĘŽiĎŇáyÇżßYcť
-szerszámláda/ŐAUQĘŽiĎŇáyÇżßYcť
-szerszámkészlet/VËŻj×LÓnňéyČŔŕTtYcź
+szerszámtáska/ŐAUQĘŽiĎŇáyÇżßYcťám||táska
+szerszámosláda/ŐAUQĘŽiĎŇáyÇżßYcťámos||láda
+szerszámláda/ŐAUQĘŽiĎŇáyÇżßYcťám||láda
+szerszámkészlet/VËŻj×LÓnňéyČŔŕTtYcźám||készlet
 szerszám/UĘŽiÖKŇmôáyÇżßQSsYcť
 szerpentinkő/WŢŘÔyjYcČ	övek
 szerpentin/VËŻj×LÓnňéčłÄäRYc¸źl
@@ -11909,8 +11929,8 @@ szentségtartó/ŐAUQĘŽiĎŇáyÇżßYcť
 szentségház/UmôŇyiYcÇ	égházak
 szentkép/VËŻj×LÓnňéyČŔŕTtYcź
 szentjánoskenyérfa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-szentjánoskenyér/VÓnňyjYcČ	ánoskenyerek
-szentjánosbogár/UmôŇyiYcÇQ	ánosbogarak
+szentjánoskenyér/VÓnňyjYcČ	ánoskenyerekános||kenyér
+szentjánosbogár/UmôŇyiYcÇQ	ánosbogarakános||bogár
 szentimentalizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szentháromságfű/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 szentháromság/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -11919,15 +11939,15 @@ szenteste/ŐBVRËŻjĐÓéyČŔŕYcź
 szentenciózus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szentenciázik
 szentencia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-szenteltvíztartó/ŐAUQĘŽiĎŇáyÇżßYcť
+szenteltvíztartó/ŐAUQĘŽiĎŇáyÇżßYcťíz||tartó
 szenteltvíz/VÓnňyjYcČ
 szentelmény/VËŻj×LÓnňéčłÄäTtYc¸źl
 szentbeszéd/VËŻj×LÓnňéyČŔŕRTtYcź
 szentatya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szent-györgyi/w
 szent/VËŻj×LÓnňéčłÄäRYc¸ź
-szennyvízkiöntő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-szennyvízcsatorna/ŐAUQĘŽiĎŇáyÇżßYcť
+szennyvízkiöntő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝íz||kiöntő
+szennyvízcsatorna/ŐAUQĘŽiĎŇáyÇżßYcťíz||csatorna
 szennyvíz/VÓnňyjYcČ
 szennylap/UĘŽiÖKŇmôáyÇżßQYcť
 szennyirodalom/UmôyiYcŽ
@@ -11963,8 +11983,8 @@ szenderegem/w
 szenderegek/w
 szendereged/w
 szender/VËŻj×LÓnňéčłÄäRTtYc¸źl
-szemüvegtok/UĘŽiÖKŇmôáyÇżßQYcť
-szemüvegkeret/VËŻj×LÓnňéyČŔŕTtYcź
+szemüvegtok/UĘŽiÖKŇmôáyÇżßQYcťüveg||tok
+szemüvegkeret/VËŻj×LÓnňéyČŔŕTtYcźüveg||keret
 szemüveg/VËŻj×LÓnňéyČŔŕRTtYcź
 szemöldökráncolás/UĘŽiÖKŇmôáyÇżßSsYcť
 szemöldökgerenda/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -12022,12 +12042,12 @@ szeminárium/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szeminarista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szemiinvariáns/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szemidiszkretizáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-szemhéjgyulladás/UĘŽiÖKŇmôáyÇżßSsYcť
+szemhéjgyulladás/UĘŽiÖKŇmôáyÇżßSsYcťéj||gyulladás
 szemhéj/VÓnňyjYcČ	éjak
 szemhatár/UĘŽiÖKŇmôáyÇżßSsYcť
 szemgyulladás/UĘŽiÖKŇmôáyÇżßSsYcť
 szemgolyó/ŐAUQĘŽiĎŇáyÇżßYcť
-szemfényvesztés/VËŻj×LÓnňéyČŔŕTtYcź
+szemfényvesztés/VËŻj×LÓnňéyČŔŕTtYcźény||vesztés
 szemforgatás/UĘŽiÖKŇmôáyÇżßSsYcť
 szemfog/UmôŇyiYcÇ
 szemfelszedő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
@@ -12195,11 +12215,10 @@ szegregáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szegmentáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szegmentum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szegmens/VËŻj×LÓnňéčłÄäTtYc¸źl
-szeglyukfúró/ŐAUQĘŽiĎŇáyÇżßYcť
 szeglet/VËŻj×LÓnňéčłÄäTtYc¸źl
 szeghúzó/ŐAUQĘŽiĎŇáyÇżßYcť
-szegfűszeg/VËŻj×LÓnňéyČŔŕTtYcź
-szegfűbors/UĘŽiÖKŇmôáyÇżßSsYcť
+szegfűszeg/VËŻj×LÓnňéyČŔŕTtYcźű||szeg
+szegfűbors/UĘŽiÖKŇmôáyÇżßSsYcťű||bors
 szegfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvek
 szegesdrót/UĘŽiÖKŇmôáyÇżßQYcť
 szegecsvágó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -12223,8 +12242,10 @@ szecesszionista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szebbik/Tt×nÓVD)ép
 szebben/D)ép
 szebb/×nÓBDLVR)ép
+szcéna/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szcintillátor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szcintilláció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+szcintigráfia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szcientológus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szcientológia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szcenárió/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -12470,7 +12491,7 @@ szabadtartás/UĘŽiÖKŇmôáyÇżßSsYcť
 szabadságolás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szabadságjog/UĘŽiÖKŇmôáyÇżßSsYcť
 szabadság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-szabadszórendűség/VËŻj×LÓnňéyČŔŕTtYcź
+szabadszórendűség/VËŻj×LÓnňéyČŔŕTtYcźó|rendűség
 szabadstrand/UĘŽiÖKŇmôáyÇżßQYcť
 szabadsor/UĘŽiÖKŇmôáyÇżßSsYcť
 szabadrúgás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -12493,7 +12514,7 @@ szabadgondolkozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szabadgondolkodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 szabadfoglalkozású/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 szabadesés/VËŻj×LÓnňéčłÄäTtYc¸źl
-szabadelőadás/UĘŽiÖKŇmôáyÇżßSsYcť
+szabadelőadás/UĘŽiÖKŇmôáyÇżßSsYcťő|adás
 szabadegyház/UmôŇyiYcÇ	ázakáz
 szabadegyetem/VËŻj×LÓnňéčłÄäTtYc¸źl
 szabadedzés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -12565,7 +12586,7 @@ sutyorgó/ŐAUQĘŽiĎŇáç˛ĂăYcˇťX)Ó_PRESPART_adj
 sutyorgás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk)Ás_PROCESS/RESULT_noun
 sutyiban
 sutura/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-suttyó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+suttyó/ŐAUQĘŽiĎŇáç˛Ăăcˇť
 suttyomban
 suttogó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 sut/UĘŽiÖKŇmôáç˛ĂăQYcˇť
@@ -12649,7 +12670,7 @@ subaszőnyeg/VËŻj×LÓnňéčłÄäTtYc¸źl
 suba/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 stúdió/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 stúdium/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-stósz/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
+stósz/UĘŽiÖKŇmôáç˛ĂăSsYcˇť	ph:stóc
 stóla/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 stílus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 stílművész/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -12686,6 +12707,7 @@ strici/ŐBVRËŻjĐÓéčłÄäYc¸ź
 stria/ŐAUQĘŽiĎŇáç˛Ăăvcˇť
 stressz/VËŻj×LÓnňéčłÄäTtYc¸ź
 streetball/UĘŽiÖKŇmôáç˛ĂăQYcˇťk	ph:sztrítból
+streaming/VËŻj×LÓnňéčłÄäRYc¸źl	ph:sztríming
 stratégia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 stratéga/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 stratus/UĘŽiÖKŇmöáç˛ĂăSsYcˇťk
@@ -13081,6 +13103,7 @@ snapszli/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 snapszer/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRTtYcˇť¸źkl
 snapsz/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
 snack/VËŻj×LnÓňéčłÄäRYc¸ź
+smúzol
 smár/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 smukk/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 smucigság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -13108,6 +13131,7 @@ sláger/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäTtYcˇť¸źkl
 slusszkulcs/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 slussz/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
 slukk/UĘŽiÖKŇmôáç˛ĂăQYcˇť
+slozi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 slowfox/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 sligovica/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 slicc/VËŻj×LÓnňéčłÄäTtYc¸ź
@@ -13447,7 +13471,7 @@ segédmotor/UĘŽiÖKŇmôáyÇżßQYcť
 segédlet/VËŻj×LÓnňéčłÄäTtYc¸źl
 segédlelkész/VËŻj×LÓnňéčłÄäTtYc¸źl
 segédige/ŐBVRËŻjĐÓéyČŔŕYcź
-segédhajtómű/WŢŘÔyjYcČ	édhajtóművek
+segédhajtómű/WŢŘÔyjYcČ	édhajtóművekéd||hajtó|mű
 segédeszköz/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 segéd/VËŻj×LÓnňéčłÄäRTtYc¸źl
 segg/VËŻj×LÓnňéčłÄäTtYc¸ź=
@@ -13618,7 +13642,6 @@ sajátkezűleg
 sajátidő/ŐCWĚŻjŢÔíyČÁ˙Yc˝	átidej
 sajátidej/uxytT¸)átidő
 sajátfrekvencia/ŐAUQĘŽiĎŇáyÇżßYcť
-sajtószerte
 sajtópáholy/UĘŽiÖKŇmôáyÇżßSsYcť
 sajtókarzat/UĘŽiÖKŇmôáyÇżßSsYcť
 sajtóhiba/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -13632,7 +13655,7 @@ sajtos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 sajtológép/VËŻj×LÓnňéyČŔŕRTtYcź
 sajtkukac/UĘŽiÖKŇmôáyÇżßSsYcť
 sajtfajta/ŐAUQĘŽiĎŇáyÇżßYcť
-sajtburger/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRTtYcˇť¸źkl
+sajtburger/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRTtYcťź
 sajt/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 sajogunk/w
 sajogott/w
@@ -13845,7 +13868,7 @@ részére
 részvétel/VËŻj×LÓnňéyČŔŕTtYcź
 részvét/VËŻj×LÓnňéčłÄäTtYc¸źl
 részvénytúljegyzés/VËŻj×LÓnňéčłÄäTtYc¸źl
-részvénytársaság/UĘŽiÖKŇmôáyÇżßSsYcť
+részvénytársaság/UĘŽiÖKŇmôáyÇżßSsYcťész|vény||társaság
 részvénypakett/VËŻj×LÓnňéčłÄäRYc¸źl
 részvényes/VËŻj×LÓnňéčłÄäTtYc¸źl
 részvény/VËŻj×LÓnňéyČŔŕTtYcź
@@ -13869,9 +13892,9 @@ részesmunka/ŐAUQĘŽiĎŇáyÇżßYcť
 részeshatározó/ŐAUQĘŽiĎŇáyÇżßYcť
 részegül
 részegítő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
-részegyház/UmôŇyiYcÇ	észegyházak
+részegyház/UmôŇyiYcÇ	észegyházakész||egy|ház
 részegszik
-részegkorpafű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	észegkorpafüvek
+részegkorpafű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	észegkorpafüvekészeg||korpa|fű
 részecskegyorsító/ŐAUQĘŽiĎŇáyÇżßYcť
 részecske/ŐBVRËŻjĐÓéčłÄäYc¸ź
 részben
@@ -13892,7 +13915,7 @@ rémség/VËŻj×LÓnňéčłÄäTtYc¸źl
 rémregény/VËŻj×LÓnňéyČŔŕTtYcź
 rémkép/VËŻj×LÓnňéyČŔŕTtYcź
 rémit/w
-rémhírterjesztés/VËŻj×LÓnňéyČŔŕTtYcź
+rémhírterjesztés/VËŻj×LÓnňéyČŔŕTtYcźém|hír||terjesztés
 rém/VËŻj×LÓnňéčłÄäTtYc¸ź
 rékli/ŐBVRËŻjĐÓéčłÄäYc¸ź
 régóta
@@ -13976,7 +13999,7 @@ ráhagyás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 rágógumi/ŐAUQĘŽiĎŇáyÇżßYcť
 rágcsáló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 rágcsálnivaló/ŐAUQĘŽiĎŇáyÇżßYcť
-rágalomhadjárat/UĘŽiÖKŇmôáyÇżßSsYcť
+rágalomhadjárat/UĘŽiÖKŇmôáyÇżßSsYcťágalom||had|járat
 rágalom/UmôçiYcŽk	ágalmak
 ráfogás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ráfekvés/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -13988,7 +14011,7 @@ rádli/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 rádiózik
 rádióvétel/VËŻj×LÓnňéyČŔŕTtYcź
 rádióvevő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-rádiótávirat/UĘŽiÖKŇmôáyÇżßSsYcť
+rádiótávirat/UĘŽiÖKŇmôáyÇżßSsYcťádió||táv|irat
 rádiótelefon/UĘŽiÖKŇmôáyÇżßQYcť
 rádiószekrény/VËŻj×LÓnňéyČŔŕTtYcź
 rádiós/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -14127,6 +14150,7 @@ rovatcím/VËŻj×LÓnňéyČŔŕTtYcź
 rovat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 rovarölőszer-/=
 rovarölő_szer/VËŻj×LÓnňéčłÄäTtc¸źl
+rovarász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 rovartan/UĘŽiÖKŇmôáyÇżßSsYcť
 rovarirtószer-/=
 rovarirtó_szer/VËŻj×LÓnňéčłÄäTtc¸źl
@@ -14279,7 +14303,7 @@ rokkantság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 rokkantsegély/VËŻj×LÓnňéčłÄäTtYc¸źl
 rokkantnyugdíjazás/UĘŽiÖKŇmôáyÇżßSsYcť
 rokkantnyugdíjas/UĘŽiÖKŇmôáyÇżßSsYcť
-rokkantnyugdíj/UŇmôyiYcÇ	íjak
+rokkantnyugdíj/UŇmôyiYcÇ	íjakíj
 rokkantkártya/ŐAUQĘŽiĎŇáyÇżßYcť
 rokkantkocsi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 rokkantgondozás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -14305,12 +14329,11 @@ rodanid/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 rocska/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 rockénekes/VËŻj×LÓnňéčłÄäTtYc¸źl
 rockzene/ŐBVRËŻjĐÓéčłÄäYc¸ź
-rockopera/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+rockopera/ŐAUQĘŽiĎŇáyÇżßYcť
 rocker/VËŻj×LÓnňéčłÄäRTtYc¸źl
 rock/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 robotol
 robotmunka/ŐAUQĘŽiĎŇáyÇżßYcť
-robotizálás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 robotika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 robot/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 roborálás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -14458,7 +14481,7 @@ rezsó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 rezsim/VËŻj×LÓnňéčłÄäRYc¸źl
 rezsi/ŐBVRËŻjĐÓéčłÄäYc¸ź
 rezorcin/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
-rezonőr/WĚŻjŘMÝňÔíyČÁ˙RTtYc˝
+rezonőr/WĚŻjŘMÝňÔíčłĹĺRTtYc¸˝l
 rezonátor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 rezonál
 rezonancia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -14563,7 +14586,7 @@ repülősebesség/VËŻj×LÓnňéyČŔŕTtYcź
 repülőraj/UĘŽiÖKŇmôáyÇżßSsYcť
 repülőosztály/UĘŽiÖKŇmôáyÇżßSsYcť
 repülőjárat/UĘŽiÖKŇmôáyÇżßSsYcť
-repülőgéptörzs/VNËŻj×LÝňÔéyČŔŕTtYcź
+repülőgéptörzs/VNËŻj×LÝňÔéyČŔŕTtYcźülő|gép||törzs
 repülőgép/VËŻj×LÓnňéyČŔŕRTtYcź
 repülőfedélzet/VËŻj×LÓnňéyČŔŕTtYcź
 repülőcsapat/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -14624,19 +14647,19 @@ rengeteg/VËŻj×LÓnňéčłÄäRTtYc¸źl
 reneszánsz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 renegát/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 rendül
-rendőrőrszoba/ŐAUQĘŽiĎŇáyÇżßYcť
+rendőrőrszoba/ŐAUQĘŽiĎŇáyÇżßYcťőr||őr|szoba
 rendőrség/VËŻj×LÓnňéyČŔŕTtYcź
-rendőrnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-rendőrhatóság/UĘŽiÖKŇmôáyÇżßSsYcť
+rendőrnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝őr||nő
+rendőrhatóság/UĘŽiÖKŇmôáyÇżßSsYcťőr||hatóság
 rendőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 rendészet/VËŻj×LÓnňéčłÄäTtYc¸źl
 rendész/VËŻj×LÓnňéčłÄäTtYc¸źl
 rendvédelmis/VËŻj×LÓnňéyČŔŕTtYcź
-rendszerváltás/UĘŽiÖKŇmôáyÇżßSsYcť
-rendszerszervező/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-rendszerszervezés/VËŻj×LÓnňéyČŔŕTtYcź
-rendszerprogramozó/ŐAUQĘŽiĎŇáyÇżßYcť
-rendszerprogramozás/UĘŽiÖKŇmôáyÇżßSsYcť
+rendszerváltás/UĘŽiÖKŇmôáyÇżßSsYcťáltás
+rendszerszervező/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő
+rendszerszervezés/VËŻj×LÓnňéyČŔŕTtYcźés
+rendszerprogramozó/ŐAUQĘŽiĎŇáyÇżßYcťó
+rendszerprogramozás/UĘŽiÖKŇmôáyÇżßSsYcťás
 rendszerint
 rendszeretet/VËŻj×LÓnňéyČŔŕTtYcź
 rendszer/VËŻj×LÓnňéyČŔŕTtYcź
@@ -14855,7 +14878,7 @@ redundancia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 reduktor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 redukció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 reducens/VËŻj×LÓnňéčłÄäTtYc¸źl
-redoxiátalakulás/UĘŽiÖKŇmôáyÇżßSsYcť
+redoxiátalakulás/UĘŽiÖKŇmôáyÇżßSsYcťát|alakulás
 redoxireakció/ŐAUQĘŽiĎŇáyÇżßYcť
 redoxipotenciál/UĘŽiÖKŇmôáyÇżßQYcť
 redoxikatalizátor/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -14955,13 +14978,10 @@ rakva/X)
 rakunk/X)
 raktér/VÓnňyjYcČ
 raktátok/X)
-raktárállomány/UĘŽiÖKŇmôáyÇżßSsYcť
-raktárszoba/ŐAUQĘŽiĎŇáyÇżßYcť
 raktáros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 raktárnok/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-raktárkönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
-raktárház/UmôŇyiYcÇ	árházak
-raktárhelyiség/VËŻj×LÓnňéyČŔŕTtYcź
+raktárház/UmôŇyiYcÇ	árházakár||ház
+raktárhelyiség/VËŻj×LÓnňéyČŔŕTtYcźár||helyiség
 raktár/UmôŇyiYcÇ	árak
 raktál/X)
 rakták/X)
@@ -15144,7 +15164,7 @@ rachitis/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 raccsol
 rabulisztika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 rabság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-rabszolgatartó/ŐAUQĘŽiĎŇáyÇżßYcť
+rabszolgatartó/ŐAUQĘŽiĎŇáyÇżßYcťó
 rabszolgaság/UĘŽiÖKŇmôáyÇżßSsYcť
 rabszolgahajcsár/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 rabszolga/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -15308,7 +15328,7 @@ pózna/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 póz/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
 pótülés/VËŻj×LÓnňéyČŔŕTtYcź
 pótóra/ŐAUQĘŽiĎŇáyÇżßYcť
-pótírásbeli/ŐBVRËŻjĐÓéyČŔŕYcźót||írás|beli
+pótírásbeli/ŐBVRËŻjĐÓéyČŔŕYcź
 pótérettségi/ŐBVRËŻjĐÓéyČŔŕYcź
 pótágy/UmôŇyiYcÇ	ótágyak
 pótzárthelyi/ŐBVRËŻjĐÓéyČŔŕYcźót||zárt|helyi
@@ -15352,7 +15372,7 @@ pótmegoldás/UĘŽiÖKŇmôáyÇżßSsYcť
 pótmegjegyzés/VËŻj×LÓnňéyČŔŕTtYcź
 pótmarkolat/UĘŽiÖKŇmôáyÇżßSsYcť
 pótmama/ŐAUQĘŽiĎŇáyÇżßYcť
-pótmagánvád/UmôŇyiYcÇQ	ótmagánvádak
+pótmagánvád/UmôŇyiYcÇQ	ótmagánvádakót||magán|vád
 pótlólag
 pótló/ŐAUQĘŽiĎŇáç˛ĂăYcˇťX)ótolÓ_PRESPART_adj
 pótlék/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
@@ -15375,7 +15395,7 @@ pótjegy/VËŻj×LÓnňéyČŔŕTtYcź
 pótilleték/VËŻj×LÓnňéyČŔŕTtYcź
 póthitel/VËŻj×LÓnňéyČŔŕTtYcź
 póthatáridő/ŐCWĚŻjŢÔíyČÁ˙Yc˝	óthatáridej
-póthatáridej/uxytT¸)óthatáridő
+póthatáridej/uxytT¸)óthatáridő	ót||határ|idő
 póthaj/UmôŇyiYcÇ	óthajak
 póthagyaték/UĘŽiÖKŇmôáyÇżßSsYcť
 pótfüzet/VËŻj×LÓnňéyČŔŕRTtYcź
@@ -15403,10 +15423,10 @@ pótberuházás/UĘŽiÖKŇmôáyÇżßSsYcťót||be|ruházás
 pótbelső/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 pótbeiratkozás/UĘŽiÖKŇmôáyÇżßSsYcť
 pótbefizetés/VËŻj×LÓnňéyČŔŕTtYcźót||be|fizetés
-pótapa/	ótap
+pótapa/ŐAUQĘŽiĎŇáyÇżßYcť	ótap
 pótap/uQ)ótapa
 pótanyag/UĘŽiÖKŇmôáyÇżßSsYcť
-pótanya/	ótany
+pótanya/ŐAUQĘŽiĎŇáyÇżßYcť	ótany
 pótany/uQ)ótanya
 pótalkatrész/VËŻj×LÓnňéyČŔŕTtYcźót||alkat|rész
 pótadó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -15428,7 +15448,7 @@ pólyakötő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 pólya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 pólus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 póling/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-pókhálósgomba/ŐAUQĘŽiĎŇáyÇżßYcť
+pókhálósgomba/ŐAUQĘŽiĎŇáyÇżßYcťók|hálós||gomba
 pókháló/ŐAUQĘŽiĎŇáyÇżßYcť
 pókerezik
 póker/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRTtYcˇť¸źkl
@@ -15452,11 +15472,11 @@ péterfillér/VËŻj×LÓnňéyČŔŕTtYcź
 pészméker/VËŻj×LÓnňéčłÄäRTtYc¸źl
 pér/VËŻj×LÓnňéčłÄäRYc¸ź
 pép/VËŻj×LÓnňéčłÄäRYc¸ź
-pénzügyőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
+pénzügyőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝énz|ügy||őr
 pénzügyér/VËŻj×LÓnňéyČŔŕTtYcź
-pénzügyminisztérium/UĘŽiÖKŇmôáyÇżßSsYcť
+pénzügyminisztérium/UĘŽiÖKŇmôáyÇżßSsYcťénz|ügy||minisztérium
 pénzügyis/VËŻj×LÓnňéyČŔŕTtYcź
-pénzügyigazgatóság/UĘŽiÖKŇmôáyÇżßSsYcť
+pénzügyigazgatóság/UĘŽiÖKŇmôáyÇżßSsYcťénz|ügy||igazgatóság
 pénzügy/VNËŻj×LÝňÔéyČŔŕTtYcź
 pénzösszeg/VËŻj×LÓnňéyČŔŕTtYcź
 pénzváltó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -15467,15 +15487,15 @@ pénzverde/ŐBVRËŻjĐÓéčłÄäYc¸ź
 pénztárosnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 pénztáros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 pénztárnok/UĘŽiÖKŇmôáyÇżßSsYcť
-pénztárgép/VËŻj×LÓnňéyČŔŕRTtYcź
+pénztárgép/VËŻj×LÓnňéyČŔŕRTtYcźénz|tár||gép
 pénztárca/ŐAUQĘŽiĎŇáyÇżßYcť
-pénztárablak/UĘŽiÖKŇmôáyÇżßSsYcť
+pénztárablak/UĘŽiÖKŇmôáyÇżßSsYcťénz|tár||ablak
 pénztár/UmôŇyiYcÇ	énztárak
 pénzszűkítés/VËŻj×LÓnňéyČŔŕTtYcźénz|szű-kí-tés
 pénzszűke/ŐBVRËŻjĐÓéyČŔŕYcźénz|szű-ke
 pénzszekrény/VËŻj×LÓnňéyČŔŕTtYcźénz|szek-rény
 pénzsegély/VËŻj×LÓnňéyČŔŕTtYcźénz|se-gély
-pénzrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+pénzrendszer/VËŻj×LÓnňéyČŔŕTtYcźénz||rend|szer
 pénzpiac/UĘŽiÖKŇmôáyÇżßSsYcť
 pénznem/VËŻj×LÓnňéyČŔŕTtYcź
 pénzmágnás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -15571,8 +15591,8 @@ pártkassza/ŐAUQĘŽiĎŇáyÇżßYcť
 párthűség/VËŻj×LÓnňéyČŔŕTtYcź
 pártfunkcionárius/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 pártfogás/UĘŽiÖKŇmôáyÇżßSsYcť
-pártanácsadó/ŐAUQĘŽiĎŇáyÇżßYcť
-pártanácsadás/UĘŽiÖKŇmôáyÇżßSsYcť
+pártanácsadó/ŐAUQĘŽiĎŇáyÇżßYcťár||tanács|adó
+pártanácsadás/UĘŽiÖKŇmôáyÇżßSsYcťár||tanács|adás
 párta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 párt/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 párszor
@@ -16090,7 +16110,7 @@ processzor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 processzió/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 procedúra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 probáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-problémamegoldó/ŐAUQĘŽiĎŇáyÇżßYcť
+problémamegoldó/ŐAUQĘŽiĎŇáyÇżßYcťéma||meg|oldó
 probléma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 problematika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 pro_patria/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -16302,7 +16322,7 @@ porozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇťX
 porozás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 porozitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 poroszsüveg/VËŻj×LÓnňéčłÄäRTtYc¸źl
-poroszlósapka/ŐAUQĘŽiĎŇáyÇżßYcť
+poroszló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 poroszkál
 poroszka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 poronty/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -16373,9 +16393,9 @@ ponor/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 pongyolaság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 pongyola/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 pondró/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+poncsó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ph:poncho	ph:ponchó
 ponciusát
 poncichter/VËŻj×LÓnňéčłÄäTtYc¸źl
-poncho/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ponc/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
 pomádé/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 pompázik
@@ -16557,7 +16577,7 @@ poetry/VËŻjŐBĐŃéčłÄäRYc¸źl
 poe-i/ŃĎŐAFUKSs)	ph:pói
 podzolosodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťkás
 podzol/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-podcast/UĘŽiÖKŇmôáç˛ĂăQYcˇťk	ph:podkaszt	ph:podkeszt
+podcast/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRYcˇť¸źkl	ph:podkaszt	ph:podkeszt
 podagrafű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvek
 podagra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 pocséta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -17520,7 +17540,7 @@ parafrázis/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 parafinolaj/UmôŇyiYcÇ
 parafingyertya/ŐAUQĘŽiĎŇáyÇżßYcť
 paraffin/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
-parafenomén/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRTtYcťź
+parafenomén/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRTtYcťź
 parafa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 paradoxon/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 paradigma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -17537,7 +17557,6 @@ papíráru/ŐAUQĘŽiĎŇáyÇżßYcť
 papírzsebkendő-/=
 papírvágó/ŐAUQĘŽiĎŇáyÇżßYcť
 papírsárkány/UĘŽiÖKŇmôáyÇżßSsYcť
-papírpénztárca/ŐAUQĘŽiĎŇáyÇżßYcť
 papírpénz/VËŻj×LÓnňéyČŔŕTtYcź
 papírpecsét/VËŻj×LÓnňéyČŔŕRYcź
 papírnyomat/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -17692,7 +17711,7 @@ pakfon/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 pakett/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRYcˇť¸źkl
 pajzstetű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 pajzsoscankó/ŐAUQĘŽiĎŇáyÇżßYcť
-pajzsmirigytúltengés/VËŻj×LÓnňéyČŔŕTtcź
+pajzsmirigytúltengés/VËŻj×LÓnňéyČŔŕTtcźúl|tengés
 pajzsmirigy/VËŻj×LÓnňéyČŔŕTtYcź
 pajzsika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 pajzs/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
@@ -17922,7 +17941,7 @@ orvhalász/UĘŽiÖKŇmôáyÇżßSsYcť
 orv/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 ortopédia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ortopéd/VËŻj×LÓnňéčłÄäRYc¸źl
-ortoperjódsav/UmôŇyiYcÇQ	ódsavak
+ortoperjódsav/UmôŇyiYcÇQ	ódsavakód|sav
 ortológus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ortológia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ortoklász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -17940,7 +17959,6 @@ orsógiliszta/ŐAUQĘŽiĎŇáyÇżßYcť
 orsócsont/UĘŽiÖKŇmôáyÇżßQYcť
 orsó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 országút/UmôŇyiYcÇQ	águtak
-országszerte
 országol
 országnagy/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 országlás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -17976,7 +17994,7 @@ oroszóra/ŐAUQĘŽiĎŇáyÇżßYcť
 orosztudás/UĘŽiÖKŇmôáyÇżßSsYcť
 orosztanítás/UĘŽiÖKŇmôáyÇżßSsYcť
 orosztanár/UĘŽiÖKŇmôáyÇżßQSsYcť
-orosztankönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
+orosztankönyv/VNËŻj×LÝňÔéyČŔŕTtYcźönyv
 orosznyelv-/vc
 oroszlánszáj/UmôŇyiYcÇ	ánszájak
 oroszlánfóka/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -18017,7 +18035,7 @@ origami/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 orientáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 orientalisztika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 orgánum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-orgyilkosság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+orgyilkosság/UĘŽiÖKŇmôáyÇżßSsYcť	ph:orvgyilkosság	ph:orrgyilkosság
 orgyilkos/UĘŽiÖKŇmôáyÇżßSsYcť	ph:orvgyilkos	ph:orrgyilkos
 orgonál
 orgonista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -18033,6 +18051,7 @@ organogram/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 organizátor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 organizáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 organizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+organigram/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 orfeum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ordó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ordítozik
@@ -18082,6 +18101,7 @@ operaelőadás/UĘŽiÖKŇmôáyÇżßSsYcť
 opera/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 openoffice.org-os/ŇŮmAFUKQ)
 openoffice-os/ŇŮmAFUKQ)	ph:openofiszos
+openStreetMapes/w
 openSUSE-vá/)
 openSUSE-val/)
 openSUSE-s/ŇŮmAFUKQ)
@@ -18176,7 +18196,7 @@ olvasópolc/UĘŽiÖKŇmôáyÇżßSsYcť
 olvasókönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
 olvasó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 olvasztótégely/VËŻj×LÓnňéyČŔŕTtYcź
-olvasztóműhely/VËŻj×LÓnňéyČŔŕTtYcź
+olvasztóműhely/VËŻj×LÓnňéyČŔŕTtYcźó||mű|hely
 olvasztókemence/ŐBVRËŻjĐÓéyČŔŕYcź
 olvasztókanna/ŐAUQĘŽiĎŇáyÇżßYcť
 olvasztó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -18320,8 +18340,8 @@ oktatástechnológus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 oktatástan/UĘŽiÖKŇmôáyÇżßSsYcť
 oktatás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 oktanol/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
-oktadekánsav/UmôŇyiYcÇQ	ánsavak
-oktadecénsav/UmôŇyiYcÇQ	énsavak
+oktadekánsav/UmôŇyiYcÇQ	ánsavakán|sav
+oktadecénsav/UmôŇyiYcÇQ	énsavakén||sav
 oktadecinsav/UmôŇyiYcÇQ
 okt.-t/)
 okt.-ré/)
@@ -18594,17 +18614,17 @@ nézdegél
 névérték/VËŻj×LÓnňéyČŔŕTtYcź
 névutó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 névtábla/ŐAUQĘŽiĎŇáyÇżßYcť
-névsorolvasás/UĘŽiÖKŇmôáyÇżßSsYcť
+névsorolvasás/UĘŽiÖKŇmôáyÇżßSsYcťév|sor||olvasás
 névsor/UĘŽiÖKŇmôáyÇżßSsYcť
 névmás/UĘŽiÖKŇmôáyÇżßSsYcť
 névleg
 névjegyzék/VËŻj×LÓnňéyČŔŕTtYcź
-névjegytárca/ŐAUQĘŽiĎŇáyÇżßYcť
+névjegytárca/ŐAUQĘŽiĎŇáyÇżßYcťév|jegy||tárca
 névjegykártya/ŐAUQĘŽiĎŇáyÇżßYcťév|jegy||kártya # <névjegykártyaszerű>
 névjegy/VËŻj×LÓnňéyČŔŕTtYcź
 névelő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 névcédula/ŐAUQĘŽiĎŇáyÇżßYcť
-névaláírás/UĘŽiÖKŇmôáyÇżßSsYcť
+névaláírás/UĘŽiÖKŇmôáyÇżßSsYcťév||alá|írás
 név/VÓnňčjYcł
 népének/VËŻj×LÓnňéyČŔŕTtYcźépénektár>
 népámítás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -18645,7 +18665,7 @@ németóra/ŐAUQĘŽiĎŇáyÇżßYcť
 némettudás/UĘŽiÖKŇmôáyÇżßSsYcť
 némettanítás/UĘŽiÖKŇmôáyÇżßSsYcť
 némettanár/UĘŽiÖKŇmôáyÇżßQSsYcť
-némettankönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
+némettankönyv/VNËŻj×LÝňÔéyČŔŕTtYcźémet||tan|könyv
 némettamariska/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 németnyelv-/vc
 németkönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
@@ -18703,24 +18723,24 @@ négyévi
 négyévente
 négyévenként
 négyzetöl/WÝÔyjYcČĚŻŘMňíÁ˙Tt˝	égyzetölek
-négyzetméterár/UmôŇyiYcÇ	égyzetméterárak
+négyzetméterár/UmôŇyiYcÇ	égyzetméterárakégyzet|méter||ár
 négyzetkilométer/VËŻj×LÓnňéyČŔŕRTtYcź
 négyzetfa/ŐAUQĘŽiĎŇáyÇżßYcť
 négyzet/VËŻj×LÓnňéčłÄäTtYc¸źl
 négytrillióan/b)égytrillió
 négytrillió/ĎŇŐAUÚQbci	égytrillióan
 négytrilliárd/mÖKkUÚQbci
-négyszögöl/WÝÔyjYcČĚŻŘMňíÁ˙Tt˝	égyszögölek
+négyszögöl/WÝÔyjYcČĚŻŘMňíÁ˙Tt˝	égyszögölekégy|szög||öl
 négyszögesítés/VËŻj×LÓnňéyČŔŕTtYcź
 négyszög/VNËŻj×LÝňÔéyČŔŕTtYcź
-négyszázfelé
-négyszázezres/×BŐV
-négyszázezrek/I)égyszázezer
+négyszázfeléégy|száz||felé
+négyszázezres/×BŐV	égy|száz||ezres
+négyszázezrek/I)égyszázezer	égy|száz||ezrek
 négyszázas/AFUÚ)égyszáz
 négyszázan/)égyszáz
 négyszázadik/mŇŮAUÚ)égyszáz
 négyszázad/AUÚ)égyszáz
-négyszáz/$UŮÖmŇSscÚ	égyszázaségyszázanégyszázadikégyszázadégyszázaségyszázadikégyszázad
+négyszáz/$UŮÖmŇSscÚ	égyszázaségyszázanégyszázadikégyszázad
 négyszemközt
 négyrét
 négypercenként
@@ -18731,7 +18751,7 @@ négymillióan/b)égymillió
 négymillió/ĎŇŐAUÚQbcjKkaż	égymillióan
 négymilliárdan/b)égymilliárd
 négymilliárd/mÖKkUÚQbciAŇaż	égymilliárdan
-négylapfej/VËŻj×LÓnňéyČŔŕTtYcź
+négylapfej/VËŻj×LÓnňéyČŔŕTtYcźégy|lap||fej
 négykézlábra
 négykézláb
 négykerék-meghajtás/UĘŽiÖKŇmôáyÇżßSscť
@@ -18751,7 +18771,7 @@ négyezrek/Iba)
 négyezredik/nÓ×BVÜb)égyezer
 négyezred/BVÜb)égyezer
 négyezet/VËŻj×LÓnňéčłÄäTtYc¸źl
-négyezerfelé
+négyezerfeléégy|ezer||felé
 négyezer/ŐnBVÜjbcÓ×LlTts	égyezreségyezrenégyezrekégyezredikégyezred
 négyesével
 négyesztendőnként
@@ -18765,7 +18785,7 @@ négyen/abh)égy
 négybillióan/b)égybillió
 négybillió/ĎŇŐAUÚQbci	égybillióan
 négybilliárd/mÖKkUÚQbci
-négy-ötmillió/ĎŇŐAUÚQbcw
+négy-ötmillió/ĎŇŐAUÚQbcw	égy-öt|millió
 négy/nVÜLlTtbhcÓ×a	égyen
 négus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 néger/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -18853,7 +18873,7 @@ nyúlkál
 nyúlketrec/VËŻj×LÓnňéyČŔŕTtYcź
 nyúlfi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 nyúlfarknyi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-nyúlfarkfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	úlfarkfüvek
+nyúlfarkfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	úlfarkfüvekúl|fark||fű
 nyúlfark/UĘŽiÖKŇmôáyÇżßQYcť
 nyúl/UmôŇçiYc˛
 nyújtózkodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -18940,14 +18960,14 @@ nyugi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 nyughely/×VËŻjLÓnňéčłÄäTtYc¸źl
 nyugger/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRTtYcˇť¸źkl
 nyugellátás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-nyugdíjpénztár/UmôŇyiYcÇ	íjpénztárak
-nyugdíjjogosult/UĘŽi$sŇmôáyÇżßQxcť
+nyugdíjpénztár/UmôŇyiYcÇ	íjpénztárakíj||pénz|tár
+nyugdíjjogosult/UĘŽi$sŇmôáyÇżßQxcťíj||jogosult
 nyugdíjasítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nyugdíjaskor/UĘŽiÖKŇmôáyÇżßQYcť
 nyugdíjasklub/UĘŽiÖKŇmôáyÇżßQYcť
 nyugdíjaskedvezmény/VËŻj×LÓnňéyČŔŕTtYcź
-nyugdíjasház/UmôŇyiYcÇ	íjasházak
-nyugdíjas-találkozó/ŐAUQĘŽiĎŇáyÇżßcť
+nyugdíjasház/UmôŇyiYcÇ	íjasházakíjas||ház
+nyugdíjas-találkozó/ŐAUQĘŽiĎŇáyÇżßcťíjas-találkozó
 nyugdíj/UŇmôyiYcÇ	íjak
 nyugatabbról/D)
 nyugatabbra/D)
@@ -18985,7 +19005,7 @@ nyomtatvány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nyomravezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 nyomozat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nyomottság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-nyomottfejű-hangya/ŐAUQĘŽiĎŇáyÇżßYcť
+nyomottfejű-hangya/ŐAUQĘŽiĎŇáyÇżßYcťű-hangya
 nyomorúság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nyomortanya/ŐAUQĘŽiĎŇáyÇżßYcť
 nyomoronc/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -19020,30 +19040,36 @@ nyolcévi
 nyolcévente
 nyolcévenként
 nyolcvanötödik/!VÓn×Llbh)öt
-nyolcvanöttrillióan/b)öttrillió
-nyolcvanöttrillió/ĎŇŐAUÚQbci	öttrillióan
-nyolcvanöttrilliárd/mÖKkUÚQbci
-nyolcvanötmillióan/b)ötmillió
-nyolcvanötmillió/ĎŇŐAUÚQbcj	ötmillióan
-nyolcvanötmilliárdan/b)ötmilliárd
-nyolcvanötmilliárd/mÖKkUÚQbci	ötmilliárdan
-nyolcvanötfelé
-nyolcvanötezres/×BŐVb)ötezer
-nyolcvanötezren/b)ötezer
-nyolcvanötezrek/Ib)ötezer
-nyolcvanötezredik/nÓ×BVÜb)ötezer
-nyolcvanötezred/BVÜb)ötezer
-nyolcvanötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred
+nyolcvanöttrillióan/b)öttrillió	öt||trillióan
+nyolcvanöttrillió/ĎŇŐAUÚQbci	öttrillióan	öt||trillió
+nyolcvanöttrilliárd/mÖKkUÚQbci	öt||trilliárd
+nyolcvanötmillióan/b)ötmillió	öt||millióan
+nyolcvanötmillió/ĎŇŐAUÚQbcj	ötmillióan	öt||millió
+nyolcvanötmilliárdan/b)ötmilliárd	öt||milliárdan
+nyolcvanötmilliárd/mÖKkUÚQbci	ötmilliárdan	öt||milliárd
+nyolcvanötfeléöt||felé
+nyolcvanötezres/×BŐVb)ötezer	öt||ezres
+nyolcvanötezren/b)ötezer	öt||ezren
+nyolcvanötezrek/Ib)ötezer	öt||ezrek
+nyolcvanötezredik/nÓ×BVÜb)ötezer	öt||ezredik
+nyolcvanötezred/BVÜb)ötezer	öt||ezred
+nyolcvanötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred	öt||ezer
 nyolcvanöten/bh)öt
-nyolcvanötbillióan/b)ötbillió
-nyolcvanötbillió/ĎŇŐAUÚQbci	ötbillióan
-nyolcvanötbilliárd/mÖKkUÚQbci
+nyolcvanötbillióan/b)ötbillió	öt||billióan
+nyolcvanötbillió/ĎŇŐAUÚQbci	ötbillióan	öt||billió
+nyolcvanötbilliárd/mÖKkUÚQbci	öt||billiárd
 nyolcvanöt/ÝWŰMRbhc	ötödiköten
 nyolcvanóránként
 nyolcvanórai
 nyolcvanévi
 nyolcvanévente
 nyolcvanévenként
+nyolcvanvalahánymillió/ĎŇŐAUÚQbcj	ány||millió
+nyolcvanvalahánymilliárd/mÖKkUÚQbci	ány||milliárd
+nyolcvanvalahányfeléány||felé
+nyolcvanvalahányezres/×BŐVb)ányezer	ány||ezres
+nyolcvanvalahányezren/b)ányezer	ány||ezren
+nyolcvanvalahányezer/ŐnBVÜjbc	ányezresányezren	ány||ezer
 nyolcvanvalahányan/bh))ány
 nyolcvanvalahányan/bh)
 nyolcvanvalahányadikak/nI))ány
@@ -19054,42 +19080,42 @@ nyolcvantrillióan/b)ó
 nyolcvantrillió/ĎŇŐAUÚQbci	óan
 nyolcvantrilliárd/mÖKkUÚQbci
 nyolcvanpercenként
-nyolcvannégytrillióan/b)égytrillió
-nyolcvannégytrillió/ĎŇŐAUÚQbci	égytrillióan
-nyolcvannégytrilliárd/mÖKkUÚQbci
-nyolcvannégymillióan/b)égymillió
-nyolcvannégymillió/ĎŇŐAUÚQbcj	égymillióan
-nyolcvannégymilliárdan/b)égymilliárd
-nyolcvannégymilliárd/mÖKkUÚQbci	égymilliárdan
-nyolcvannégyfelé
-nyolcvannégyezres/×BŐVb)égyezer
-nyolcvannégyezren/b)égyezer
-nyolcvannégyezrek/Ib)égyezer
-nyolcvannégyezredik/nÓ×BVÜb)égyezer
-nyolcvannégyezred/BVÜb)égyezer
-nyolcvannégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred
+nyolcvannégytrillióan/b)égytrillió	égy||trillióan
+nyolcvannégytrillió/ĎŇŐAUÚQbci	égytrillióan	égy||trillió
+nyolcvannégytrilliárd/mÖKkUÚQbci	égy||trilliárd
+nyolcvannégymillióan/b)égymillió	égy||millióan
+nyolcvannégymillió/ĎŇŐAUÚQbcj	égymillióan	égy||millió
+nyolcvannégymilliárdan/b)égymilliárd	égy||milliárdan
+nyolcvannégymilliárd/mÖKkUÚQbci	égymilliárdan	égy||milliárd
+nyolcvannégyfeléégy||felé
+nyolcvannégyezres/×BŐVb)égyezer	égy||ezres
+nyolcvannégyezren/b)égyezer	égy||ezren
+nyolcvannégyezrek/Ib)égyezer	égy||ezrek
+nyolcvannégyezredik/nÓ×BVÜb)égyezer	égy||ezredik
+nyolcvannégyezred/BVÜb)égyezer	égy||ezred
+nyolcvannégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred	égy||ezer
 nyolcvannégyen/bh)égy
-nyolcvannégybillióan/b)égybillió
-nyolcvannégybillió/ĎŇŐAUÚQbci	égybillióan
-nyolcvannégybilliárd/mÖKkUÚQbci
+nyolcvannégybillióan/b)égybillió	égy||billióan
+nyolcvannégybillió/ĎŇŐAUÚQbci	égybillióan	égy||billió
+nyolcvannégybilliárd/mÖKkUÚQbci	égy||billiárd
 nyolcvannégy/nVÜLlTtbhc	égyen
-nyolcvannyolctrillióan/b)ó
-nyolcvannyolctrillió/ĎŇŐAUÚQbci	óan
-nyolcvannyolctrilliárd/mÖKkUÚQbci
-nyolcvannyolcmillióan/b)ó
-nyolcvannyolcmillió/ĎŇŐAUÚQbcj	óan
-nyolcvannyolcmilliárdan/b)árd
-nyolcvannyolcmilliárd/mÖKkUÚQbci	árdan
-nyolcvannyolcfelé
+nyolcvannyolctrillióan/b)ó	óan
+nyolcvannyolctrillió/ĎŇŐAUÚQbci	óan	ó
+nyolcvannyolctrilliárd/mÖKkUÚQbci	árd
+nyolcvannyolcmillióan/b)ó	óan
+nyolcvannyolcmillió/ĎŇŐAUÚQbcj	óan	ó
+nyolcvannyolcmilliárdan/b)árd	árdan
+nyolcvannyolcmilliárd/mÖKkUÚQbci	árdan	árd
+nyolcvannyolcfeléé
 nyolcvannyolcezres/×BŐVb)
 nyolcvannyolcezren/b)
 nyolcvannyolcezrek/Ib)
 nyolcvannyolcezredik/nÓ×BVÜb)
 nyolcvannyolcezred/BVÜb)
 nyolcvannyolcezer/ŐnBVÜjbc
-nyolcvannyolcbillióan/b)ó
-nyolcvannyolcbillió/ĎŇŐAUÚQbci	óan
-nyolcvannyolcbilliárd/mÖKkUÚQbci
+nyolcvannyolcbillióan/b)ó	óan
+nyolcvannyolcbillió/ĎŇŐAUÚQbci	óan	ó
+nyolcvannyolcbilliárd/mÖKkUÚQbci	árd
 nyolcvannyolcan/bh)
 nyolcvannyolcadikak/nI)
 nyolcvannyolcadik/!AUÖmŇŮKkbh)
@@ -19101,32 +19127,32 @@ nyolcvanmillióan/b)ó
 nyolcvanmillió/ĎŇŐAUÚQbcj	óan
 nyolcvanmilliárdan/b)árd
 nyolcvanmilliárd/mÖKkUÚQbci	árdan
-nyolcvankéttrillióan/b)éttrillió
-nyolcvankéttrillió/ĎŇŐAUÚQbci	éttrillióan
-nyolcvankéttrilliárd/mÖKkUÚQbci
-nyolcvankétmillióan/b)étmillió
-nyolcvankétmillió/ĎŇŐAUÚQbcj	étmillióan
-nyolcvankétmilliárdan/b)étmilliárd
-nyolcvankétmilliárd/mÖKkUÚQbci	étmilliárdan
-nyolcvankétfelé
-nyolcvankétezres/×BŐVb)étezer
-nyolcvankétezren/b)étezer
-nyolcvankétezrek/Ib)étezer
-nyolcvankétezredik/nÓ×BVÜb)étezer
-nyolcvankétezred/BVÜb)étezer
-nyolcvankétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-nyolcvankétbillióan/b)étbillió
-nyolcvankétbillió/ĎŇŐAUÚQbci	étbillióan
-nyolcvankétbilliárd/mÖKkUÚQbci
+nyolcvankéttrillióan/b)éttrillió	ét||trillióan
+nyolcvankéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+nyolcvankéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+nyolcvankétmillióan/b)étmillió	ét||millióan
+nyolcvankétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+nyolcvankétmilliárdan/b)étmilliárd	ét||milliárdan
+nyolcvankétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+nyolcvankétfeléét||felé
+nyolcvankétezres/×BŐVb)étezer	ét||ezres
+nyolcvankétezren/b)étezer	ét||ezren
+nyolcvankétezrek/Ib)étezer	ét||ezrek
+nyolcvankétezredik/nÓ×BVÜb)étezer	ét||ezredik
+nyolcvankétezred/BVÜb)étezer	ét||ezred
+nyolcvankétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+nyolcvankétbillióan/b)étbillió	ét||billióan
+nyolcvankétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+nyolcvankétbilliárd/mÖKkUÚQbci	ét||billiárd
 nyolcvankét/bÜhc
-nyolcvankilenctrillióan/b)ó
-nyolcvankilenctrillió/ĎŇŐAUÚQbci	óan
-nyolcvankilenctrilliárd/mÖKkUÚQbci
-nyolcvankilencmillióan/b)ó
-nyolcvankilencmillió/ĎŇŐAUÚQbcj	óan
-nyolcvankilencmilliárdan/b)árd
-nyolcvankilencmilliárd/mÖKkUÚQbci	árdan
-nyolcvankilencfelé
+nyolcvankilenctrillióan/b)ó	óan
+nyolcvankilenctrillió/ĎŇŐAUÚQbci	óan	ó
+nyolcvankilenctrilliárd/mÖKkUÚQbci	árd
+nyolcvankilencmillióan/b)ó	óan
+nyolcvankilencmillió/ĎŇŐAUÚQbcj	óan	ó
+nyolcvankilencmilliárdan/b)árd	árdan
+nyolcvankilencmilliárd/mÖKkUÚQbci	árdan	árd
+nyolcvankilencfeléé
 nyolcvankilencezres/×BŐVb)
 nyolcvankilencezren/b)
 nyolcvankilencezrek/Ib)
@@ -19135,65 +19161,65 @@ nyolcvankilencezred/BVÜb)
 nyolcvankilencezer/ŐnBVÜjbc
 nyolcvankilencen/bh)
 nyolcvankilencedik/!VÓn×Llbh)
-nyolcvankilencbillióan/b)ó
-nyolcvankilencbillió/ĎŇŐAUÚQbci	óan
-nyolcvankilencbilliárd/mÖKkUÚQbci
+nyolcvankilencbillióan/b)ó	óan
+nyolcvankilencbillió/ĎŇŐAUÚQbci	óan	ó
+nyolcvankilencbilliárd/mÖKkUÚQbci	árd
 nyolcvankilenc/nňVÜLlTtbhc
-nyolcvankettőtrillióan/b)őtrillió
-nyolcvankettőtrillió/ĎŇŐAUÚQbci	őtrillióan
-nyolcvankettőtrilliárd/mÖKkUÚQbci
-nyolcvankettőmillióan/b)őmillió
-nyolcvankettőmillió/ĎŇŐAUÚQbcj	őmillióan
-nyolcvankettőmilliárdan/b)őmilliárd
-nyolcvankettőmilliárd/mÖKkUÚQbci	őmilliárdan
-nyolcvankettőfelé
-nyolcvankettőezres/×BŐVb)őezer
-nyolcvankettőezren/b)őezer
-nyolcvankettőezrek/Ib)őezer
-nyolcvankettőezredik/nÓ×BVÜb)őezer
-nyolcvankettőezred/BVÜb)őezer
-nyolcvankettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred
-nyolcvankettőbillióan/b)őbillió
-nyolcvankettőbillió/ĎŇŐAUÚQbci	őbillióan
-nyolcvankettőbilliárd/mÖKkUÚQbci
+nyolcvankettőtrillióan/b)őtrillió	ő||trillióan
+nyolcvankettőtrillió/ĎŇŐAUÚQbci	őtrillióan	ő||trillió
+nyolcvankettőtrilliárd/mÖKkUÚQbci	ő||trilliárd
+nyolcvankettőmillióan/b)őmillió	ő||millióan
+nyolcvankettőmillió/ĎŇŐAUÚQbcj	őmillióan	ő||millió
+nyolcvankettőmilliárdan/b)őmilliárd	ő||milliárdan
+nyolcvankettőmilliárd/mÖKkUÚQbci	őmilliárdan	ő||milliárd
+nyolcvankettőfeléő||felé
+nyolcvankettőezres/×BŐVb)őezer	ő||ezres
+nyolcvankettőezren/b)őezer	ő||ezren
+nyolcvankettőezrek/Ib)őezer	ő||ezrek
+nyolcvankettőezredik/nÓ×BVÜb)őezer	ő||ezredik
+nyolcvankettőezred/BVÜb)őezer	ő||ezred
+nyolcvankettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred	ő||ezer
+nyolcvankettőbillióan/b)őbillió	ő||billióan
+nyolcvankettőbillió/ĎŇŐAUÚQbci	őbillióan	ő||billió
+nyolcvankettőbilliárd/mÖKkUÚQbci	ő||billiárd
 nyolcvankettő/ŢWŰMRbhc
 nyolcvanketten/bh)ő
 nyolcvankettedik/!VÓn×Llbh)ő
-nyolcvanhéttrillióan/b)éttrillió
-nyolcvanhéttrillió/ĎŇŐAUÚQbci	éttrillióan
-nyolcvanhéttrilliárd/mÖKkUÚQbci
-nyolcvanhétmillióan/b)étmillió
-nyolcvanhétmillió/ĎŇŐAUÚQbcj	étmillióan
-nyolcvanhétmilliárdan/b)étmilliárd
-nyolcvanhétmilliárd/mÖKkUÚQbci	étmilliárdan
-nyolcvanhétfelé
-nyolcvanhétezres/×BŐVb)étezer
-nyolcvanhétezren/b)étezer
-nyolcvanhétezrek/Ib)étezer
-nyolcvanhétezredik/nÓ×BVÜb)étezer
-nyolcvanhétezred/BVÜb)étezer
-nyolcvanhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-nyolcvanhétbillióan/b)étbillió
-nyolcvanhétbillió/ĎŇŐAUÚQbci	étbillióan
-nyolcvanhétbilliárd/mÖKkUÚQbci
+nyolcvanhéttrillióan/b)éttrillió	ét||trillióan
+nyolcvanhéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+nyolcvanhéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+nyolcvanhétmillióan/b)étmillió	ét||millióan
+nyolcvanhétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+nyolcvanhétmilliárdan/b)étmilliárd	ét||milliárdan
+nyolcvanhétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+nyolcvanhétfeléét||felé
+nyolcvanhétezres/×BŐVb)étezer	ét||ezres
+nyolcvanhétezren/b)étezer	ét||ezren
+nyolcvanhétezrek/Ib)étezer	ét||ezrek
+nyolcvanhétezredik/nÓ×BVÜb)étezer	ét||ezredik
+nyolcvanhétezred/BVÜb)étezer	ét||ezred
+nyolcvanhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+nyolcvanhétbillióan/b)étbillió	ét||billióan
+nyolcvanhétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+nyolcvanhétbilliárd/mÖKkUÚQbci	ét||billiárd
 nyolcvanhét/nVÜbhc
-nyolcvanháromtrillióan/b)áromtrillió
-nyolcvanháromtrillió/ĎŇŐAUÚQbci	áromtrillióan
-nyolcvanháromtrilliárd/mÖKkUÚQbci
-nyolcvanhárommillióan/b)árommillió
-nyolcvanhárommillió/ĎŇŐAUÚQbcj	árommillióan
-nyolcvanhárommilliárdan/b)árommilliárd
-nyolcvanhárommilliárd/mÖKkUÚQbci	árommilliárdan
-nyolcvanháromfelé
-nyolcvanháromezres/×BŐVb)áromezer
-nyolcvanháromezren/b)áromezer
-nyolcvanháromezrek/Ib)áromezer
-nyolcvanháromezredik/nÓ×BVÜb)áromezer
-nyolcvanháromezred/BVÜb)áromezer
-nyolcvanháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred
-nyolcvanhárombillióan/b)árombillió
-nyolcvanhárombillió/ĎŇŐAUÚQbci	árombillióan
-nyolcvanhárombilliárd/mÖKkUÚQbci
+nyolcvanháromtrillióan/b)áromtrillió	árom||trillióan
+nyolcvanháromtrillió/ĎŇŐAUÚQbci	áromtrillióan	árom||trillió
+nyolcvanháromtrilliárd/mÖKkUÚQbci	árom||trilliárd
+nyolcvanhárommillióan/b)árommillió	árom||millióan
+nyolcvanhárommillió/ĎŇŐAUÚQbcj	árommillióan	árom||millió
+nyolcvanhárommilliárdan/b)árommilliárd	árom||milliárdan
+nyolcvanhárommilliárd/mÖKkUÚQbci	árommilliárdan	árom||milliárd
+nyolcvanháromfeléárom||felé
+nyolcvanháromezres/×BŐVb)áromezer	árom||ezres
+nyolcvanháromezren/b)áromezer	árom||ezren
+nyolcvanháromezrek/Ib)áromezer	árom||ezrek
+nyolcvanháromezredik/nÓ×BVÜb)áromezer	árom||ezredik
+nyolcvanháromezred/BVÜb)áromezer	árom||ezred
+nyolcvanháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred	árom||ezer
+nyolcvanhárombillióan/b)árombillió	árom||billióan
+nyolcvanhárombillió/ĎŇŐAUÚQbci	árombillióan	árom||billió
+nyolcvanhárombilliárd/mÖKkUÚQbci	árom||billiárd
 nyolcvanhárom/mUÚbhc	ármanármak
 nyolcvanhárman/bh)árom
 nyolcvanhármak/Ibh)árom
@@ -19206,25 +19232,25 @@ nyolcvanhetedik/!VÓn×Llbh)ét
 nyolcvanhavonta
 nyolcvanhavonként
 nyolcvanhavi
-nyolcvanhattrillióan/b)ó
-nyolcvanhattrillió/ĎŇŐAUÚQbci	óan
-nyolcvanhattrilliárd/mÖKkUÚQbci
+nyolcvanhattrillióan/b)ó	óan
+nyolcvanhattrillió/ĎŇŐAUÚQbci	óan	ó
+nyolcvanhattrilliárd/mÖKkUÚQbci	árd
 nyolcvanhatodikak/nI)
 nyolcvanhatodik/!AUÖmŇŮKkbh)
-nyolcvanhatmillióan/b)ó
-nyolcvanhatmillió/ĎŇŐAUÚQbcj	óan
-nyolcvanhatmilliárdan/b)árd
-nyolcvanhatmilliárd/mÖKkUÚQbci	árdan
-nyolcvanhatfelé
+nyolcvanhatmillióan/b)ó	óan
+nyolcvanhatmillió/ĎŇŐAUÚQbcj	óan	ó
+nyolcvanhatmilliárdan/b)árd	árdan
+nyolcvanhatmilliárd/mÖKkUÚQbci	árdan	árd
+nyolcvanhatfeléé
 nyolcvanhatezres/×BŐVb)
 nyolcvanhatezren/b)
 nyolcvanhatezrek/Ib)
 nyolcvanhatezredik/nÓ×BVÜb)
 nyolcvanhatezred/BVÜb)
 nyolcvanhatezer/ŐnBVÜjbc
-nyolcvanhatbillióan/b)ó
-nyolcvanhatbillió/ĎŇŐAUÚQbci	óan
-nyolcvanhatbilliárd/mÖKkUÚQbci
+nyolcvanhatbillióan/b)ó	óan
+nyolcvanhatbillió/ĎŇŐAUÚQbci	óan	ó
+nyolcvanhatbilliárd/mÖKkUÚQbci	árd
 nyolcvanhatan/bh)
 nyolcvanhat/mUÚKkbhc
 nyolcvanharmadikak/nI)árom
@@ -19238,14 +19264,14 @@ nyolcvanezred/BVÜb)
 nyolcvanezer/ŐnBVÜjbc
 nyolcvanesztendőnként
 nyolcvanesztendei
-nyolcvanegytrillióan/b)ó
-nyolcvanegytrillió/ĎŇŐAUÚQbci	óan
-nyolcvanegytrilliárd/mÖKkUÚQbci
-nyolcvanegymillióan/b)ó
-nyolcvanegymillió/ĎŇŐAUÚQbcj	óan
-nyolcvanegymilliárdan/b)árd
-nyolcvanegymilliárd/mÖKkUÚQbci	árdan
-nyolcvanegyfelé
+nyolcvanegytrillióan/b)ó	óan
+nyolcvanegytrillió/ĎŇŐAUÚQbci	óan	ó
+nyolcvanegytrilliárd/mÖKkUÚQbci	árd
+nyolcvanegymillióan/b)ó	óan
+nyolcvanegymillió/ĎŇŐAUÚQbcj	óan	ó
+nyolcvanegymilliárdan/b)árd	árdan
+nyolcvanegymilliárd/mÖKkUÚQbci	árdan	árd
+nyolcvanegyfeléé
 nyolcvanegyezres/×BŐVb)
 nyolcvanegyezren/b)
 nyolcvanegyezrek/Ib)
@@ -19254,9 +19280,9 @@ nyolcvanegyezred/BVÜb)
 nyolcvanegyezer/ŐnBVÜjbc
 nyolcvanegyen/bh)
 nyolcvanegyedik/VÓn×Llbh)
-nyolcvanegybillióan/b)ó
-nyolcvanegybillió/ĎŇŐAUÚQbci	óan
-nyolcvanegybilliárd/mÖKkUÚQbci
+nyolcvanegybillióan/b)ó	óan
+nyolcvanegybillió/ĎŇŐAUÚQbci	óan	ó
+nyolcvanegybilliárd/mÖKkUÚQbci	árd
 nyolcvanegy/nVÜLlbhc
 nyolcvanbillióan/b)ó
 nyolcvanbillió/ĎŇŐAUÚQbci	óan
@@ -19264,7 +19290,6 @@ nyolcvanbilliárd/mÖKkUÚQbci
 nyolcvanas/UĘŽiÖKŇmôáç˛ĂăSscˇťkADFabh
 nyolcvanas/UĘŽiÖKŇmôáç˛ĂăSscˇťkADFabh
 nyolcvanan/bh)
-nyolcvanakfelé
 nyolcvanadszorra/bh)
 nyolcvanadszori/bh
 nyolcvanadszor
@@ -19279,14 +19304,14 @@ nyolctrillióan/b)ó
 nyolctrillió/ĎŇŐAUÚQbci	óan
 nyolctrilliárd/mÖKkUÚQbci
 nyolcszög/VNËŻj×LÝňÔéyČŔŕTtYcźög
-nyolcszázfelé
-nyolcszázezres/×BŐV
-nyolcszázezrek/I)ázezer
-nyolcszázas/AFUÚ)áz
-nyolcszázan/)áz
-nyolcszázadik/mŇŮAUÚ)áz
-nyolcszázad/AUÚ)áz
-nyolcszáz/$UŮÖmŇSscÚ	ázasázanázadikázadázasázadikázad
+nyolcszázfeléáz||felé
+nyolcszázezres/×BŐV	áz||ezres
+nyolcszázezrek/I)ázezer	áz||ezrek
+nyolcszázas/AFUÚ)áz	ázas
+nyolcszázan/)ázázan
+nyolcszázadik/mŇŮAUÚ)áz	ázadik
+nyolcszázad/AUÚ)áz	ázad
+nyolcszáz/$UŮÖmŇSscÚ	ázasázanázadikázad	áz
 nyolcpercenként
 nyolcnaponta
 nyolcnaponként
@@ -19307,7 +19332,7 @@ nyolcezrek/Iba)
 nyolcezrek/Iba)
 nyolcezredik/nÓ×BVÜb)
 nyolcezred/BVÜb)
-nyolcezerfelé
+nyolcezerfeléé
 nyolcezer/ŐnBVÜjbcÓ×LlTts
 nyolcesztendőnként
 nyolcesztendei
@@ -19330,18 +19355,18 @@ nyolcadiki/AUŇŐĎľ)
 nyolcadikak/nI)
 nyolcadika/AUŇŐĎľ)
 nyolcadik/c!AUÖmŇŮKkabh)
-nyolcadféltrillió/AUŐĎŇKQxcˇĂżÇ
-nyolcadfélszázad/AUÖmŇKkQcˇĂżÇ
-nyolcadfélszáz/$UŮÖmŇSscÇ
-nyolcadfélmillió/AUŐĎŇKQxcˇĂżÇ
-nyolcadfélmilliárd/AUÖmŇKkQcˇĂżÇ
-nyolcadfélezer/VÓn×LlTtcČ
-nyolcadfélbillió/AUŐĎŇKQxcˇĂżÇ
+nyolcadféltrillió/AUŐĎŇKQxcˇĂżÇ	él||trillió
+nyolcadfélszázad/AUÖmŇKkQcˇĂżÇ	él||század
+nyolcadfélszáz/$UŮÖmŇSscÇ	él||száz
+nyolcadfélmillió/AUŐĎŇKQxcˇĂżÇ	él||millió
+nyolcadfélmilliárd/AUÖmŇKkQcˇĂżÇ	él||milliárd
+nyolcadfélezer/VÓn×LlTtcČ	él||ezer
+nyolcadfélbillió/AUŐĎŇKQxcˇĂżÇ	él||billió
 nyolcadfél/VÓnňyjYcČ)él	él
 nyolcadannyian
 nyolcadannyi/UŐĎŇ
 nyolcad/AĂUÖmŇKkQiSsabhz!)
-nyolc-kilencmillió/ĎŇŐAUÚQbcw
+nyolc-kilencmillió/ĎŇŐAUÚQbcw	ó
 nyolc/môA$UÚSsbhcŮÖŇa
 nyivákol
 nyitó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -19413,7 +19438,7 @@ nyersalumínium/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nyersacél/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 nyerges/VËŻj×LÓnňéčłÄäTtYc¸źl
 nyereségrészesedés/VËŻj×LÓnňéyČŔŕTtYcź
-nyereségkimutatás/UĘŽiÖKŇmôáyÇżßSsYcť
+nyereségkimutatás/UĘŽiÖKŇmôáyÇżßSsYcťég||ki|mutatás
 nyereséghajhász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nyereségelosztás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nyereség/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -19492,7 +19517,7 @@ nyakmerevség/VËŻj×LÓnňéyČŔŕTtYcź
 nyakló/ŐAUQĘŽiĎŇáyÇżßYcť
 nyaklánc/UĘŽiÖKŇmôáyÇżßSsYcť
 nyakleves/VËŻj×LÓnňéyČŔŕTtYcź
-nyakkendőtű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+nyakkendőtű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő||tű
 nyakkendő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 nyakfodor/UmôyiYcŽ
 nyakbőség/VËŻj×LÓnňéyČŔŕTtYcź
@@ -19633,7 +19658,7 @@ nominálbér/VËŻj×LÓnňéčłÄäTtYc¸źl
 nominatívusz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nominativus/UĘŽiÖKŇmöáç˛ĂăSsYcˇťk
 nominalizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-nomenklatúra/ŐAUQĘŽiĎŇáyÇżßYcť
+nomenklatúra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 nomen_est
 nomadizálás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nokedli/ŐAUBVLQRĘŽËŻijĎĐÓáéçč˛łÄäĂăYcˇť¸ź
@@ -19763,10 +19788,10 @@ netkód/UĘŽiÖKŇmôáyÇżßQYcť
 netkávézó/ŐAUQĘŽiĎŇáyÇżßYcť
 netkapcsolat/UĘŽiÖKŇmôáyÇżßSsYcť
 netikett/VËŻj×LÓnňéčłÄäRYc¸źl
-nethozzáférés/VËŻj×LÓnňéyČŔŕTtYcź
+nethozzáférés/VËŻj×LÓnňéyČŔŕTtYcźá|férés
 nethasználó/ŐAUQĘŽiĎŇáyÇżßYcť
 nethasználat/UĘŽiÖKŇmôáyÇżßSsYcť
-netfelhasználó/ŐAUQĘŽiĎŇáyÇżßYcť
+netfelhasználó/ŐAUQĘŽiĎŇáyÇżßYcťáló
 netbook/UĘŽiÖKŇmôáç˛ĂăQYcˇťk	ph:netbuk	ph:netbúk
 netbank/UĘŽiÖKŇmôáyÇżßQYcť
 net/VËŻj×LÓnňéčÄäRTtc¸ź
@@ -19819,7 +19844,7 @@ nemzet/VËŻj×LÓnňéčłÄäTtYc¸źl
 nemzedék/VËŻj×LÓnňéčłÄäTtYc¸źl
 nemváltó/ŐAUQĘŽiĎŇáyÇżßYcť
 nemváltás/UĘŽiÖKŇmôáyÇżßSsYcť
-nemvasfém/VËŻj×LÓnňéyČŔŕRYcź
+nemvasfém/VËŻj×LÓnňéyČŔŕRYcźém
 nemulass/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nemtő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 nemtetszés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -19834,7 +19859,7 @@ nemrégiben
 nemrégen
 nemrég
 nemritkán
-nemnemesfém/VËŻj×LÓnňéyČŔŕRYcź
+nemnemesfém/VËŻj×LÓnňéyČŔŕRYcźém
 nemlétezés/VËŻj×LÓnňéyČŔŕTtYcź
 nemlét/VËŻj×LÓnňéyČŔŕTtYcź
 nemlinearitás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -19852,7 +19877,7 @@ nemezis/VËŻj×LÓnňéčłÄäTtYc¸źl
 nemez/VËŻj×LÓnňéčłÄäTtYc¸źl
 nemesül
 nemesérc/VËŻj×LÓnňéčłÄäTtYc¸źl
-nemesszívűség/VËŻj×LÓnňéyČŔŕTtYcźí-vű-ség
+nemesszívűség/VËŻj×LÓnňéyČŔŕTtYcźí-vű-ségívűség
 nemespenész/wYVËŻj×LÓnňéčłÄäTtc¸źl
 nemesopál/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 nemeslevél/VÓnňyjYcČ
@@ -19892,7 +19917,7 @@ nehézásvány/UĘŽiÖKŇmôáyÇżßSsYcť
 nehézágyú/ŐAUQĘŽiĎŇáyÇżßYcť
 nehézvíz/VÓnňyjYcČ	ézvizek
 nehézvállú/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-nehézvegyipar/UĘŽiÖKŇmôáyÇżßSsYcť
+nehézvegyipar/UĘŽiÖKŇmôáyÇżßSsYcťéz||vegy|ipar
 nehéztüzérség/VËŻj×LÓnňéyČŔŕTtYcź
 nehézsúly/UĘŽiÖKŇmôáyÇżßSsYcťéz|súly
 nehézség/VËŻj×LÓnňéčłÄäTtYc¸źléz-ség
@@ -19904,10 +19929,10 @@ nehézlovas/UĘŽiÖKŇmôáyÇżßSsYcť
 nehézipar/UĘŽiÖKŇmôáyÇżßSsYcť
 nehézion/UĘŽiÖKŇmôáyÇżßQvcť
 nehézhidrogén/VËŻj×LÓnňéčłÄäRvc¸źl
-nehézgépszállítás/UĘŽiÖKŇmôáyÇżßSsYcť
+nehézgépszállítás/UĘŽiÖKŇmôáyÇżßSsYcťéz|gép||szállítás
 nehézgéppuska/ŐAUQĘŽiĎŇáç˛Ăăcˇťw
-nehézgépjármű/WŢŘÔyjYcČ	ézgépjárművek
-nehézgépipar/UĘŽiÖKŇmôáyÇżßSsYcť
+nehézgépjármű/WŢŘÔyjYcČ	ézgépjárművekéz||gép|jármű
+nehézgépipar/UĘŽiÖKŇmôáyÇżßSsYcťéz||gép|ipar
 nehézgép/VËŻj×LÓnňéyČŔŕRTtYcź
 nehézfém/VËŻj×LÓnňéyČŔŕTtYcź
 nehézfiú/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -19931,30 +19956,36 @@ nehezebben/D)éz
 nehezebb/×nÓBDLVR)éz
 negáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 negyvenötödik/!VÓn×Llbh)öt
-negyvenöttrillióan/b)öttrillió
-negyvenöttrillió/ĎŇŐAUÚQbci	öttrillióan
-negyvenöttrilliárd/mÖKkUÚQbci
-negyvenötmillióan/b)ötmillió
-negyvenötmillió/ĎŇŐAUÚQbcj	ötmillióan
-negyvenötmilliárdan/b)ötmilliárd
-negyvenötmilliárd/mÖKkUÚQbci	ötmilliárdan
-negyvenötfelé
-negyvenötezres/×BŐVb)ötezer
-negyvenötezren/b)ötezer
-negyvenötezrek/Ib)ötezer
-negyvenötezredik/nÓ×BVÜb)ötezer
-negyvenötezred/BVÜb)ötezer
-negyvenötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred
+negyvenöttrillióan/b)öttrillió	öt||trillióan
+negyvenöttrillió/ĎŇŐAUÚQbci	öttrillióan	öt||trillió
+negyvenöttrilliárd/mÖKkUÚQbci	öt||trilliárd
+negyvenötmillióan/b)ötmillió	öt||millióan
+negyvenötmillió/ĎŇŐAUÚQbcj	ötmillióan	öt||millió
+negyvenötmilliárdan/b)ötmilliárd	öt||milliárdan
+negyvenötmilliárd/mÖKkUÚQbci	ötmilliárdan	öt||milliárd
+negyvenötfeléöt||felé
+negyvenötezres/×BŐVb)ötezer	öt||ezres
+negyvenötezren/b)ötezer	öt||ezren
+negyvenötezrek/Ib)ötezer	öt||ezrek
+negyvenötezredik/nÓ×BVÜb)ötezer	öt||ezredik
+negyvenötezred/BVÜb)ötezer	öt||ezred
+negyvenötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred	öt||ezer
 negyvenöten/bh)öt
-negyvenötbillióan/b)ötbillió
-negyvenötbillió/ĎŇŐAUÚQbci	ötbillióan
-negyvenötbilliárd/mÖKkUÚQbci
+negyvenötbillióan/b)ötbillió	öt||billióan
+negyvenötbillió/ĎŇŐAUÚQbci	ötbillióan	öt||billió
+negyvenötbilliárd/mÖKkUÚQbci	öt||billiárd
 negyvenöt/ÝWŰMRbhc	ötödiköten
 negyvenóránként
 negyvenórai
 negyvenévi
 negyvenévente
 negyvenévenként
+negyvenvalahánymillió/ĎŇŐAUÚQbcj	ány||millió
+negyvenvalahánymilliárd/mÖKkUÚQbci	ány||milliárd
+negyvenvalahányfeléány||felé
+negyvenvalahányezres/×BŐVb)ányezer	ány||ezres
+negyvenvalahányezren/b)ányezer	ány||ezren
+negyvenvalahányezer/ŐnBVÜjbc	ányezresányezren	ány||ezer
 negyvenvalahányan/bh))ány
 negyvenvalahányan/bh)
 negyvenvalahányadikak/nI))ány
@@ -19965,42 +19996,42 @@ negyventrillióan/b)ó
 negyventrillió/ĎŇŐAUÚQbci	óan
 negyventrilliárd/mÖKkUÚQbci
 negyvenpercenként
-negyvennégytrillióan/b)égytrillió
-negyvennégytrillió/ĎŇŐAUÚQbci	égytrillióan
-negyvennégytrilliárd/mÖKkUÚQbci
-negyvennégymillióan/b)égymillió
-negyvennégymillió/ĎŇŐAUÚQbcj	égymillióan
-negyvennégymilliárdan/b)égymilliárd
-negyvennégymilliárd/mÖKkUÚQbci	égymilliárdan
-negyvennégyfelé
-negyvennégyezres/×BŐVb)égyezer
-negyvennégyezren/b)égyezer
-negyvennégyezrek/Ib)égyezer
-negyvennégyezredik/nÓ×BVÜb)égyezer
-negyvennégyezred/BVÜb)égyezer
-negyvennégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred
+negyvennégytrillióan/b)égytrillió	égy||trillióan
+negyvennégytrillió/ĎŇŐAUÚQbci	égytrillióan	égy||trillió
+negyvennégytrilliárd/mÖKkUÚQbci	égy||trilliárd
+negyvennégymillióan/b)égymillió	égy||millióan
+negyvennégymillió/ĎŇŐAUÚQbcj	égymillióan	égy||millió
+negyvennégymilliárdan/b)égymilliárd	égy||milliárdan
+negyvennégymilliárd/mÖKkUÚQbci	égymilliárdan	égy||milliárd
+negyvennégyfeléégy||felé
+negyvennégyezres/×BŐVb)égyezer	égy||ezres
+negyvennégyezren/b)égyezer	égy||ezren
+negyvennégyezrek/Ib)égyezer	égy||ezrek
+negyvennégyezredik/nÓ×BVÜb)égyezer	égy||ezredik
+negyvennégyezred/BVÜb)égyezer	égy||ezred
+negyvennégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred	égy||ezer
 negyvennégyen/bh)égy
-negyvennégybillióan/b)égybillió
-negyvennégybillió/ĎŇŐAUÚQbci	égybillióan
-negyvennégybilliárd/mÖKkUÚQbci
+negyvennégybillióan/b)égybillió	égy||billióan
+negyvennégybillió/ĎŇŐAUÚQbci	égybillióan	égy||billió
+negyvennégybilliárd/mÖKkUÚQbci	égy||billiárd
 negyvennégy/nVÜLlTtbhc	égyen
-negyvennyolctrillióan/b)ó
-negyvennyolctrillió/ĎŇŐAUÚQbci	óan
-negyvennyolctrilliárd/mÖKkUÚQbci
-negyvennyolcmillióan/b)ó
-negyvennyolcmillió/ĎŇŐAUÚQbcj	óan
-negyvennyolcmilliárdan/b)árd
-negyvennyolcmilliárd/mÖKkUÚQbci	árdan
-negyvennyolcfelé
+negyvennyolctrillióan/b)ó	óan
+negyvennyolctrillió/ĎŇŐAUÚQbci	óan	ó
+negyvennyolctrilliárd/mÖKkUÚQbci	árd
+negyvennyolcmillióan/b)ó	óan
+negyvennyolcmillió/ĎŇŐAUÚQbcj	óan	ó
+negyvennyolcmilliárdan/b)árd	árdan
+negyvennyolcmilliárd/mÖKkUÚQbci	árdan	árd
+negyvennyolcfeléé
 negyvennyolcezres/×BŐVb)
 negyvennyolcezren/b)
 negyvennyolcezrek/Ib)
 negyvennyolcezredik/nÓ×BVÜb)
 negyvennyolcezred/BVÜb)
 negyvennyolcezer/ŐnBVÜjbc
-negyvennyolcbillióan/b)ó
-negyvennyolcbillió/ĎŇŐAUÚQbci	óan
-negyvennyolcbilliárd/mÖKkUÚQbci
+negyvennyolcbillióan/b)ó	óan
+negyvennyolcbillió/ĎŇŐAUÚQbci	óan	ó
+negyvennyolcbilliárd/mÖKkUÚQbci	árd
 negyvennyolcan/bh)
 negyvennyolcadikak/nI)
 negyvennyolcadik/!AUÖmŇŮKkbh)
@@ -20012,32 +20043,32 @@ negyvenmillióan/b)ó
 negyvenmillió/ĎŇŐAUÚQbcj	óan
 negyvenmilliárdan/b)árd
 negyvenmilliárd/mÖKkUÚQbci	árdan
-negyvenkéttrillióan/b)éttrillió
-negyvenkéttrillió/ĎŇŐAUÚQbci	éttrillióan
-negyvenkéttrilliárd/mÖKkUÚQbci
-negyvenkétmillióan/b)étmillió
-negyvenkétmillió/ĎŇŐAUÚQbcj	étmillióan
-negyvenkétmilliárdan/b)étmilliárd
-negyvenkétmilliárd/mÖKkUÚQbci	étmilliárdan
-negyvenkétfelé
-negyvenkétezres/×BŐVb)étezer
-negyvenkétezren/b)étezer
-negyvenkétezrek/Ib)étezer
-negyvenkétezredik/nÓ×BVÜb)étezer
-negyvenkétezred/BVÜb)étezer
-negyvenkétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-negyvenkétbillióan/b)étbillió
-negyvenkétbillió/ĎŇŐAUÚQbci	étbillióan
-negyvenkétbilliárd/mÖKkUÚQbci
+negyvenkéttrillióan/b)éttrillió	ét||trillióan
+negyvenkéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+negyvenkéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+negyvenkétmillióan/b)étmillió	ét||millióan
+negyvenkétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+negyvenkétmilliárdan/b)étmilliárd	ét||milliárdan
+negyvenkétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+negyvenkétfeléét||felé
+negyvenkétezres/×BŐVb)étezer	ét||ezres
+negyvenkétezren/b)étezer	ét||ezren
+negyvenkétezrek/Ib)étezer	ét||ezrek
+negyvenkétezredik/nÓ×BVÜb)étezer	ét||ezredik
+negyvenkétezred/BVÜb)étezer	ét||ezred
+negyvenkétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+negyvenkétbillióan/b)étbillió	ét||billióan
+negyvenkétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+negyvenkétbilliárd/mÖKkUÚQbci	ét||billiárd
 negyvenkét/bÜhc
-negyvenkilenctrillióan/b)ó
-negyvenkilenctrillió/ĎŇŐAUÚQbci	óan
-negyvenkilenctrilliárd/mÖKkUÚQbci
-negyvenkilencmillióan/b)ó
-negyvenkilencmillió/ĎŇŐAUÚQbcj	óan
-negyvenkilencmilliárdan/b)árd
-negyvenkilencmilliárd/mÖKkUÚQbci	árdan
-negyvenkilencfelé
+negyvenkilenctrillióan/b)ó	óan
+negyvenkilenctrillió/ĎŇŐAUÚQbci	óan	ó
+negyvenkilenctrilliárd/mÖKkUÚQbci	árd
+negyvenkilencmillióan/b)ó	óan
+negyvenkilencmillió/ĎŇŐAUÚQbcj	óan	ó
+negyvenkilencmilliárdan/b)árd	árdan
+negyvenkilencmilliárd/mÖKkUÚQbci	árdan	árd
+negyvenkilencfeléé
 negyvenkilencezres/×BŐVb)
 negyvenkilencezren/b)
 negyvenkilencezrek/Ib)
@@ -20046,65 +20077,65 @@ negyvenkilencezred/BVÜb)
 negyvenkilencezer/ŐnBVÜjbc
 negyvenkilencen/bh)
 negyvenkilencedik/!VÓn×Llbh)
-negyvenkilencbillióan/b)ó
-negyvenkilencbillió/ĎŇŐAUÚQbci	óan
-negyvenkilencbilliárd/mÖKkUÚQbci
+negyvenkilencbillióan/b)ó	óan
+negyvenkilencbillió/ĎŇŐAUÚQbci	óan	ó
+negyvenkilencbilliárd/mÖKkUÚQbci	árd
 negyvenkilenc/nňVÜLlTtbhc
-negyvenkettőtrillióan/b)őtrillió
-negyvenkettőtrillió/ĎŇŐAUÚQbci	őtrillióan
-negyvenkettőtrilliárd/mÖKkUÚQbci
-negyvenkettőmillióan/b)őmillió
-negyvenkettőmillió/ĎŇŐAUÚQbcj	őmillióan
-negyvenkettőmilliárdan/b)őmilliárd
-negyvenkettőmilliárd/mÖKkUÚQbci	őmilliárdan
-negyvenkettőfelé
-negyvenkettőezres/×BŐVb)őezer
-negyvenkettőezren/b)őezer
-negyvenkettőezrek/Ib)őezer
-negyvenkettőezredik/nÓ×BVÜb)őezer
-negyvenkettőezred/BVÜb)őezer
-negyvenkettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred
-negyvenkettőbillióan/b)őbillió
-negyvenkettőbillió/ĎŇŐAUÚQbci	őbillióan
-negyvenkettőbilliárd/mÖKkUÚQbci
+negyvenkettőtrillióan/b)őtrillió	ő||trillióan
+negyvenkettőtrillió/ĎŇŐAUÚQbci	őtrillióan	ő||trillió
+negyvenkettőtrilliárd/mÖKkUÚQbci	ő||trilliárd
+negyvenkettőmillióan/b)őmillió	ő||millióan
+negyvenkettőmillió/ĎŇŐAUÚQbcj	őmillióan	ő||millió
+negyvenkettőmilliárdan/b)őmilliárd	ő||milliárdan
+negyvenkettőmilliárd/mÖKkUÚQbci	őmilliárdan	ő||milliárd
+negyvenkettőfeléő||felé
+negyvenkettőezres/×BŐVb)őezer	ő||ezres
+negyvenkettőezren/b)őezer	ő||ezren
+negyvenkettőezrek/Ib)őezer	ő||ezrek
+negyvenkettőezredik/nÓ×BVÜb)őezer	ő||ezredik
+negyvenkettőezred/BVÜb)őezer	ő||ezred
+negyvenkettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred	ő||ezer
+negyvenkettőbillióan/b)őbillió	ő||billióan
+negyvenkettőbillió/ĎŇŐAUÚQbci	őbillióan	ő||billió
+negyvenkettőbilliárd/mÖKkUÚQbci	ő||billiárd
 negyvenkettő/ŢWŰMRbhc
 negyvenketten/bh)ő
 negyvenkettedik/!VÓn×Llbh)ő
-negyvenhéttrillióan/b)éttrillió
-negyvenhéttrillió/ĎŇŐAUÚQbci	éttrillióan
-negyvenhéttrilliárd/mÖKkUÚQbci
-negyvenhétmillióan/b)étmillió
-negyvenhétmillió/ĎŇŐAUÚQbcj	étmillióan
-negyvenhétmilliárdan/b)étmilliárd
-negyvenhétmilliárd/mÖKkUÚQbci	étmilliárdan
-negyvenhétfelé
-negyvenhétezres/×BŐVb)étezer
-negyvenhétezren/b)étezer
-negyvenhétezrek/Ib)étezer
-negyvenhétezredik/nÓ×BVÜb)étezer
-negyvenhétezred/BVÜb)étezer
-negyvenhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-negyvenhétbillióan/b)étbillió
-negyvenhétbillió/ĎŇŐAUÚQbci	étbillióan
-negyvenhétbilliárd/mÖKkUÚQbci
+negyvenhéttrillióan/b)éttrillió	ét||trillióan
+negyvenhéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+negyvenhéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+negyvenhétmillióan/b)étmillió	ét||millióan
+negyvenhétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+negyvenhétmilliárdan/b)étmilliárd	ét||milliárdan
+negyvenhétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+negyvenhétfeléét||felé
+negyvenhétezres/×BŐVb)étezer	ét||ezres
+negyvenhétezren/b)étezer	ét||ezren
+negyvenhétezrek/Ib)étezer	ét||ezrek
+negyvenhétezredik/nÓ×BVÜb)étezer	ét||ezredik
+negyvenhétezred/BVÜb)étezer	ét||ezred
+negyvenhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+negyvenhétbillióan/b)étbillió	ét||billióan
+negyvenhétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+negyvenhétbilliárd/mÖKkUÚQbci	ét||billiárd
 negyvenhét/nVÜbhc
-negyvenháromtrillióan/b)áromtrillió
-negyvenháromtrillió/ĎŇŐAUÚQbci	áromtrillióan
-negyvenháromtrilliárd/mÖKkUÚQbci
-negyvenhárommillióan/b)árommillió
-negyvenhárommillió/ĎŇŐAUÚQbcj	árommillióan
-negyvenhárommilliárdan/b)árommilliárd
-negyvenhárommilliárd/mÖKkUÚQbci	árommilliárdan
-negyvenháromfelé
-negyvenháromezres/×BŐVb)áromezer
-negyvenháromezren/b)áromezer
-negyvenháromezrek/Ib)áromezer
-negyvenháromezredik/nÓ×BVÜb)áromezer
-negyvenháromezred/BVÜb)áromezer
-negyvenháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred
-negyvenhárombillióan/b)árombillió
-negyvenhárombillió/ĎŇŐAUÚQbci	árombillióan
-negyvenhárombilliárd/mÖKkUÚQbci
+negyvenháromtrillióan/b)áromtrillió	árom||trillióan
+negyvenháromtrillió/ĎŇŐAUÚQbci	áromtrillióan	árom||trillió
+negyvenháromtrilliárd/mÖKkUÚQbci	árom||trilliárd
+negyvenhárommillióan/b)árommillió	árom||millióan
+negyvenhárommillió/ĎŇŐAUÚQbcj	árommillióan	árom||millió
+negyvenhárommilliárdan/b)árommilliárd	árom||milliárdan
+negyvenhárommilliárd/mÖKkUÚQbci	árommilliárdan	árom||milliárd
+negyvenháromfeléárom||felé
+negyvenháromezres/×BŐVb)áromezer	árom||ezres
+negyvenháromezren/b)áromezer	árom||ezren
+negyvenháromezrek/Ib)áromezer	árom||ezrek
+negyvenháromezredik/nÓ×BVÜb)áromezer	árom||ezredik
+negyvenháromezred/BVÜb)áromezer	árom||ezred
+negyvenháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred	árom||ezer
+negyvenhárombillióan/b)árombillió	árom||billióan
+negyvenhárombillió/ĎŇŐAUÚQbci	árombillióan	árom||billió
+negyvenhárombilliárd/mÖKkUÚQbci	árom||billiárd
 negyvenhárom/mUÚbhc	ármanármak
 negyvenhárman/bh)árom
 negyvenhármak/Ibh)árom
@@ -20117,25 +20148,25 @@ negyvenhetedik/!VÓn×Llbh)ét
 negyvenhavonta
 negyvenhavonként
 negyvenhavi
-negyvenhattrillióan/b)ó
-negyvenhattrillió/ĎŇŐAUÚQbci	óan
-negyvenhattrilliárd/mÖKkUÚQbci
+negyvenhattrillióan/b)ó	óan
+negyvenhattrillió/ĎŇŐAUÚQbci	óan	ó
+negyvenhattrilliárd/mÖKkUÚQbci	árd
 negyvenhatodikak/nI)
 negyvenhatodik/!AUÖmŇŮKkbh)
-negyvenhatmillióan/b)ó
-negyvenhatmillió/ĎŇŐAUÚQbcj	óan
-negyvenhatmilliárdan/b)árd
-negyvenhatmilliárd/mÖKkUÚQbci	árdan
-negyvenhatfelé
+negyvenhatmillióan/b)ó	óan
+negyvenhatmillió/ĎŇŐAUÚQbcj	óan	ó
+negyvenhatmilliárdan/b)árd	árdan
+negyvenhatmilliárd/mÖKkUÚQbci	árdan	árd
+negyvenhatfeléé
 negyvenhatezres/×BŐVb)
 negyvenhatezren/b)
 negyvenhatezrek/Ib)
 negyvenhatezredik/nÓ×BVÜb)
 negyvenhatezred/BVÜb)
 negyvenhatezer/ŐnBVÜjbc
-negyvenhatbillióan/b)ó
-negyvenhatbillió/ĎŇŐAUÚQbci	óan
-negyvenhatbilliárd/mÖKkUÚQbci
+negyvenhatbillióan/b)ó	óan
+negyvenhatbillió/ĎŇŐAUÚQbci	óan	ó
+negyvenhatbilliárd/mÖKkUÚQbci	árd
 negyvenhatan/bh)
 negyvenhat/mUÚKkbhc
 negyvenharmadikak/nI)árom
@@ -20151,14 +20182,14 @@ negyvenesztendőnként
 negyvenesztendei
 negyvenes/VÓnň×DGTtabh
 negyvenen/bh)
-negyvenegytrillióan/b)ó
-negyvenegytrillió/ĎŇŐAUÚQbci	óan
-negyvenegytrilliárd/mÖKkUÚQbci
-negyvenegymillióan/b)ó
-negyvenegymillió/ĎŇŐAUÚQbcj	óan
-negyvenegymilliárdan/b)árd
-negyvenegymilliárd/mÖKkUÚQbci	árdan
-negyvenegyfelé
+negyvenegytrillióan/b)ó	óan
+negyvenegytrillió/ĎŇŐAUÚQbci	óan	ó
+negyvenegytrilliárd/mÖKkUÚQbci	árd
+negyvenegymillióan/b)ó	óan
+negyvenegymillió/ĎŇŐAUÚQbcj	óan	ó
+negyvenegymilliárdan/b)árd	árdan
+negyvenegymilliárd/mÖKkUÚQbci	árdan	árd
+negyvenegyfeléé
 negyvenegyezres/×BŐVb)
 negyvenegyezren/b)
 negyvenegyezrek/Ib)
@@ -20167,9 +20198,9 @@ negyvenegyezred/BVÜb)
 negyvenegyezer/ŐnBVÜjbc
 negyvenegyen/bh)
 negyvenegyedik/VÓn×Llbh)
-negyvenegybillióan/b)ó
-negyvenegybillió/ĎŇŐAUÚQbci	óan
-negyvenegybilliárd/mÖKkUÚQbci
+negyvenegybillióan/b)ó	óan
+negyvenegybillió/ĎŇŐAUÚQbci	óan	ó
+negyvenegybilliárd/mÖKkUÚQbci	árd
 negyvenegy/nVÜLlbhc
 negyvenedszerre/bh)
 negyvenedszeri/bh
@@ -20213,17 +20244,17 @@ negyediki/BVÓŐĐś)égy
 negyedikes/VËŻj×LÓnňéčłÄäTtYc¸źl
 negyedike/BVÓŐĐś)égy
 negyedik/c!VÓn×Llabh)égy
-negyedidőszak/UĘŽiÖKŇmôáyÇżßQYcť
+negyedidőszak/UĘŽiÖKŇmôáyÇżßQYcťő|szak
 negyedheti
 negyedhavi
 negyedhang/UĘŽiÖKŇmôáyÇżßQYcť
-negyedféltrillió/AUŐĎŇKQxcˇĂżÇ
-negyedfélszázad/AUÖmŇKkQcˇĂżÇ
-negyedfélszáz/$UŮÖmŇSscÇ
-negyedfélmillió/AUŐĎŇKQxcˇĂżÇ
-negyedfélmilliárd/AUÖmŇKkQcˇĂżÇ
-negyedfélezer/VÓn×LlTtcČ
-negyedfélbillió/AUŐĎŇKQxcˇĂżÇ
+negyedféltrillió/AUŐĎŇKQxcˇĂżÇ	él||trillió
+negyedfélszázad/AUÖmŇKkQcˇĂżÇ	él||század
+negyedfélszáz/$UŮÖmŇSscÇ	él||száz
+negyedfélmillió/AUŐĎŇKQxcˇĂżÇ	él||millió
+negyedfélmilliárd/AUÖmŇKkQcˇĂżÇ	él||milliárd
+negyedfélezer/VÓn×LlTtcČ	él||ezer
+negyedfélbillió/AUŐĎŇKQxcˇĂżÇ	él||billió
 negyedfél/VÓnňyjYcČ)él	él
 negyedesztendőnként
 negyedesztendei
@@ -20251,7 +20282,7 @@ nedvesül
 nedvességmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 nedv/VËŻj×LÓnňéčłÄäTtYc¸ź
 necc/VËŻj×LÓnňéčłÄäTtYc¸ź
-nebáncsvirág/UĘŽiÖKŇmôáyÇżßQSsYcť
+nebáncsvirág/UĘŽiÖKŇmôáyÇżßQSsYcťáncs||virág
 nebuló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ne_adj''_isten	ph:neadjisten
 navigátor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -20266,6 +20297,7 @@ nature-ös/Ô×nCHWMR)	ph:nécs	ph:nécörös
 naturalizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nativitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 naszád/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+nassolnivaló/ŐAUQĘŽiĎŇáyÇżßYcť
 naspolya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 narvál/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 narrátor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -20286,7 +20318,7 @@ narancslekvár/UĘŽiÖKŇmôáyÇżßQYcť
 narancs/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 napóra/ŐAUQĘŽiĎŇáyÇżßYcť
 napév/VËŻj×LÓnňéyČŔŕTtYcź
-napéjegyenlőség/wYVËŻj×LÓnňéyČŔŕTtcź
+napéjegyenlőség/wYVËŻj×LÓnňéčłÄäTtc¸źl
 napégés/VËŻj×LÓnňéyČŔŕTtYcź
 napvirág/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 napvilág/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -20300,7 +20332,7 @@ napszúrás/UĘŽiÖKŇmôáyÇżßSsYcť
 napszámos/UĘŽiÖKŇmôáyÇżßSsYcť
 napszám/UĘŽiÖKŇmôáyÇżßSsYcť
 napszállta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-napszemüveg/VËŻj×LÓnňéyČŔŕRTtYcź
+napszemüveg/VËŻj×LÓnňéyČŔŕRTtYcźüveg
 napsugár/UmôŇyiYcÇ
 naprózsa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 napraforgó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -20337,9 +20369,9 @@ napibér/VËŻj×LÓnňéčłÄäTtYc¸źl
 naphosszat
 napfürdőzik
 napfürdő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-napfénykúra/ŐAUQĘŽiĎŇáyÇżßYcť
-napfényképező/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-napfényizzó/ŐAUQĘŽiĎŇáyÇżßYcť
+napfénykúra/ŐAUQĘŽiĎŇáyÇżßYcťény||kúra
+napfényképező/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ény|képező
+napfényizzó/ŐAUQĘŽiĎŇáyÇżßYcťény||izzó
 napfény/VËŻj×LÓnňéyČŔŕTtYcź
 napforduló/ŐAUQĘŽiĎŇáyÇżßYcť
 napfolt/UĘŽiÖKŇmôáyÇżßQYcť
@@ -20388,7 +20420,7 @@ nagyítógép/VËŻj×LÓnňéyČŔŕRTtYcź
 nagyító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 nagyétkűség/VËŻj×LÓnňéčłÄäTtYc¸źl
 nagyér-/=
-nagyáruház/UmôŇyiYcÇ	áruházak
+nagyáruház/UmôŇyiYcÇ	áruházakáru|ház
 nagyállattartás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nagyágyú/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 nagyágy/UmôŇyiYcÇ	ágyak
@@ -20400,7 +20432,7 @@ nagyvíz/VÓnňyjYcČ
 nagyvásártelep/VËŻj×LÓnňéčłÄäRTtYc¸źl
 nagyvásár/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 nagyváros/UĘŽiÖKŇmôáyÇżßSsYcť
-nagyváltósúly/UĘŽiÖKŇmôáyÇżßSsYcť
+nagyváltósúly/UĘŽiÖKŇmôáyÇżßSsYcťáltó|súly
 nagyvállalkozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 nagyvállalkozás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nagyvállalat/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -20431,6 +20463,7 @@ nagytanács/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nagytakarítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nagyság/UĘŽiÖKŇmôáç˛ĂăSsYck
 nagyszünet/VËŻj×LÓnňéčłÄäTtYc¸źl
+nagyszülőség/VËŻj×LÓnňéyČŔŕTtYcź
 nagyszülő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝	üleiteküleinküleimüleiküleidülei
 nagyszüleitek/VnÓ×)ülő
 nagyszüleink/VnÓ×)ülő
@@ -20439,8 +20472,8 @@ nagyszüleik/VnÓ×)ülő
 nagyszüleid/VnÓ×)ülő
 nagyszülei/VĐÓ×)ülő
 nagyszüle/ŐBVRËŻjĐÓéyČŔŕYcź
-nagyszótár/UmôŇyiYcÇ	ótárak
-nagyszínpad/UĘŽiÖKŇmôáyÇżßQSsYcť
+nagyszótár/UmôŇyiYcÇ	ótárakó|tár
+nagyszínpad/UĘŽiÖKŇmôáyÇżßQSsYcťín|pad
 nagyszínház/UmôŇyiYcÇ	ínházakín|ház
 nagyszámítógép/VËŻj×LÓnňéčłÄäRTtYc¸źl
 nagyszálló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -20519,7 +20552,7 @@ nagynénike/ŐBVRËŻjĐÓéyČŔŕYcź
 nagynéni/ŐBVRËŻjĐÓéyČŔŕYcź
 nagynéne/ŐBVËŻjĐÓéyČŔŕYcź	én
 nagynén/uR)éne
-nagymuter/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRYcťź
+nagymuter/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
 nagymutató/ŐAUQĘŽiĎŇáyÇżßYcť
 nagymotor/UĘŽiÖKŇmôáyÇżßQYcť
 nagymosás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -20536,7 +20569,7 @@ nagymama/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ájáék
 nagymacska/ŐAUQĘŽiĎŇáyÇżßYcť
 nagylétszámú/w
 nagylány/UĘŽiÖKŇmôáyÇżßSsYcť
-nagylábujj/UmôŇyiYcÇ	ábujjak
+nagylábujj/UmôŇyiYcÇ	ábujjakáb|ujj
 nagyleány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nagylexikon/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 nagylemez/VËŻj×LÓnňéyČŔŕTtYcź
@@ -20547,7 +20580,7 @@ nagyközség/VËŻj×LÓnňéyČŔŕTtYcźöz-ség
 nagykövetség/VËŻj×LÓnňéyČŔŕTtYcź
 nagykövet/VËŻj×LÓnňéyČŔŕTtYcź
 nagykötőjelet/x)ötőjel
-nagykötőjel/VËŻj×LÓnňéyČŔŕRYcź	ötőjelet
+nagykötőjel/VËŻj×LÓnňéyČŔŕRYcź	ötőjeletötő|jel
 nagykörút/UmôŇyiYcÇQ	örutakör|út
 nagykönyv/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 nagykutya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -20568,7 +20601,7 @@ nagykapitalista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 nagykanál/UmôŇyiYcÇ
 nagykalapács/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 nagykabát/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-nagyjátékfilm/VËŻj×LÓnňéyČŔŕRYcź
+nagyjátékfilm/VËŻj×LÓnňéyČŔŕRYcźáték|film
 nagyjából
 nagyjelenet/VËŻj×LÓnňéyČŔŕTtYcź
 nagyjavítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -20602,8 +20635,8 @@ nagyfeszültség/VËŻj×LÓnňéčłÄäTtYc¸źl
 nagyfelhasználó/ŐAUQĘŽiĎŇáyÇżßYcť
 nagyfejedelemség/VËŻj×LÓnňéyČŔŕTtYcź
 nagyfejedelem/VnňyjYcŻ
-nagyfater/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRYcťź
-nagyezerjófű/WŢŘÔyjYcČ	ófüvek
+nagyfater/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
+nagyezerjófű/WŢŘÔyjYcČ	ófüvekó|fű
 nagyevő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 nagyestélyi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 nagyeskü/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -20712,6 +20745,7 @@ művész/VËŻj×LÓnňéčłÄäTtYc¸źl
 művér/VËŻj×LÓnňéyČŔŕTtYcź
 művileg
 művi/BGVxĐŐÓ)ű
+művház/UmôŇyiYcÇ	űvházak
 művezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 művesség/VËŻj×LÓnňéčłÄäTtYc¸źl
 művese/ŐBVRËŻjĐÓéyČŔŕYcź
@@ -20736,11 +20770,11 @@ műszőrme/ŐBVRËŻjĐÓéyČŔŕYcź
 műszó/UĎÖŇyiYcÇ	űszavak
 műszál/UmôŇyiYcÇ	űszálak
 műszerész/VËŻj×LÓnňéyČŔŕTtYcź
-műszertábla/ŐAUQĘŽiĎŇáyÇżßYcť
-műszerfal/UmôŇyiYcÇ	űszerfalak
+műszertábla/ŐAUQĘŽiĎŇáyÇżßYcťű|szer||tábla
+műszerfal/UmôŇyiYcÇ	űszerfalakű|szer||fal
 műszerezettség/VËŻj×LÓnňéyČŔŕTtYcź
 műszer/VËŻj×LÓnňéyČŔŕTtYcź
-műszakváltás/UĘŽiÖKŇmôáyÇżßSsYcť
+műszakváltás/UĘŽiÖKŇmôáyÇżßSsYcťű|szak||váltás
 műszak/UĘŽiÖKŇmôáyÇżßQYcť
 műsorközlő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 műsorbemondó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -20781,7 +20815,7 @@ műgond/UĘŽiÖKŇmôáyÇżßQYcť
 műfű/WŢŘÔyjYcČ	űfüvek
 műforma/ŐAUQĘŽiĎŇáyÇżßYcťűformaválasztás>
 műfogás/UĘŽiÖKŇmôáyÇżßSsYcť
-műfogsor/UĘŽiÖKŇmôáyÇżßSsYcť
+műfogsor/UĘŽiÖKŇmôáyÇżßSsYcťű||fog|sor
 műfog/UmôŇyiYcÇ	űfogak
 műfal/UmôŇyiYcÇ	űfalak
 műfaj/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -20908,7 +20942,7 @@ mókázik
 mókus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 móka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 módusz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-módszertan/UĘŽiÖKŇmôáyÇżßSsYcť
+módszertan/UĘŽiÖKŇmôáyÇżßSsYcťód|szer||tan
 módszer/VËŻj×LÓnňéyČŔŕTtYcź
 módozat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 módosítójavaslat/wYUĘŽiÖKŇmôáyÇżßQcť
@@ -20950,7 +20984,7 @@ mézbor/UĘŽiÖKŇmôáyÇżßSsYcť
 méz/VÓnňčjYcł	ézek
 métázik
 méteráru/ŐAUQĘŽiĎŇáyÇżßYcť
-méterrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+méterrendszer/VËŻj×LÓnňéyČŔŕTtYcźéter||rend|szer
 méter/VËŻj×LÓnňéčłÄäRTtYc¸źl
 mételyfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ételyfüvek
 métely/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -20966,8 +21000,8 @@ mészárlás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 mésztufa/ŐAUQĘŽiĎŇáyÇżßYcť
 mészpát/UĘŽiÖKŇmôáyÇżßQYcť
 mészpor/UĘŽiÖKŇmôáyÇżßQSsYcť
-mészkőhegység/VËŻj×LÓnňéyČŔŕTtYcź
-mészkőbánya/ŐAUQĘŽiĎŇáyÇżßYcť
+mészkőhegység/VËŻj×LÓnňéyČŔŕTtYcźész|kő||hegység
+mészkőbánya/ŐAUQĘŽiĎŇáyÇżßYcťész|kő||bánya
 mészkő/WŢŘÔyjYcČ	észkövek
 mészhomok/UĘŽiÖKŇmôáyÇżßQYcť
 mész/VÓnňčjYcł
@@ -20975,12 +21009,12 @@ mérőóra/ŐAUQĘŽiĎŇáyÇżßYcť
 mérőón/UĘŽiÖKŇmôáyÇżßQYcť
 mérőszalag/UĘŽiÖKŇmôáyÇżßQYcť
 mérőrúd/UmôŇyiYcÇQ	érőrudak
-mérőműszer/VËŻj×LÓnňéyČŔŕTtYcź
+mérőműszer/VËŻj×LÓnňéyČŔŕTtYcźérő||mű|szer
 mérőléc/VËŻj×LÓnňéyČŔŕTtYcź
 mérőeszköz/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 mérv/VËŻj×LÓnňéčłÄäTtYc¸ź
 mértékszabóság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-mértékrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+mértékrendszer/VËŻj×LÓnňéyČŔŕTtYcźérték||rend|szer
 mértékegység/VËŻj×LÓnňéyČŔŕTtYcź
 mértékalap/UĘŽiÖKŇmôáyÇżßQYcť
 mérték/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -21011,7 +21045,7 @@ mérgesgomba-/=
 mérges_kígyó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 mérges_gáz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 mérges_gomba/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-mérföldkő/WŢŘÔyjYcČ	érföldkövek
+mérföldkő/WŢŘÔyjYcČ	érföldkövekér|föld||kő
 mérföld/VNËŻj×LÝňÔéyČŔŕRYcź
 méretkezik
 méreteloszlás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -21084,7 +21118,7 @@ méhtenyésztés/VËŻj×LÓnňéyČŔŕTtYcź
 méhsejt/VËŻj×LÓnňéyČŔŕRYcź
 méhraj/UĘŽiÖKŇmôáyÇżßSsYcť
 méhlepény/VËŻj×LÓnňéyČŔŕTtYcź
-méhkirálynő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+méhkirálynő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝éh||király|nő
 méhkenyér/VÓnňyjYcČ	éhkenyerek
 méhkas/UĘŽiÖKŇmôáyÇżßSsYcť
 méhkaparás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -21434,7 +21468,7 @@ mozi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 mozgólépcső/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 mozgókép/VËŻj×LÓnňéyČŔŕTtYcź
 mozgójárda/ŐAUQĘŽiĎŇáyÇżßYcť
-mozgófénykép/VËŻj×LÓnňéyČŔŕTtYcź
+mozgófénykép/VËŻj×LÓnňéyČŔŕTtYcźó||fény|kép
 mozgódaru/ŐAUQĘŽiĎŇáyÇżßYcť
 mozgó/ŐAUQĘŽiĎŇáç˛ĂăYcˇťX)Ó_PRESPART_adj
 mozgó/ŐAUQĘŽiĎŇáç˛ĂăYcˇťX
@@ -21484,7 +21518,7 @@ motorozik
 motoros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 motorkíséret/VËŻj×LÓnňéyČŔŕTtYcź
 motorkocsi/ŐAUQĘŽiĎŇáyÇżßYcť
-motorkerékpár/UĘŽiÖKŇmôáyÇżßQYcť
+motorkerékpár/UĘŽiÖKŇmôáyÇżßQYcťék|pár
 motorizáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 motorika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 motorcsónak/UĘŽiÖKŇmôáyÇżßQYcť
@@ -22572,7 +22606,7 @@ metafoszforsav/UmôŇyiYcÇQ
 metafoszforossav/UmôŇyiYcÇQ
 metafora/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 metafizika/ŐAUQĘŽiĎŇáyÇżßYcť
-metabórsav/UmôŇyiYcÇ	órsavak
+metabórsav/UmôŇyiYcÇ	órsavakór|sav
 metabolizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 metabolit/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 metabiszulfit/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
@@ -22727,7 +22761,7 @@ mensevik/VËŻj×LÓnňéčłÄäRYc¸źl
 menses/VËŻj×LÓnőéčłÄäTtYc¸źl
 menopauza/ŐAUQĘŽiĎŇáyÇżßYcť
 mennyország/UĘŽiÖKŇmôáyÇżßSsYcť
-mennykőcsapás/UĘŽiÖKŇmôáyÇżßSsYcť
+mennykőcsapás/UĘŽiÖKŇmôáyÇżßSsYcťő||csapás
 mennykő/WŢŘÔyjYcČ	övek
 mennyiünk/WÔ×Ý)
 mennyiük/WÔ×Ý)
@@ -22839,7 +22873,7 @@ mellékösvény/VËŻj×LÓnňéyČŔŕTtYcź
 mellékíz/VËŻj×LÓnňéyČŔŕTtYcź
 mellékértelem/VnňyjYcŻ	ékértelmek
 melléképület/VËŻj×LÓnňéyČŔŕTtYcź
-mellékáramkör/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
+mellékáramkör/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ék||áram|kör
 mellékág/UmôŇyiYcÇ	ékágak
 mellékvonal/UmôŇyiYcÇ	ékvonalak
 mellékutca/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -22881,7 +22915,7 @@ mellszobor/UmôyiYcŽ
 mellkas/UĘŽiÖKŇmôáyÇżßSsYcť
 mellitus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 mellitsav/UmôŇyiYcÇQ
-mellhártyagyulladás/UĘŽiÖKŇmôáyÇżßSsYcť
+mellhártyagyulladás/UĘŽiÖKŇmôáyÇżßSsYcťártya||gyulladás
 mellhártya/ŐAUQĘŽiĎŇáyÇżßYcť
 mellfurdancs/UĘŽiÖKŇmôáyÇżßSsYcť
 mellettünk/)
@@ -22910,6 +22944,8 @@ melegítőfelső/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 melegítőalsó/ŐAUQĘŽiĎŇáyÇżßYcť
 melegítő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 melegágy/UmôŇyiYcÇ	ágyak
+melegvíz-mérő_óra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ph:melegvízmérő-óra*
+melegvíz-mérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝	ph:melegvízmérő
 melegvíz-/=
 melegszilárdság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 melegszervezet/VËŻj×LÓnňéyČŔŕTtYcź
@@ -22917,7 +22953,7 @@ melegszendvics/VËŻj×LÓnňéčłÄäTtYc¸źl
 melegruha-/=
 melegrekord/UĘŽiÖKŇmôáyÇżßQYcť
 melegpadló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-melegmegmunkálás/UĘŽiÖKŇmôáyÇżßSsYcť
+melegmegmunkálás/UĘŽiÖKŇmôáyÇżßSsYcťálás
 meleglevegő-/=
 meleglaboratórium/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 melegkonyha/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -22926,7 +22962,7 @@ melegindítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 melegházasság/UĘŽiÖKŇmôáyÇżßSsYcť
 melegház/UmôŇyiYcÇ	ázak
 meleghullám/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-meleghengermű/WŢŘÔyjYcČ	űvek
+meleghengermű/WŢŘÔyjYcČ	űvekű
 meleghengerlés/VËŻj×LÓnňéčłÄäTtYc¸źl
 melegfény-/=
 melegfront/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -22940,6 +22976,7 @@ melegcsap/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 melegbár/UĘŽiÖKŇmôáyÇżßQYcť
 melegburkoló/ŐAUQĘŽiĎŇáyÇżßYcť
 melegburkolat/UĘŽiÖKŇmôáyÇżßSsYcť
+melegbetörés/VËŻj×LÓnňéyČŔŕTtYcźörés
 melegalakítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 meleg_étel/VËŻj×LÓnňéčłÄäTtYc¸źl
 meleg_érzés/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -22987,7 +23024,6 @@ megállapodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 megzsarolás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 megzavarás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 megyéspüspök/WĚŻjŘMÝňÔíyČÁ˙RTtYc˝
-megyeszerte
 megyen/)
 megye/ŐBVRËŻjĐÓéčłÄäYc¸ź
 megvétel/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -23748,7 +23784,7 @@ marhanyelv/VËŻj×LÓnňéyČŔŕTtYcź
 marhamód
 marhahús/UĘŽiÖKŇmôáyÇżßSsYcť
 marhahajcsár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-marhafartő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+marhafartő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő
 marhafaj/UĘŽiÖKŇmôáyÇżßSsYcť
 marhacomb/UĘŽiÖKŇmôáyÇżßQYcť
 marha/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -23958,7 +23994,7 @@ magárahagyatottság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 magára
 magánügy/VNËŻj×LÝňÔéyČŔŕTtYcź
 magánúton
-magánútlevél/VÓnňyjYcČ	ánútlevelek
+magánútlevél/VÓnňyjYcČ	ánútlevelekán||út|levél
 magánút/UmôŇyiYcÇ	ánutak
 magánóra/ŐAUQĘŽiĎŇáyÇżßYcť
 magánítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -23974,7 +24010,7 @@ magányosul
 magányos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 magány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 magánvélemény/VËŻj×LÓnňéyČŔŕTtYcź
-magánvégrendelet/VËŻj×LÓnňéyČŔŕTtYcź
+magánvégrendelet/VËŻj×LÓnňéyČŔŕTtYcźán||vég|rendelet
 magánvállalkozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 magánvállalkozás/UĘŽiÖKŇmôáyÇżßSsYcť
 magánvállalat/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -24019,16 +24055,16 @@ magánokirat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 magánnyugdíj/UŇmôyiYcÇ	ánnyugdíjakán||nyug|díj
 magánnyomozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇťán|nyomozó
 magánmunka/ŐAUQĘŽiĎŇáyÇżßYcť
-magánmegtakarítás/UĘŽiÖKŇmôáyÇżßSsYcť
+magánmegtakarítás/UĘŽiÖKŇmôáyÇżßSsYcťán||meg|takarítás
 magánmecenatúra/ŐAUQĘŽiĎŇáyÇżßYcť
 magánlátogatás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 magánlevél/VÓnňyjYcČ	ánlevelek
 magánlevelezés/VËŻj×LÓnňéyČŔŕTtYcź
 magánlakás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 magánlaksértés/VËŻj×LÓnňéčłÄäTtYc¸źl
-magánlakosztály/UĘŽiÖKŇmôáyÇżßSsYcť
-magánkönyvtár/UmôŇyiYcÇ	ánkönyvtárak
-magánkórház/UmôŇyiYcÇ	ánkórházak
+magánlakosztály/UĘŽiÖKŇmôáyÇżßSsYcťán||lak|osztály
+magánkönyvtár/UmôŇyiYcÇ	ánkönyvtárakán||könyv|tár
+magánkórház/UmôŇyiYcÇ	ánkórházakán||kór|ház
 magánkívül/WĚŻjŘMÝňÔíčłĹĺRYc¸˝l
 magánkézben
 magánkézbe
@@ -24052,7 +24088,7 @@ magánház/UmôŇyiYcÇ	ánházak
 magánhitel/VËŻj×LÓnňéčłÄäTtYc¸źl
 magánhasználat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 magánhangzó/ŐAUQĘŽiĎŇáyÇżßYcť
-magánhadsereg/VËŻj×LÓnňéyČŔŕTtYcź
+magánhadsereg/VËŻj×LÓnňéyČŔŕTtYcźán||had|sereg
 magángyűjtő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 magángyűjtemény/VËŻj×LÓnňéyČŔŕTtYcź
 magángyónás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -24064,7 +24100,7 @@ magánfuvarozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 magánforrás/UĘŽiÖKŇmôáyÇżßSsYcť
 magánfogyasztó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 magánfogat/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
-magánfodrászüzlet/VËŻj×LÓnňéyČŔŕRYcź
+magánfodrászüzlet/VËŻj×LÓnňéyČŔŕRYcźán||fodrász|üzlet
 magánerő/ŐCWĚŻjŢÔíyČÁ˙Yc˝	ánerej
 magánerej/uxyT¸)ánerő
 magánember/VËŻj×LÓnňéyČŔŕRYcź
@@ -24266,7 +24302,7 @@ maestro/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ph:májsztró
 madárvárta/ŐAUQĘŽiĎŇáyÇżßYcť
 madártej/VËŻj×LÓnňéčłÄäTtYc¸źl
 madársisak/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-madárkeserűfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	árkeserűfüvek
+madárkeserűfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	árkeserűfüvekár||keserű|fű
 madárka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 madárbirs/VËŻj×LÓnňéčłÄäTtYc¸źl
 madár/UmôŇçiYc˛k
@@ -24480,16 +24516,16 @@ lőtér/VÓnňyjYcČ	őterek
 lőtávolság/UĘŽiÖKŇmôáyÇżßSsYcť
 lőtávol/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 lőtábla/ŐAUQĘŽiĎŇáyÇżßYcť
-lőszerszekrény/VËŻj×LÓnňéyČŔŕTtYcź
-lőszerkocsi/ŐAUQĘŽiĎŇáyÇżßYcť
+lőszerszekrény/VËŻj×LÓnňéyČŔŕTtYcźő|szer||szekrény
+lőszerkocsi/ŐAUQĘŽiĎŇáyÇżßYcťő|szer||kocsi
 lőszeresláda/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 lőszer/VËŻj×LÓnňéyČŔŕTtYcź
 lőrés/VËŻj×LÓnňéyČŔŕTtYcź
 lőre/ŐBVRËŻjĐÓéčłÄäYc¸ź
-lőpárbaj/UĘŽiÖKŇmôáyÇżßSsYcť
-lőportár/UmôŇyiYcÇ	őportárak
-lőporraktár/UmôŇyiYcÇ	őporraktárak
-lőporgyár/UmôŇyiYcÇ	őporgyárak
+lőpárbaj/UĘŽiÖKŇmôáyÇżßSsYcťő||pár|baj
+lőportár/UmôŇyiYcÇ	őportárakő|por||tár
+lőporraktár/UmôŇyiYcÇ	őporraktárakő|por||rak|tár
+lőporgyár/UmôŇyiYcÇ	őporgyárakő|por||gyár
 lőpor/UĘŽiÖKŇmôáyÇżßQSsYcť
 lőpad/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 lőn
@@ -24516,7 +24552,7 @@ lózung/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 lóvé/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 lóvátétel/VËŻj×LÓnňéčłÄäTtYc¸źl
 lóversenyzés/VËŻj×LÓnňéyČŔŕTtYcź
-lóversenypálya/ŐAUQĘŽiĎŇáyÇżßYcť
+lóversenypálya/ŐAUQĘŽiĎŇáyÇżßYcťó|verseny||pálya
 lóversenyez
 lóverseny/VËŻj×LÓnňéyČŔŕTtYcź
 lóvasút/UmôŇyiYcÇQ	óvasutakó||vas|út
@@ -24554,7 +24590,7 @@ lótenyésztés/VËŻj×LÓnňéyČŔŕTtYcź
 lótej/VËŻj×LÓnňéyČŔŕTtYcź
 lótartás/UĘŽiÖKŇmôáyÇżßSsYcť
 lót-fut	ótás-futásóthat-futhatótó-futóótott-futott
-lószerszám/UĘŽiÖKŇmôáyÇżßSsYcť
+lószerszám/UĘŽiÖKŇmôáyÇżßSsYcťó||szer|szám
 lóssál-fussál
 lóssunk-fussunk
 lósson-fusson
@@ -24608,7 +24644,7 @@ lévén
 létére
 létszámfölötti/ŐBVRËŻjĐÓéčłÄäYc¸ź
 létszámfeletti/ŐBVRËŻjĐÓéčłÄäYc¸ź
-létszámcsökkenés/VËŻj×LÓnňéyČŔŕTtYcź
+létszámcsökkenés/VËŻj×LÓnňéyČŔŕTtYcźét|szám||csökkenés
 létszám/UĘŽiÖKŇmôáyÇżßSsYcť
 létrejövünk/)étreön
 létrejövök/)étreön
@@ -24699,7 +24735,7 @@ lélektan/UĘŽiÖKŇmôáyÇżßSsYcť
 lélekszám/UĘŽiÖKŇmôáyÇżßSsYcť
 lélekszakadva
 lélekkufárság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-lélekjelenlét/VËŻj×LÓnňéyČŔŕTtYcź
+lélekjelenlét/VËŻj×LÓnňéyČŔŕTtYcźélek||jelen|lét
 lélekidomár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 lélekharang/UĘŽiÖKŇmôáyÇżßQYcť
 lélekelemzés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -24741,7 +24777,7 @@ légycsapó/ŐAUQĘŽiĎŇáyÇżßYcť
 légy_szíves	ph:légyszi	ph:lécci	ph:légysz	ph:légysí
 légy/VÓnňčjYcł
 légvédelem/VnňyjYcŻ	égvédelmekégvédelmi>
-légvárépítés/VËŻj×LÓnňéyČŔŕTtYcź
+légvárépítés/VËŻj×LÓnňéyČŔŕTtYcźég|vár||építés
 légvár/UmôŇyiYcÇ	égvárak
 légvonat/UĘŽiÖKŇmôáyÇżßSsYcť
 légvonal/UmôŇyiYcÇ	égvonalak
@@ -24750,12 +24786,12 @@ légtornász/UĘŽiÖKŇmôáyÇżßSsYcť
 légtelenítő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 légsűrítő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 légsúrlódás/UĘŽiÖKŇmôáyÇżßSsYcť
-légsúlymérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+légsúlymérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ég|súly||mérő
 légszivattyú/ŐAUQĘŽiĎŇáyÇżßYcť
 légsebesség/VËŻj×LÓnňéyČŔŕTtYcź
 légpárna/ŐAUQĘŽiĎŇáyÇżßYcť
 légpuska/ŐAUQĘŽiĎŇáyÇżßYcť
-légnyomásmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+légnyomásmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ég|nyomás||mérő
 légnyomás/UĘŽiÖKŇmôáyÇżßSsYcť
 légmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 léglökés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -24770,7 +24806,7 @@ légivadász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 légiutas/UĘŽiÖKŇmôáyÇżßSsYcť
 légitér/VÓnňyjYcČ	égiterek
 légitársaság/UĘŽiÖKŇmôáyÇżßSsYcť
-légitámaszpont/UĘŽiÖKŇmôáyÇżßQYcť
+légitámaszpont/UĘŽiÖKŇmôáyÇżßQYcťégi||támasz|pont
 légitámadás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 légitorpedó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 légiriadó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -24779,9 +24815,9 @@ légionista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 légimentő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 légikisasszony/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 légikikötő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
-légijármű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+légijármű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝égi||jár|mű
 légihíd/UŇmôyiYcÇQ	égihidak
-légifuvardíj/UŇmôyiYcÇ	égifuvardíjak
+légifuvardíj/UŇmôyiYcÇ	égifuvardíjakégi||fuvar|díj
 légiflotta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 légiesül
 légierő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -24802,7 +24838,7 @@ légfék/VËŻj×LÓnňéyČŔŕRTtYcź
 légfrissítő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 légellenállás/UĘŽiÖKŇmôáyÇżßSsYcť
 légelhárító/ŐAUQĘŽiĎŇáyÇżßYcť
-légcsőhurut/UĘŽiÖKŇmôáyÇżßQYcť
+légcsőhurut/UĘŽiÖKŇmôáyÇżßQYcťég|cső||hurut
 légcső/WŢŘÔyjYcČ	égcsövek
 légcsavar/UĘŽiÖKŇmôáyÇżßQYcť
 légcsatorna/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -24976,19 +25012,19 @@ ládakeret/VËŻj×LÓnňéyČŔŕTtYcź
 ládafia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 láda/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 lábító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-lábujjköröm/WÝyjYcŻ	ábujjkörmök
+lábujjköröm/WÝyjYcŻ	ábujjkörmökáb|ujj||köröm
 lábujjhegy/VËŻj×LÓnňéyČŔŕTtYcź
 lábujj/UmôŇyiYcÇ	ábujjak
 lábtörlő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-lábtőcsont/UĘŽiÖKŇmôáyÇżßQYcť
+lábtőcsont/UĘŽiÖKŇmôáyÇżßQYcťáb|tő||csont
 lábtő/WŢŘÔyjYcČ	ábtövek
 lábtámasz/UĘŽiÖKŇmôáyÇżßSsYcť
 lábtyű/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 lábtengó/ŐAUQĘŽiĎŇáyÇżßYcť
 lábtartás/UĘŽiÖKŇmôáyÇżßSsYcť
 lábsó/ŐAUQĘŽiĎŇáyÇżßYcť
-lábszárvédő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-lábszárcsont/UĘŽiÖKŇmôáyÇżßQYcť
+lábszárvédő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝áb|szár||védő
+lábszárcsont/UĘŽiÖKŇmôáyÇżßQYcťáb|szár||csont
 lábszár/UmôŇyiYcÇ	ábszárak
 lábravaló/ŐAUQĘŽiĎŇáyÇżßYcť
 lábos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -25005,7 +25041,7 @@ lábfagyás/UĘŽiÖKŇmôáyÇżßSsYcť
 lábdübörgés/VËŻj×LÓnňéyČŔŕTtYcź
 lábbusszal
 lábbilincs/VËŻj×LÓnňéyČŔŕTtYcź
-lábbeli/ŐBVRËŻjĐÓéyČŔŕYcź
+lábbeli/ŐBVRËŻjĐÓéčłÄäYc¸ź
 lábazat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 lábas/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 lábal
@@ -25069,6 +25105,7 @@ luft/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 lufi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 luesz/VËŻj×LÓnňéčłÄäTtYc¸źl
 ludaskása/ŐAUQĘŽiĎŇáyÇżßYcť
+lucázik
 lucsok/UmôçiYcŽkQ
 lucerna/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 lucaszék/VËŻj×LÓnňéyČŔŕTtYcź
@@ -25127,6 +25164,7 @@ londoni/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 londiner/VËŻj×LÓnňéčłÄäRTtYc¸źl
 lonc/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
 lomtár/UmôŇyiYcÇ	árak
+lomizik
 lomhul
 lombtalanodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 lombozat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -25135,7 +25173,7 @@ lombosmoha/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 lombikbébi/ŐBVRËŻjĐÓéčłÄäYc¸ź
 lombik/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 lombhullás/UĘŽiÖKŇmôáyÇżßSsYcť
-lombfűrészmunka/ŐAUQĘŽiĎŇáyÇżßYcť
+lombfűrészmunka/ŐAUQĘŽiĎŇáyÇżßYcťűrész||munka
 lombfűrész/VËŻj×LÓnňéyČŔŕTtYcź
 lombfakadás/UĘŽiÖKŇmôáyÇżßSsYcť
 lombardügylet/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -25339,7 +25377,6 @@ lezárulta/UŇĎ)árulta	árulta
 lezárt/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 lezuhanás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 lezserség/VËŻj×LÓnňéčłÄäTtYc¸źl
-lezser/VËŻj×LÓnňéčłÄäRYc¸źl
 lexéma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 lexikon/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 lexikológus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -25353,7 +25390,7 @@ levétel/VËŻj×LÓnňéčłÄäTtYc¸źl
 levés/XVËŻj×LÓnňéčłÄäTtYc¸źl)Ás_PROCESS/RESULT_noun
 levélér/VÓnňyjYcČ	élerek
 levélzet/VËŻj×LÓnňéčłÄäTtYc¸źl
-levéltávirat/UĘŽiÖKŇmôáyÇżßSsYcť
+levéltávirat/UĘŽiÖKŇmôáyÇżßSsYcťél||táv|irat
 levéltáros/UĘŽiÖKŇmôáyÇżßSsYcť
 levéltárnok/UĘŽiÖKŇmôáyÇżßSsYcť
 levéltár/UmôŇyiYcÇ	éltárak
@@ -25578,6 +25615,7 @@ lektorátus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 lektor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 lekopás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 lekonyulás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+lejövet
 lejátszófej/VËŻj×LÓnňéyČŔŕTtYcź
 lejátszó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 lejátszás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -25634,6 +25672,9 @@ legáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 legzártkörűbbik/Tt×nÓV)ártkörűbb
 legzártkörűbben/)árt_körű
 legzártkörűbb/×ŢÔCMWR)árt_körű	ártkörűbbik
+legzavarbaejtőbbik/Tt×nÓV)őbb
+legzavarbaejtőbben/)ő
+legzavarbaejtőbb/×ŢÔCMWR)ő	őbbik
 legyőzés/VËŻj×LÓnňéčłÄäTtYc¸źl
 legyőzetés/VËŻj×LÓnňéčłÄäTtYc¸źl
 legyezőpálma/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -25847,6 +25888,7 @@ lasagné/ŐAUBVLQRĘŽËŻijĎĐÓáéçč˛łÄäĂăvˇť¸źu)
 lasagne/ŐBVRËŻjĐÓéčłÄäYc¸ź	é
 larousse-i/ŃĎŐAFUKSs)	ph:larusszi
 laringoszkóp/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+lapátka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 lapát/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 lapály/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 lapzárta/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -25950,6 +25992,7 @@ lakodalom/UmôçiYcŽk
 lakmározik
 lakmusz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 lakli/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+lakkolit/VËŻj×LÓnňéčłÄäRYc¸źl
 lakkmézga/ŐAUQĘŽiĎŇáyÇżßYcť
 lakkmunka/ŐAUQĘŽiĎŇáyÇżßYcť
 lakk/UĘŽiÖKŇmôáç˛ĂăQYcˇť
@@ -25986,10 +26029,10 @@ labilitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 labializáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 labdázik
 labdaütés/VËŻj×LÓnňéyČŔŕTtYcź
-labdarúgósport/UĘŽiÖKŇmôáyÇżßQYcť
-labdarúgópálya/ŐAUQĘŽiĎŇáyÇżßYcť
-labdarúgóklub/UĘŽiÖKŇmôáyÇżßQYcť
-labdarúgócsapat/UĘŽiÖKŇmôáyÇżßQYcť
+labdarúgósport/UĘŽiÖKŇmôáyÇżßQYcťúgó||sport
+labdarúgópálya/ŐAUQĘŽiĎŇáyÇżßYcťúgó||pálya
+labdarúgóklub/UĘŽiÖKŇmôáyÇżßQYcťúgó||klub
+labdarúgócsapat/UĘŽiÖKŇmôáyÇżßQYcťúgó||csapat
 labdarúgó/ŐAUQĘŽiĎŇáyÇżßYcť
 labdarúgás/UĘŽiÖKŇmôáyÇżßSsYcť
 labdarózsa/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -26024,7 +26067,7 @@ kürt/WĚŻjŘMÝňÔíčłĹĺRYc¸˝
 küret/VËŻj×LÓnňéčłÄäRTtYc¸źl
 künn
 külügyér/VËŻj×LÓnňéyČŔŕTtYcź
-külügyminisztérium/UĘŽiÖKŇmôáyÇżßSsYcť
+külügyminisztérium/UĘŽiÖKŇmôáyÇżßSsYcťül|ügy||minisztérium
 külügy/VNËŻj×LÝňÔéyČŔŕTtYcź
 különül
 különösmód
@@ -26058,14 +26101,13 @@ különjárat/UĘŽiÖKŇmôáyÇżßSsYcť
 különirt/w
 különhajó/ŐAUQĘŽiĎŇáyÇżßYcť
 különgép/VËŻj×LÓnňéyČŔŕRYcź
-különeljárás/UĘŽiÖKŇmôáyÇżßSsYcť
+különeljárás/UĘŽiÖKŇmôáyÇżßSsYcťülön||el|járás
 különdíjszabás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 különdíj/UŇmôyiYcÇ	ülöndíjak
-különcködés/VËŻj×LÓnňéyČŔŕTtYcź
 különbözőség/VËŻj×LÓnňéčłÄäTtYc¸źl
 különbözően
 különbözik
-különbözet/VËŻj×LÓnňéyČŔŕTtYcź
+különbözet/VËŻj×LÓnňéčłÄäTtYc¸źl
 különbíróság/UĘŽiÖKŇmôáyÇżßSsYcť
 különbéke/ŐBVRËŻjĐÓéyČŔŕYcź
 különbusz/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -26086,30 +26128,28 @@ külterület/VËŻj×LÓnňéyČŔŕTtYcź
 kültelki
 kültelek/VnňyjYcŻ	ültelkek
 kültakaró/ŐAUQĘŽiĎŇáyÇżßYcť
-kültag/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+kültag/UĘŽiÖKŇmôáyÇżßQYcť
 külsőség/VËŻj×LÓnňéčłÄäTtYc¸źl
 külsős/WĚŻjŘMÝňÔíčłĹĺTtc¸˝l
 külsőleg
 külsőfül-/=
-külsődleges/VËŻj×LÓnňéčłÄäTtYc¸źl
 külső/ŐŢÔWCRD
 külsérelem/VnňyjYcŻ	ülsérelmek
 külszín/VËŻj×LÓnňéyČŔŕTtYcź
-külszolgálat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+külszolgálat/UĘŽiÖKŇmôáyÇżßSsYcť
 külsej/uxT¸)ülseje
 külpolitika/ŐAUQĘŽiĎŇáyÇżßYcť
 külpiac/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-külország/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+külország/UĘŽiÖKŇmôáyÇżßSsYcť
 külmisszió/ŐAUQĘŽiĎŇáyÇżßYcť
 küllő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 küllem/VËŻj×LÓnňéčłÄäTtYc¸źl
-külképviselet/VËŻj×LÓnňéyČŔŕTtYcź
+külképviselet/VËŻj×LÓnňéyČŔŕTtYcźül||kép|viselet
 külkereskedő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 külkereskedelem/VnňyjYcŻ	ülkereskedelmek
 külker/VËŻj×LÓnňéyČŔŕRYcź
 külkapcsolat/UĘŽiÖKŇmôáyÇżßSsYcť
 külhéj/UŇmôyiYcÇ	ülhéjak
-külhonos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 külhon/UĘŽiÖKŇmôáyÇżßQYcť
 külgazdaság/UĘŽiÖKŇmôáyÇżßSsYcť
 külföld/VNËŻj×LÝňÔéyČŔŕRYcź
@@ -26118,7 +26158,7 @@ küldött/VNËŻj×LÝňÔéčłÄäRTtYc¸źl
 küldönc/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 küldetés/VËŻj×LÓnňéčłÄäTtYc¸źl
 küldemény/VËŻj×LÓnňéčłÄäTtYc¸źl
-külcsín/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRYcťź
+külcsín/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
 külalak/UĘŽiÖKŇmôáyÇżßQYcť
 kül-
 küklopsz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -26186,11 +26226,12 @@ középnehéz/BnÓLVR	özépnehezenözépnehezek
 középnehezen/)özépnehéz
 középnehezek/n×ÓI)özépnehéz
 középmoréna/ŐAUQĘŽiĎŇáyÇżßYcť
+középkorász/UĘŽiÖKŇmôáyÇżßSsYcť
 középkor/UĘŽiÖKŇmôáyÇżßSsYcť
 középiskolás/UĘŽiÖKŇmôáyÇżßSsYcť
 középiskola/ŐAUQĘŽiĎŇáyÇżßYcť
 középhőmérséklet/VËŻj×LÓnňéyČŔŕRYcź
-középhátvéd/VËŻj×LÓnňéčłÄäRYc¸źl
+középhátvéd/VËŻj×LÓnňéyČŔŕRTtYcźözép||hát|véd
 középhegység/VËŻj×LÓnňéyČŔŕTtYcź
 középfül/VNËŻj×LÝňÔéyČŔŕTtYcź
 középfok/UĘŽiÖKŇmôáyÇżßQSsYcť
@@ -26222,7 +26263,6 @@ köztünk/)özteözt)
 köztük/)özteözt)
 köztér/VÓnňyjYcČ	özterek
 köztársaság/UĘŽiÖKŇmôáyÇżßSsYcť
-köztudott/UĘŽi$sŇmôáyÇżßQYcť
 köztudomásúlag
 köztitermék/VËŻj×LÓnňéyČŔŕTtYcź
 köztiek/VÓ×n)özti
@@ -26243,7 +26283,7 @@ közszemérem/VnňyjYcŻ	özszemérmeköz|szemérem
 közszellem/VËŻj×LÓnňéyČŔŕTtYcźöz|szel-lem
 közröhej/VËŻj×LÓnňéčłÄäTtYc¸źl
 közreműködés/VËŻj×LÓnňéyČŔŕTtYcź
-közraktár/UmôŇyiYcÇ	özraktárak
+közraktár/UmôŇyiYcÇ	özraktáraköz||rak|tár
 közpénzmilliárd/UĘŽiÖKŇmôáyÇżßQYcťöz|pénz||milliárd
 központozás/UĘŽiÖKŇmôáyÇżßSsYcť
 központosul
@@ -26462,7 +26502,7 @@ kötekedő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 köteg/VËŻj×LÓnňéčłÄäTtYc¸źl
 kötbér/VËŻj×LÓnňéyČŔŕTtYcź
 kösöntyű/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
-köszörűsműhely/VËŻj×LÓnňéyČŔŕTtYcź
+köszörűsműhely/VËŻj×LÓnňéyČŔŕTtYcźöszörűs||mű|hely
 köszörűs/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 köszörűkő/WŢŘÔyjYcČ	öszörűkövek
 köszörű/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
@@ -26586,6 +26626,7 @@ köptető/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 köpködő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 köpet/VËŻj×LÓnňéčłÄäTtYc¸źl
 köpenyke/ŐBVRËŻjĐÓéčłÄäYc¸ź
+köpenyeg/VËŻj×LÓnňéčłÄäTtYc¸źl
 köpeny/VËŻj×LÓnňéčłÄäTtYc¸źl
 köpedelem/VÓnňčjYcłl	öpedelmek
 könyörület/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -26629,7 +26670,7 @@ könnyűlovasság/UĘŽiÖKŇmôáyÇżßSsYcť
 könnyűlovas/UĘŽiÖKŇmôáyÇżßSsYcť
 könnyűipar/UĘŽiÖKŇmôáyÇżßSsYcť
 könnyűhidrogén/VËŻj×LÓnňéyČŔŕRYcź
-könnyűgépkezelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+könnyűgépkezelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝önnyű|gép||kezelő
 könnyűfémmű/WŢŘÔyjYcČ	önnyűfémművek
 könnyűfém/VËŻj×LÓnňéyČŔŕRYcź
 könnyűcirkáló/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -26645,7 +26686,7 @@ könnyár/UmôŇyiYcÇ	önnyárak
 könnyzacskó/ŐAUQĘŽiĎŇáyÇżßYcť
 könnyvezeték/VËŻj×LÓnňéyČŔŕTtYcź
 könnyit/w
-könnygázbomba/ŐAUQĘŽiĎŇáyÇżßYcť
+könnygázbomba/ŐAUQĘŽiĎŇáyÇżßYcťönny|gáz||bomba
 könnygáz/UĘŽiÖKŇmôáyÇżßSsYcť
 könnyfakasztó/ŐAUQĘŽiĎŇáyÇżßYcť
 könnyezik
@@ -26720,14 +26761,14 @@ kőzetrés/VËŻj×LÓnňéyČŔŕTtYcź
 kőzetburok/UmôyiYcŽ	őzetburkok
 kőzet/VËŻj×LÓnňéčłÄäTtYc¸źl
 kővár/UmôŇyiYcÇ	ővárak
-kőtörőfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	őtörőfüvek
+kőtörőfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	őtörőfüvekő|törő||fű
 kőtörmelék/VËŻj×LÓnňéyČŔŕTtYcź
 kőtömb/WĚŻjŘMÝňÔíyČÁ˙RYc˝
 kőtár/UmôŇyiYcÇ	őtárak
 kőtábla/ŐAUQĘŽiĎŇáyÇżßYcť
 kőtemplom/UĘŽiÖKŇmôáyÇżßSsYcť
 kősó/ŐAUQĘŽiĎŇáyÇżßYcť
-kőszínház/UmôŇyiYcÇ	őszínházak
+kőszínház/UmôŇyiYcÇ	őszínházakő||szín|ház
 kőszén/VÓnňyjYcČ	őszenek
 kőszobor/UmôyiYcŽ	őszobrok
 kőszirt/VËŻj×LÓnňéyČŔŕRYcź
@@ -26738,7 +26779,7 @@ kőris/VËŻj×LÓnňéčłÄäTtYc¸źl
 kőr/WĚŻjŘMÝňÔčłĹĺRvc¸˝
 kőpor/UĘŽiÖKŇmôáyÇżßSsYcť
 kőpad/UĘŽiÖKŇmôáyÇżßQYcť
-kőolajár/UmôŇyiYcÇ	őolajárak
+kőolajár/UmôŇyiYcÇ	őolajárakő|olaj||ár
 kőolaj/UmôŇyiYcÇ	őolajak
 kőnyomat/UĘŽiÖKŇmôáyÇżßSsYcť
 kőműves/VËŻj×LÓnňéyČŔŕTtYcź
@@ -26818,7 +26859,6 @@ kólibacilus/UĘŽiÖKŇmôáyÇżßSsYcť
 kóladió/ŐAUQĘŽiĎŇáyÇżßYcť
 kóla/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ph:cola*
 kókuszrost/UĘŽiÖKŇmôáyÇżßQYcť
-kókuszpálmafa/ŐAUQĘŽiĎŇáyÇżßYcť
 kókuszdió/ŐAUQĘŽiĎŇáyÇżßYcť
 kókusz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kóklerség/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -26857,7 +26897,6 @@ kóborgás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk)óborogÁs_PROCESS/RESULT_noun
 kóan/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kívülünk/)ívüleívül)
 kívülük/)ívüleívül)
-kívülálló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kívülállás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kívülről/D)ívül
 kívülre/D)ívül
@@ -26923,10 +26962,10 @@ kézzel-lábbal
 kéztörlő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 kéztámasz/UĘŽiÖKŇmôáyÇżßSsYcť
 kézszorítás/UĘŽiÖKŇmôáyÇżßSsYcťéz|szo-rí-tás
-kézrátétel/VËŻj×LÓnňéyČŔŕTtYcź
+kézrátétel/VËŻj×LÓnňéyČŔŕTtYcźéz||rá|tétel
 kézművesség/VËŻj×LÓnňéyČŔŕTtYcź
 kézműves/VËŻj×LÓnňéyČŔŕTtYcź
-kézműipar/UĘŽiÖKŇmôáyÇżßSsYcť
+kézműipar/UĘŽiÖKŇmôáyÇżßSsYcťéz|mű||ipar
 kézmozdulat/UĘŽiÖKŇmôáyÇżßSsYcť
 kézközép/VÓnňyjYcČ	ézközepiézközepek
 kézközepi/AFUĐŐÓ)ézközép
@@ -26936,23 +26975,23 @@ kézizálog/UĘŽiÖKŇmôáyÇżßQSsYcť
 kézitükör/WÝyjYcŻ	ézitükrök
 kézitáska/ŐAUQĘŽiĎŇáyÇżßYcť
 kézitusa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-kéziszótár/UmôŇyiYcÇ	éziszótárak
+kéziszótár/UmôŇyiYcÇ	éziszótárakézi||szó|tár
 kéziszivattyú/ŐAUQĘŽiĎŇáyÇżßYcť
 kéziszerszám/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kéziszedő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 kézisajtó/ŐAUQĘŽiĎŇáyÇżßYcť
 kézis/VËŻj×LÓnňéčłÄäTtYc¸źl
-kézirattekercs/VËŻj×LÓnňéyČŔŕTtYcź
+kézirattekercs/VËŻj×LÓnňéyČŔŕTtYcźéz|irat||tekercs
 kézirat/UĘŽiÖKŇmôáyÇżßSsYcť
-kézipénztár/UmôŇyiYcÇ	ézipénztárak
+kézipénztár/UmôŇyiYcÇ	ézipénztárakézi||pénz|tár
 kézipéldány/UĘŽiÖKŇmôáyÇżßSsYcť
 kézipoggyász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kézinyomda/ŐAUQĘŽiĎŇáyÇżßYcť
 kézimérleg/VËŻj×LÓnňéyČŔŕTtYcź
 kézimunkázik
-kézimunkaminta/ŐAUQĘŽiĎŇáyÇżßYcť
-kézimunkakosár/UmôŇyiYcÇ	ézimunkakosarak
-kézimunkadoboz/UĘŽiÖKŇmôáyÇżßSsYcť
+kézimunkaminta/ŐAUQĘŽiĎŇáyÇżßYcťézi|munka||minta
+kézimunkakosár/UmôŇyiYcÇ	ézimunkakosarakézi|munka||kosár
+kézimunkadoboz/UĘŽiÖKŇmôáyÇżßSsYcťézi|munka||doboz
 kézimunka/ŐAUQĘŽiĎŇáyÇżßYcť
 kézilány/UĘŽiÖKŇmôáyÇżßSsYcť
 kézilámpa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -27010,14 +27049,15 @@ kétség/VËŻj×LÓnňéčłÄäTtYc¸źl
 kétszínnyomó/ŐAUQĘŽiĎŇáyÇżßYcťét|szín||nyo-mó
 kétszínnyomás/UĘŽiÖKŇmôáyÇżßSsYcťét|szín||nyo-más
 kétszázzłotys/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+kétszázvalahány/UmŇŮÚ
 kétszázschillinges/VËŻj×LÓnňéčłÄäTtYc¸źl
 kétszázrubeles/VËŻj×LÓnňéčłÄäTtYc¸źl
 kétszázmárkás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kétszázforintos/UĘŽiÖKŇmôáç˛ĂăSscˇťk
 kétszázfontos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-kétszázfelé
-kétszázezres/×BŐV
-kétszázezrek/I)étszázezer
+kétszázfeléét|száz||felé
+kétszázezres/×BŐV	ét|száz||ezres
+kétszázezrek/I)étszázezer	ét|száz||ezrek
 kétszázeurós/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kétszázdolláros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kétszázas/UĘŽiÖKŇmôáç˛ĂăSsYcˇťkAFÚ)étszáz
@@ -27025,13 +27065,13 @@ kétszázas/UĘŽiÖKŇmôáç˛ĂăSsYcˇťkAFÚ
 kétszázan/)étszáz
 kétszázadik/mŇŮAUÚ)étszáz
 kétszázad/AUÚ)étszáz
-kétszáz/$UŮÖmŇSscÚ	étszázasétszázanétszázadikétszázadétszázasétszázadikétszázad
+kétszáz/$UŮÖmŇSscÚ	étszázasétszázanétszázadikétszázad
 kétszersült/VNËŻj×LÝňÔéyČŔŕRYcź
 kétszerkettő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 kétrét
 kétrubeles/VËŻj×LÓnňéčłÄäTtYc¸źl
 kétpólus/UĘŽiÖKŇmôáyÇżßSsvcť
-kétpártrendszer/VËŻj×LÓnňéyČŔŕRYcź
+kétpártrendszer/VËŻj×LÓnňéyČŔŕRYcźét|párt||rendszer
 kétpercenként
 kétpennys/VËŻj×LÓnňéčłÄäTtYc¸źlét|pen-nys
 kétoldalt
@@ -27104,7 +27144,7 @@ kétezerzłotys/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kétezerschillinges/VËŻj×LÓnňéčłÄäTtYc¸źl
 kétezerrubeles/VËŻj×LÓnňéčłÄäTtYc¸źl
 kétezerforintos/UĘŽiÖKŇmôáç˛ĂăSscˇťk
-kétezerfelé
+kétezerfeléét|ezer||felé
 kétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
 kéteurós/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kétesztendőnként
@@ -27117,7 +27157,7 @@ kétbillió/ĎŇŐAUÚQbci	étbillióan
 kétbilliárd/mÖKkUÚQbci
 kétannyian
 kétannyi/UŐĎŇ
-két-hárommillió/ĎŇŐAUÚQbcw
+két-hárommillió/ĎŇŐAUÚQbcw	ét-három|millió
 két-három
 két/bhcÜa
 későbbre/D)ésőbb
@@ -27136,7 +27176,6 @@ készáru/ŐAUQĘŽiĎŇáyÇżßYcť
 késztermék/VËŻj×LÓnňéčłÄäTtYc¸źl
 készség/VËŻj×LÓnňéčłÄäTtYc¸źl	ph:késség
 készruha/ŐAUQĘŽiĎŇáyÇżßYcť
-készpénzár/UmôŇyiYcÇ	észpénzárak
 készpénz/VËŻj×LÓnňéyČŔŕTtYcź
 készletfeltöltés/VËŻj×LÓnňéčłÄäTtYc¸źl
 készlet/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -27221,7 +27260,7 @@ képmező/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 képléc/VËŻj×LÓnňéyČŔŕTtYcź
 képlet/VËŻj×LÓnňéčłÄäTtYc¸źl
 képkiállítás/UĘŽiÖKŇmôáyÇżßSsYcť
-képjelírás/UĘŽiÖKŇmôáyÇżßSsYcť
+képjelírás/UĘŽiÖKŇmôáyÇżßSsYcťép|jel||írás
 képfelbontás/UĘŽiÖKŇmôáyÇżßSsYcť
 képfaragó/ŐAUQĘŽiĎŇáyÇżßYcť
 képest
@@ -27239,19 +27278,19 @@ kénytelen-kelletlen
 kényszerültség/VËŻj×LÓnňéčłÄäTtYc¸źl
 kényszerül
 kényszerítőzés/VËŻj×LÓnňéčłÄäTtYc¸źl
-kényszerzubbony/UĘŽiÖKŇmôáyÇżßSsYcť
+kényszerzubbony/UĘŽiÖKŇmôáyÇżßSsYcťény|szer||zubbony
 kényszernyugdíjaz
-kényszermunka/ŐAUQĘŽiĎŇáyÇżßYcť
+kényszermunka/ŐAUQĘŽiĎŇáyÇżßYcťény|szer||munka
 kényszerképzet/VËŻj×LÓnňéčłÄäTtYc¸źl
 kényszerit/w
-kényszerhelyzet/VËŻj×LÓnňéyČŔŕTtYcź
+kényszerhelyzet/VËŻj×LÓnňéyČŔŕTtYcźény|szer||helyzet
 kényszer/VËŻj×LÓnňéyČŔŕTtYcź
 kényesül
 kényeskedő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 kényeskedés/VËŻj×LÓnňéčłÄäTtYc¸źl
 kényelem/VnňčjYcŻl	ényelmek
 kény/VËŻj×LÓnňéčłÄäTtYc¸ź
-kénvirággomba/ŐAUQĘŽiĎŇáyÇżßYcť
+kénvirággomba/ŐAUQĘŽiĎŇáyÇżßYcťén|virág||gomba
 kéntelenítés/VËŻj×LÓnňéčłÄäTtYc¸źl
 kénsav/UmôŇyiYcÇQ	énsavak
 kénkő/WŢŘÔyjYcČ	énkövek
@@ -27422,13 +27461,13 @@ kálium/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kálisó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 káliszappan/UĘŽiÖKŇmôáyÇżßQSsYcť
 kálisalétrom/UĘŽiÖKŇmôáyÇżßSsvcť
-káliműtrágya/ŐAUQĘŽiĎŇáyÇżßYcť
+káliműtrágya/ŐAUQĘŽiĎŇáyÇżßYcťáli||mű|trágya
 kálilúg/UĘŽiÖKŇmôáyÇżßQYcť
-káliföldpát/UĘŽiÖKŇmôáyÇżßQYcť
+káliföldpát/UĘŽiÖKŇmôáyÇżßQYcťáli||föld|pát
 kákabél/VÓnňyjYcČ	ákabelek
 káka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 káinbélyeg/VËŻj×LÓnňéyČŔŕRTtYcź
-kádárműhely/VËŻj×LÓnňéyČŔŕTtYcź
+kádárműhely/VËŻj×LÓnňéyČŔŕTtYcźádár||mű|hely
 kádármunka/ŐAUQĘŽiĎŇáyÇżßYcť
 kádárkés/VËŻj×LÓnňéčłÄäTtYc¸źl
 kádárizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -27445,7 +27484,7 @@ kábulás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kábulat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kábul
 kábszer/VËŻj×LÓnňéyČŔŕTtYcź
-kábeltávirat/UĘŽiÖKŇmôáyÇżßSsYcť
+kábeltávirat/UĘŽiÖKŇmôáyÇżßSsYcťábel||táv|irat
 kábelnet/VËŻj×LÓnňéyČŔŕRTtYcź
 kábellerakás/UĘŽiÖKŇmôáyÇżßSsYcť
 kábelez
@@ -27464,6 +27503,7 @@ kvittek
 kvitt
 kvintillió/AUŐĎŇKkQcˇĂżçÚ
 kvintilliárd/AUÖmŇKkQcˇĂżçÚ
+kvintilis/VËŻj×LÓnňéčłÄäTtYc¸źl
 kvintett/VËŻj×LÓnňéčłÄäRYc¸źl
 kvinteszencia/ŐAUQĘŽiĎŇáç˛Ăăcˇťw
 kvintesszencia/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -27471,11 +27511,12 @@ kvint/VËŻj×LÓnňéčłÄäRYc¸ź
 kvietál
 kvietizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kviddics/VËŻj×LÓnňéčłÄäTtvc¸źl
-kvesztúra/ŐAUQĘŽiĎŇáyÇżßYcť
+kvesztúra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kvazár/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 kvaternió/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kvaterkázik
 kvasszia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+kvartilis/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäTtYcˇť¸źkl
 kvartett/VËŻj×LÓnňéčłÄäRYc¸źl
 kvart/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 kvark/UĘŽiÖKŇmôáç˛ĂăQvcˇť
@@ -27688,13 +27729,13 @@ kultúrnövény/VËŻj×LÓnňéčłÄäTtYc¸źl
 kultúrnép/VËŻj×LÓnňéyČŔŕRYcź
 kultúrnyelv/VËŻj×LÓnňéyČŔŕTtYcź
 kultúrnemzet/VËŻj×LÓnňéyČŔŕRYcź
-kultúrműsor/UĘŽiÖKŇmôáyÇżßSsYcť
+kultúrműsor/UĘŽiÖKŇmôáyÇżßSsYcťúr||mű|sor
 kultúrmérnök/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 kultúrmunka/ŐAUQĘŽiĎŇáyÇżßYcť
 kultúrmocsok/UmôyiYcŽ	úrmocskok
 kultúrmadzag/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 kultúrközösség/VËŻj×LÓnňéyČŔŕTtYcź
-kultúrközpont/UĘŽiÖKŇmôáyÇżßQYcť
+kultúrközpont/UĘŽiÖKŇmôáyÇżßQYcťúr||köz|pont
 kultúrkör/WĚŻjŘMÝňÔíyČÁ˙RYc˝
 kultúrkincs/VËŻj×LÓnňéyČŔŕTtYcź
 kultúrkapcsolat/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -27739,7 +27780,7 @@ kulissza/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kulipintyó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kulimász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kuli/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-kulcsár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+kulcsár/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 kulcstábla/ŐAUQĘŽiĎŇáyÇżßYcť
 kulcsosház/UmôŇyiYcÇ	ázak
 kulcslyuk/UmôŇyiYcÇQ
@@ -27970,7 +28011,7 @@ kozmetika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kozmaolaj/UmôŇyiYcÇĘŽÖKáżßSsť
 kovász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kovácsoltvas/UmôŇyiYcÇ	ácsoltvasak
-kovácsműhely/×VËŻjLÓnňéyČŔŕTtYcź
+kovácsműhely/×VËŻjLÓnňéyČŔŕTtYcźács||mű|hely
 kovács/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kovariancia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kovandpörk/WĚŻjŘMÝňÔíyČÁ˙RYc˝
@@ -28125,6 +28166,7 @@ korlát/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 korlatozó/w
 korifeus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 koriander/VËŻj×LÓnňéčłÄäRTtYc¸źl
+kori/ŐAUQĘŽiĎŇáç˛Ăăcˇť
 korhatár/UĘŽiÖKŇmôáyÇżßSsYcť
 korhadó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 korhadék/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -28158,7 +28200,6 @@ koraérés/VËŻj×LÓnňéyČŔŕTtYcź
 koraszülött/WĚŻjŘMÝňÔíyČÁ˙RYc˝
 koraszülés/VËŻj×LÓnňéyČŔŕTtYcź
 korallzátony/UĘŽiÖKŇmôáyÇżßSsYcť
-korallszilfa/ŐAUQĘŽiĎŇáyÇżßYcť
 korallsziget/VËŻj×LÓnňéyČŔŕTtYcź
 korallpiros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 korall/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -28171,6 +28212,7 @@ kopásgödör/WÝyjYcŻ	ásgödrök
 kopácsol
 kopács/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kopulál
+kopuláció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kopula/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 koprodukció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 koprocesszor/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -28416,7 +28458,7 @@ komámuram/UŇŮm
 komámasszony/UĘŽiÖKŇmôáyÇżßSsYcť
 kompót/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kompánia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-komputertomográf/UĘŽiÖKŇmôáyÇżßQYcť
+komputertomográf/UĘŽiÖKŇmôáyÇżßQYcťáf
 komputer/VËŻj×LÓnňéčłÄäTtYc¸źl
 komprádor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kompromisszum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -28459,6 +28501,7 @@ kompatibilitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kompasz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 komparátor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 komparativizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+kompaktor/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kompaktlemez/VËŻj×LÓnňéyČŔŕTtYcź
 komp/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 komorul
@@ -28507,6 +28550,7 @@ komfort/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 komcsi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kombájn/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kombiné/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+kombinátor/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kombinát/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kombináció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kombinatorika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -28538,6 +28582,7 @@ kolonizáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kolonializmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kolonialista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kolonc/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+kolompár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kolompol
 kolomp/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kolokán/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -28633,7 +28678,7 @@ kocsord/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kocsonyásgomba/ŐAUQĘŽiĎŇáyÇżßYcť
 kocsonya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kocsmáz
-kocsmárosné/ŐAUBVLQRĘŽËŻijĎĐÓáéyÇżßČYcťź
+kocsmárosné/ŐAUBVLQRĘŽËŻijĎĐÓáéçč˛łÄäĂăYcˇť¸ź
 kocsmáros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kocsmabelső/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 kocsma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -28712,7 +28757,7 @@ klór/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 klón/UĘŽiÖKŇmôáç˛ĂăQYcˇť	ph:clone*
 klívia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 klíring/VËŻj×LÓnňéčłÄäRYc¸źl
-klímatérkép/VËŻj×LÓnňéyČŔŕTtYcź
+klímatérkép/VËŻj×LÓnňéyČŔŕTtYcźíma||tér|kép
 klíma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 klérus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kláris/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -28990,13 +29035,13 @@ kisértem/w
 kisértekezés/VËŻj×LÓnňéyČŔŕTtYcź
 kisértek/w
 kisért/wEeŞŚ¤Ź
-kisárutermelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-kisárutermelés/VËŻj×LÓnňéyČŔŕTtYcź
+kisárutermelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝áru|termelő
+kisárutermelés/VËŻj×LÓnňéyČŔŕTtYcźáru|termelés
 kisárusítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kisárus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-kisáruház/UmôŇyiYcÇ	áruházak
-kisállattenyésztő/ŐCWRĚŻjŢÔíyČÁ˙c˝
-kisállattenyésztés/VËŻj×LÓnňéyČŔŕTtcź
+kisáruház/UmôŇyiYcÇ	áruházakáru|ház
+kisállattenyésztő/ŐCWRĚŻjŢÔíyČÁ˙c˝állat||tenyésztő
+kisállattenyésztés/VËŻj×LÓnňéyČŔŕTtcźállat||tenyésztés
 kisállattartás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kisállat/UĘŽiÖKŇmôáyÇżßQSsYcť
 kisállamok/UŇŮm
@@ -29026,11 +29071,11 @@ kiszabadítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kisvíz/VÓnňyjYcČ
 kisvártatva
 kisváros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-kisváltósúly/UĘŽiÖKŇmôáyÇżßSsYcť
+kisváltósúly/UĘŽiÖKŇmôáyÇżßSsYcťáltó|súly
 kisvállalkozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kisvállalkozás/UĘŽiÖKŇmôáyÇżßSsYcť
 kisvállalat/UĘŽiÖKŇmôáyÇżßSsYcť
-kisvilágbajnok/UĘŽiÖKŇmôáyÇżßSsYcť
+kisvilágbajnok/UĘŽiÖKŇmôáyÇżßSsYcťág|bajnok
 kisvendéglő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 kisvasút/UmôŇyiYcÇQ	út
 kisvasárnap/UĘŽiÖKŇmôáyÇżßQYcť
@@ -29051,7 +29096,7 @@ kistermelés/VËŻj×LÓnňéyČŔŕTtYcź
 kisterem/VnňyjYcŻ
 kistengely/VËŻj×LÓnňéčłÄäTtYc¸źl
 kistelepülés/VËŻj×LÓnňéčłÄäTtYc¸źl
-kisteherautó/ŐAUQĘŽiĎŇáyÇżßYcť
+kisteherautó/ŐAUQĘŽiĎŇáyÇżßYcťó
 kistanár/UĘŽiÖKŇmôáyÇżßQSsYcť
 kistafírozás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kissé
@@ -29063,10 +29108,12 @@ kisszámítógép/VËŻj×LÓnňéyČŔŕRTtYcźá-mí-tó|gép
 kisszoba/ŐAUQĘŽiĎŇáyÇżßYcť
 kissorozat-gyártás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kisrádió/ŐAUQĘŽiĎŇáyÇżßYcť
+kisrepülőgép/VËŻj×LÓnňéyČŔŕRTtYcźülő|gép
+kisrepülő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 kisregény/VËŻj×LÓnňéyČŔŕTtYcź
 kispörkölt/VNËŻj×LÝňÔéyČŔŕRYcź
 kispárna/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-kispárlófű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	árlófüvek
+kispárlófű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	árlófüvekárló|fű
 kispálya/ŐAUQĘŽiĎŇáyÇżßYcť
 kispuska/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kispróza/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -29090,7 +29137,7 @@ kisnovella/ŐAUQĘŽiĎŇáyÇżßYcť
 kisnemesség/VËŻj×LÓnňéčłÄäTtYc¸źl
 kisnemes/VËŻj×LÓnňéčłÄäTtYc¸źl
 kisnadrág/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-kisműfaj/UĘŽiÖKŇmôáyÇżßSsYcť
+kisműfaj/UĘŽiÖKŇmôáyÇżßSsYcťű|faj
 kismértékben
 kismutató/ŐAUQĘŽiĎŇáyÇżßYcť
 kismotor/UĘŽiÖKŇmôáyÇżßQYcť
@@ -29134,7 +29181,7 @@ kiskutya/ŐAUQĘŽiĎŇáyÇżßYcť
 kiskutacs/UĘŽiÖKŇmôáyÇżßSsYcť
 kiskupola/ŐAUQĘŽiĎŇáyÇżßYcť
 kiskun/UĘŽiÖKŇmôáyÇżßQYcť
-kiskrapek/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRYcťź
+kiskrapek/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
 kiskosztüm/WĚŻjŘMÝňÔíyČÁ˙RYc˝
 kiskorunk/UŇŮm
 kiskoruk/UŇŮm
@@ -29179,10 +29226,10 @@ kishúg/UĘŽiÖKŇmôáyÇżßSsYcť
 kishold/UmôŇyiYcÇQ
 kishivatalnok/UĘŽiÖKŇmôáyÇżßSsYcť
 kishirdetés/VËŻj×LÓnňéčłÄäTtYc¸źl
-kishatárforgalom/UmôyiYcŽ	árforgalmak
-kishaszonjármű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	árművek
-kishaszongépjármű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	épjárművek
-kishaszonbérlet/VËŻj×LÓnňéyČŔŕRTtYcź
+kishatárforgalom/UmôyiYcŽ	árforgalmakár||forgalom
+kishaszonjármű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	árművekármű
+kishaszongépjármű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	épjárművekép|jármű
+kishaszonbérlet/VËŻj×LÓnňéyČŔŕRTtYcźérlet
 kishangya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kishal/UmôŇyiYcÇ
 kishajó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -29233,7 +29280,7 @@ kiselefánt/UĘŽiÖKŇmôáyÇżßQYcť
 kisegítő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 kisegér/VÓnňyjYcČ
 kisegyüttes/VËŻj×LÓnňéyČŔŕTtYcź
-kisegyház/UmôŇyiYcÇ	ázak
+kisegyház/UmôŇyiYcÇ	ázakáz
 kisebbségrendűség/wYVËŻj×LÓnňéčłÄäTtc¸źl
 kisebbség/VËŻj×LÓnňéčłÄäTtYc¸źl
 kisebbszerű/ŢÔŐCHMWR
@@ -29301,7 +29348,7 @@ királyka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 királygyilkosság/UĘŽiÖKŇmôáyÇżßSsYcť
 királyfiak/UmŇŮ)ályfi
 királyfia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-királyfi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ályfiak
+királyfi/ŐAUQĘŽiĎŇáyÇżßYcť	ályfiak
 királydinnye/ŐBVRËŻjĐÓéčłÄäYc¸ź
 királybegónia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 király/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -29440,8 +29487,8 @@ kilotesla/ŐAUQĘŽiĎŇáç˛Ăăcˇť
 kilopond/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kilopascal/UĘŽiÖKŇmôáyÇżßQYcť
 kiloohm/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-kilométeróra/ŐAUQĘŽiĎŇáyÇżßYcť
-kilométerkő/WŢŘÔyjYcČ	éterkövek
+kilométeróra/ŐAUQĘŽiĎŇáyÇżßYcťéter||óra
+kilométerkő/WŢŘÔyjYcČ	éterkövekéter||kő
 kilométer/VËŻj×LÓnňéyČŔŕRTtYcź
 kilombosodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kilokelvin/VËŻj×LÓnňéčłÄäRYc¸źl
@@ -29473,30 +29520,36 @@ kilencévi
 kilencévente
 kilencévenként
 kilencvenötödik/!VÓn×Llbh)öt
-kilencvenöttrillióan/b)öttrillió
-kilencvenöttrillió/ĎŇŐAUÚQbci	öttrillióan
-kilencvenöttrilliárd/mÖKkUÚQbci
-kilencvenötmillióan/b)ötmillió
-kilencvenötmillió/ĎŇŐAUÚQbcj	ötmillióan
-kilencvenötmilliárdan/b)ötmilliárd
-kilencvenötmilliárd/mÖKkUÚQbci	ötmilliárdan
-kilencvenötfelé
-kilencvenötezres/×BŐVb)ötezer
-kilencvenötezren/b)ötezer
-kilencvenötezrek/Ib)ötezer
-kilencvenötezredik/nÓ×BVÜb)ötezer
-kilencvenötezred/BVÜb)ötezer
-kilencvenötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred
+kilencvenöttrillióan/b)öttrillió	öt||trillióan
+kilencvenöttrillió/ĎŇŐAUÚQbci	öttrillióan	öt||trillió
+kilencvenöttrilliárd/mÖKkUÚQbci	öt||trilliárd
+kilencvenötmillióan/b)ötmillió	öt||millióan
+kilencvenötmillió/ĎŇŐAUÚQbcj	ötmillióan	öt||millió
+kilencvenötmilliárdan/b)ötmilliárd	öt||milliárdan
+kilencvenötmilliárd/mÖKkUÚQbci	ötmilliárdan	öt||milliárd
+kilencvenötfeléöt||felé
+kilencvenötezres/×BŐVb)ötezer	öt||ezres
+kilencvenötezren/b)ötezer	öt||ezren
+kilencvenötezrek/Ib)ötezer	öt||ezrek
+kilencvenötezredik/nÓ×BVÜb)ötezer	öt||ezredik
+kilencvenötezred/BVÜb)ötezer	öt||ezred
+kilencvenötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred	öt||ezer
 kilencvenöten/bh)öt
-kilencvenötbillióan/b)ötbillió
-kilencvenötbillió/ĎŇŐAUÚQbci	ötbillióan
-kilencvenötbilliárd/mÖKkUÚQbci
+kilencvenötbillióan/b)ötbillió	öt||billióan
+kilencvenötbillió/ĎŇŐAUÚQbci	ötbillióan	öt||billió
+kilencvenötbilliárd/mÖKkUÚQbci	öt||billiárd
 kilencvenöt/ÝWŰMRbhc	ötödiköten
 kilencvenóránként
 kilencvenórai
 kilencvenévi
 kilencvenévente
 kilencvenévenként
+kilencvenvalahánymillió/ĎŇŐAUÚQbcj	ány||millió
+kilencvenvalahánymilliárd/mÖKkUÚQbci	ány||milliárd
+kilencvenvalahányfeléány||felé
+kilencvenvalahányezres/×BŐVb)ányezer	ány||ezres
+kilencvenvalahányezren/b)ányezer	ány||ezren
+kilencvenvalahányezer/ŐnBVÜjbc	ányezresányezren	ány||ezer
 kilencvenvalahányan/bh))ány
 kilencvenvalahányan/bh)
 kilencvenvalahányadikak/nI))ány
@@ -29507,42 +29560,42 @@ kilencventrillióan/b)ó
 kilencventrillió/ĎŇŐAUÚQbci	óan
 kilencventrilliárd/mÖKkUÚQbci
 kilencvenpercenként
-kilencvennégytrillióan/b)égytrillió
-kilencvennégytrillió/ĎŇŐAUÚQbci	égytrillióan
-kilencvennégytrilliárd/mÖKkUÚQbci
-kilencvennégymillióan/b)égymillió
-kilencvennégymillió/ĎŇŐAUÚQbcj	égymillióan
-kilencvennégymilliárdan/b)égymilliárd
-kilencvennégymilliárd/mÖKkUÚQbci	égymilliárdan
-kilencvennégyfelé
-kilencvennégyezres/×BŐVb)égyezer
-kilencvennégyezren/b)égyezer
-kilencvennégyezrek/Ib)égyezer
-kilencvennégyezredik/nÓ×BVÜb)égyezer
-kilencvennégyezred/BVÜb)égyezer
-kilencvennégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred
+kilencvennégytrillióan/b)égytrillió	égy||trillióan
+kilencvennégytrillió/ĎŇŐAUÚQbci	égytrillióan	égy||trillió
+kilencvennégytrilliárd/mÖKkUÚQbci	égy||trilliárd
+kilencvennégymillióan/b)égymillió	égy||millióan
+kilencvennégymillió/ĎŇŐAUÚQbcj	égymillióan	égy||millió
+kilencvennégymilliárdan/b)égymilliárd	égy||milliárdan
+kilencvennégymilliárd/mÖKkUÚQbci	égymilliárdan	égy||milliárd
+kilencvennégyfeléégy||felé
+kilencvennégyezres/×BŐVb)égyezer	égy||ezres
+kilencvennégyezren/b)égyezer	égy||ezren
+kilencvennégyezrek/Ib)égyezer	égy||ezrek
+kilencvennégyezredik/nÓ×BVÜb)égyezer	égy||ezredik
+kilencvennégyezred/BVÜb)égyezer	égy||ezred
+kilencvennégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred	égy||ezer
 kilencvennégyen/bh)égy
-kilencvennégybillióan/b)égybillió
-kilencvennégybillió/ĎŇŐAUÚQbci	égybillióan
-kilencvennégybilliárd/mÖKkUÚQbci
+kilencvennégybillióan/b)égybillió	égy||billióan
+kilencvennégybillió/ĎŇŐAUÚQbci	égybillióan	égy||billió
+kilencvennégybilliárd/mÖKkUÚQbci	égy||billiárd
 kilencvennégy/nVÜLlTtbhc	égyen
-kilencvennyolctrillióan/b)ó
-kilencvennyolctrillió/ĎŇŐAUÚQbci	óan
-kilencvennyolctrilliárd/mÖKkUÚQbci
-kilencvennyolcmillióan/b)ó
-kilencvennyolcmillió/ĎŇŐAUÚQbcj	óan
-kilencvennyolcmilliárdan/b)árd
-kilencvennyolcmilliárd/mÖKkUÚQbci	árdan
-kilencvennyolcfelé
+kilencvennyolctrillióan/b)ó	óan
+kilencvennyolctrillió/ĎŇŐAUÚQbci	óan	ó
+kilencvennyolctrilliárd/mÖKkUÚQbci	árd
+kilencvennyolcmillióan/b)ó	óan
+kilencvennyolcmillió/ĎŇŐAUÚQbcj	óan	ó
+kilencvennyolcmilliárdan/b)árd	árdan
+kilencvennyolcmilliárd/mÖKkUÚQbci	árdan	árd
+kilencvennyolcfeléé
 kilencvennyolcezres/×BŐVb)
 kilencvennyolcezren/b)
 kilencvennyolcezrek/Ib)
 kilencvennyolcezredik/nÓ×BVÜb)
 kilencvennyolcezred/BVÜb)
 kilencvennyolcezer/ŐnBVÜjbc
-kilencvennyolcbillióan/b)ó
-kilencvennyolcbillió/ĎŇŐAUÚQbci	óan
-kilencvennyolcbilliárd/mÖKkUÚQbci
+kilencvennyolcbillióan/b)ó	óan
+kilencvennyolcbillió/ĎŇŐAUÚQbci	óan	ó
+kilencvennyolcbilliárd/mÖKkUÚQbci	árd
 kilencvennyolcan/bh)
 kilencvennyolcadikak/nI)
 kilencvennyolcadik/!AUÖmŇŮKkbh)
@@ -29554,32 +29607,32 @@ kilencvenmillióan/b)ó
 kilencvenmillió/ĎŇŐAUÚQbcj	óan
 kilencvenmilliárdan/b)árd
 kilencvenmilliárd/mÖKkUÚQbci	árdan
-kilencvenkéttrillióan/b)éttrillió
-kilencvenkéttrillió/ĎŇŐAUÚQbci	éttrillióan
-kilencvenkéttrilliárd/mÖKkUÚQbci
-kilencvenkétmillióan/b)étmillió
-kilencvenkétmillió/ĎŇŐAUÚQbcj	étmillióan
-kilencvenkétmilliárdan/b)étmilliárd
-kilencvenkétmilliárd/mÖKkUÚQbci	étmilliárdan
-kilencvenkétfelé
-kilencvenkétezres/×BŐVb)étezer
-kilencvenkétezren/b)étezer
-kilencvenkétezrek/Ib)étezer
-kilencvenkétezredik/nÓ×BVÜb)étezer
-kilencvenkétezred/BVÜb)étezer
-kilencvenkétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-kilencvenkétbillióan/b)étbillió
-kilencvenkétbillió/ĎŇŐAUÚQbci	étbillióan
-kilencvenkétbilliárd/mÖKkUÚQbci
+kilencvenkéttrillióan/b)éttrillió	ét||trillióan
+kilencvenkéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+kilencvenkéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+kilencvenkétmillióan/b)étmillió	ét||millióan
+kilencvenkétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+kilencvenkétmilliárdan/b)étmilliárd	ét||milliárdan
+kilencvenkétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+kilencvenkétfeléét||felé
+kilencvenkétezres/×BŐVb)étezer	ét||ezres
+kilencvenkétezren/b)étezer	ét||ezren
+kilencvenkétezrek/Ib)étezer	ét||ezrek
+kilencvenkétezredik/nÓ×BVÜb)étezer	ét||ezredik
+kilencvenkétezred/BVÜb)étezer	ét||ezred
+kilencvenkétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+kilencvenkétbillióan/b)étbillió	ét||billióan
+kilencvenkétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+kilencvenkétbilliárd/mÖKkUÚQbci	ét||billiárd
 kilencvenkét/bÜh
-kilencvenkilenctrillióan/b)ó
-kilencvenkilenctrillió/ĎŇŐAUÚQbci	óan
-kilencvenkilenctrilliárd/mÖKkUÚQbci
-kilencvenkilencmillióan/b)ó
-kilencvenkilencmillió/ĎŇŐAUÚQbcj	óan
-kilencvenkilencmilliárdan/b)árd
-kilencvenkilencmilliárd/mÖKkUÚQbci	árdan
-kilencvenkilencfelé
+kilencvenkilenctrillióan/b)ó	óan
+kilencvenkilenctrillió/ĎŇŐAUÚQbci	óan	ó
+kilencvenkilenctrilliárd/mÖKkUÚQbci	árd
+kilencvenkilencmillióan/b)ó	óan
+kilencvenkilencmillió/ĎŇŐAUÚQbcj	óan	ó
+kilencvenkilencmilliárdan/b)árd	árdan
+kilencvenkilencmilliárd/mÖKkUÚQbci	árdan	árd
+kilencvenkilencfeléé
 kilencvenkilencezres/×BŐVb)
 kilencvenkilencezren/b)
 kilencvenkilencezrek/Ib)
@@ -29588,65 +29641,65 @@ kilencvenkilencezred/BVÜb)
 kilencvenkilencezer/ŐnBVÜjbc
 kilencvenkilencen/bh)
 kilencvenkilencedik/!VÓn×Llbh)
-kilencvenkilencbillióan/b)ó
-kilencvenkilencbillió/ĎŇŐAUÚQbci	óan
-kilencvenkilencbilliárd/mÖKkUÚQbci
+kilencvenkilencbillióan/b)ó	óan
+kilencvenkilencbillió/ĎŇŐAUÚQbci	óan	ó
+kilencvenkilencbilliárd/mÖKkUÚQbci	árd
 kilencvenkilenc/nňVÜLlTtbhc
-kilencvenkettőtrillióan/b)őtrillió
-kilencvenkettőtrillió/ĎŇŐAUÚQbci	őtrillióan
-kilencvenkettőtrilliárd/mÖKkUÚQbci
-kilencvenkettőmillióan/b)őmillió
-kilencvenkettőmillió/ĎŇŐAUÚQbcj	őmillióan
-kilencvenkettőmilliárdan/b)őmilliárd
-kilencvenkettőmilliárd/mÖKkUÚQbci	őmilliárdan
-kilencvenkettőfelé
-kilencvenkettőezres/×BŐVb)őezer
-kilencvenkettőezren/b)őezer
-kilencvenkettőezrek/Ib)őezer
-kilencvenkettőezredik/nÓ×BVÜb)őezer
-kilencvenkettőezred/BVÜb)őezer
-kilencvenkettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred
-kilencvenkettőbillióan/b)őbillió
-kilencvenkettőbillió/ĎŇŐAUÚQbci	őbillióan
-kilencvenkettőbilliárd/mÖKkUÚQbci
+kilencvenkettőtrillióan/b)őtrillió	ő||trillióan
+kilencvenkettőtrillió/ĎŇŐAUÚQbci	őtrillióan	ő||trillió
+kilencvenkettőtrilliárd/mÖKkUÚQbci	ő||trilliárd
+kilencvenkettőmillióan/b)őmillió	ő||millióan
+kilencvenkettőmillió/ĎŇŐAUÚQbcj	őmillióan	ő||millió
+kilencvenkettőmilliárdan/b)őmilliárd	ő||milliárdan
+kilencvenkettőmilliárd/mÖKkUÚQbci	őmilliárdan	ő||milliárd
+kilencvenkettőfeléő||felé
+kilencvenkettőezres/×BŐVb)őezer	ő||ezres
+kilencvenkettőezren/b)őezer	ő||ezren
+kilencvenkettőezrek/Ib)őezer	ő||ezrek
+kilencvenkettőezredik/nÓ×BVÜb)őezer	ő||ezredik
+kilencvenkettőezred/BVÜb)őezer	ő||ezred
+kilencvenkettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred	ő||ezer
+kilencvenkettőbillióan/b)őbillió	ő||billióan
+kilencvenkettőbillió/ĎŇŐAUÚQbci	őbillióan	ő||billió
+kilencvenkettőbilliárd/mÖKkUÚQbci	ő||billiárd
 kilencvenkettő/ŢWŰMRbhc
 kilencvenketten/bh)ő
 kilencvenkettedik/!VÓn×Llbh)ő
-kilencvenhéttrillióan/b)éttrillió
-kilencvenhéttrillió/ĎŇŐAUÚQbci	éttrillióan
-kilencvenhéttrilliárd/mÖKkUÚQbci
-kilencvenhétmillióan/b)étmillió
-kilencvenhétmillió/ĎŇŐAUÚQbcj	étmillióan
-kilencvenhétmilliárdan/b)étmilliárd
-kilencvenhétmilliárd/mÖKkUÚQbci	étmilliárdan
-kilencvenhétfelé
-kilencvenhétezres/×BŐVb)étezer
-kilencvenhétezren/b)étezer
-kilencvenhétezrek/Ib)étezer
-kilencvenhétezredik/nÓ×BVÜb)étezer
-kilencvenhétezred/BVÜb)étezer
-kilencvenhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-kilencvenhétbillióan/b)étbillió
-kilencvenhétbillió/ĎŇŐAUÚQbci	étbillióan
-kilencvenhétbilliárd/mÖKkUÚQbci
+kilencvenhéttrillióan/b)éttrillió	ét||trillióan
+kilencvenhéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+kilencvenhéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+kilencvenhétmillióan/b)étmillió	ét||millióan
+kilencvenhétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+kilencvenhétmilliárdan/b)étmilliárd	ét||milliárdan
+kilencvenhétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+kilencvenhétfeléét||felé
+kilencvenhétezres/×BŐVb)étezer	ét||ezres
+kilencvenhétezren/b)étezer	ét||ezren
+kilencvenhétezrek/Ib)étezer	ét||ezrek
+kilencvenhétezredik/nÓ×BVÜb)étezer	ét||ezredik
+kilencvenhétezred/BVÜb)étezer	ét||ezred
+kilencvenhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+kilencvenhétbillióan/b)étbillió	ét||billióan
+kilencvenhétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+kilencvenhétbilliárd/mÖKkUÚQbci	ét||billiárd
 kilencvenhét/nVÜbhc
-kilencvenháromtrillióan/b)áromtrillió
-kilencvenháromtrillió/ĎŇŐAUÚQbci	áromtrillióan
-kilencvenháromtrilliárd/mÖKkUÚQbci
-kilencvenhárommillióan/b)árommillió
-kilencvenhárommillió/ĎŇŐAUÚQbcj	árommillióan
-kilencvenhárommilliárdan/b)árommilliárd
-kilencvenhárommilliárd/mÖKkUÚQbci	árommilliárdan
-kilencvenháromfelé
-kilencvenháromezres/×BŐVb)áromezer
-kilencvenháromezren/b)áromezer
-kilencvenháromezrek/Ib)áromezer
-kilencvenháromezredik/nÓ×BVÜb)áromezer
-kilencvenháromezred/BVÜb)áromezer
-kilencvenháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred
-kilencvenhárombillióan/b)árombillió
-kilencvenhárombillió/ĎŇŐAUÚQbci	árombillióan
-kilencvenhárombilliárd/mÖKkUÚQbci
+kilencvenháromtrillióan/b)áromtrillió	árom||trillióan
+kilencvenháromtrillió/ĎŇŐAUÚQbci	áromtrillióan	árom||trillió
+kilencvenháromtrilliárd/mÖKkUÚQbci	árom||trilliárd
+kilencvenhárommillióan/b)árommillió	árom||millióan
+kilencvenhárommillió/ĎŇŐAUÚQbcj	árommillióan	árom||millió
+kilencvenhárommilliárdan/b)árommilliárd	árom||milliárdan
+kilencvenhárommilliárd/mÖKkUÚQbci	árommilliárdan	árom||milliárd
+kilencvenháromfeléárom||felé
+kilencvenháromezres/×BŐVb)áromezer	árom||ezres
+kilencvenháromezren/b)áromezer	árom||ezren
+kilencvenháromezrek/Ib)áromezer	árom||ezrek
+kilencvenháromezredik/nÓ×BVÜb)áromezer	árom||ezredik
+kilencvenháromezred/BVÜb)áromezer	árom||ezred
+kilencvenháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred	árom||ezer
+kilencvenhárombillióan/b)árombillió	árom||billióan
+kilencvenhárombillió/ĎŇŐAUÚQbci	árombillióan	árom||billió
+kilencvenhárombilliárd/mÖKkUÚQbci	árom||billiárd
 kilencvenhárom/mUÚbhc	ármanármak
 kilencvenhárman/bh)árom
 kilencvenhármak/Ibh)árom
@@ -29659,25 +29712,25 @@ kilencvenhetedik/!VÓn×Llbh)ét
 kilencvenhavonta
 kilencvenhavonként
 kilencvenhavi
-kilencvenhattrillióan/b)ó
-kilencvenhattrillió/ĎŇŐAUÚQbci	óan
-kilencvenhattrilliárd/mÖKkUÚQbci
+kilencvenhattrillióan/b)ó	óan
+kilencvenhattrillió/ĎŇŐAUÚQbci	óan	ó
+kilencvenhattrilliárd/mÖKkUÚQbci	árd
 kilencvenhatodikak/nI)
 kilencvenhatodik/!AUÖmŇŮKkbh)
-kilencvenhatmillióan/b)ó
-kilencvenhatmillió/ĎŇŐAUÚQbcj	óan
-kilencvenhatmilliárdan/b)árd
-kilencvenhatmilliárd/mÖKkUÚQbci	árdan
-kilencvenhatfelé
+kilencvenhatmillióan/b)ó	óan
+kilencvenhatmillió/ĎŇŐAUÚQbcj	óan	ó
+kilencvenhatmilliárdan/b)árd	árdan
+kilencvenhatmilliárd/mÖKkUÚQbci	árdan	árd
+kilencvenhatfeléé
 kilencvenhatezres/×BŐVb)
 kilencvenhatezren/b)
 kilencvenhatezrek/Ib)
 kilencvenhatezredik/nÓ×BVÜb)
 kilencvenhatezred/BVÜb)
 kilencvenhatezer/ŐnBVÜjbc
-kilencvenhatbillióan/b)ó
-kilencvenhatbillió/ĎŇŐAUÚQbci	óan
-kilencvenhatbilliárd/mÖKkUÚQbci
+kilencvenhatbillióan/b)ó	óan
+kilencvenhatbillió/ĎŇŐAUÚQbci	óan	ó
+kilencvenhatbilliárd/mÖKkUÚQbci	árd
 kilencvenhatan/bh)
 kilencvenhat/mUÚKkbhc
 kilencvenharmadikak/nI)árom
@@ -29693,14 +29746,14 @@ kilencvenesztendőnként
 kilencvenesztendei
 kilencvenes/VÓnň×DGTtabh
 kilencvenen/bh)
-kilencvenegytrillióan/b)ó
-kilencvenegytrillió/ĎŇŐAUÚQbci	óan
-kilencvenegytrilliárd/mÖKkUÚQbci
-kilencvenegymillióan/b)ó
-kilencvenegymillió/ĎŇŐAUÚQbcj	óan
-kilencvenegymilliárdan/b)árd
-kilencvenegymilliárd/mÖKkUÚQbci	árdan
-kilencvenegyfelé
+kilencvenegytrillióan/b)ó	óan
+kilencvenegytrillió/ĎŇŐAUÚQbci	óan	ó
+kilencvenegytrilliárd/mÖKkUÚQbci	árd
+kilencvenegymillióan/b)ó	óan
+kilencvenegymillió/ĎŇŐAUÚQbcj	óan	ó
+kilencvenegymilliárdan/b)árd	árdan
+kilencvenegymilliárd/mÖKkUÚQbci	árdan	árd
+kilencvenegyfeléé
 kilencvenegyezres/×BŐVb)
 kilencvenegyezren/b)
 kilencvenegyezrek/Ib)
@@ -29709,9 +29762,9 @@ kilencvenegyezred/BVÜb)
 kilencvenegyezer/ŐnBVÜjbc
 kilencvenegyen/bh)
 kilencvenegyedik/VÓn×Llbh)
-kilencvenegybillióan/b)ó
-kilencvenegybillió/ĎŇŐAUÚQbci	óan
-kilencvenegybilliárd/mÖKkUÚQbci
+kilencvenegybillióan/b)ó	óan
+kilencvenegybillió/ĎŇŐAUÚQbci	óan	ó
+kilencvenegybilliárd/mÖKkUÚQbci	árd
 kilencvenegy/nVÜLlbhc
 kilencvenedszerre/bh)
 kilencvenedszeri/bh
@@ -29728,14 +29781,14 @@ kilencven/VÓn×LlTtcÜbh
 kilenctrillióan/b)ó
 kilenctrillió/ĎŇŐAUÚQbci	óan
 kilenctrilliárd/mÖKkUÚQbci
-kilencszázfelé
-kilencszázezres/×BŐV
-kilencszázezrek/I)ázezer
-kilencszázas/AFUÚ)áz
-kilencszázan/)áz
-kilencszázadik/mŇŮAUÚ)áz
-kilencszázad/AUÚ)áz
-kilencszáz/$UŮÖmŇSscÚ	ázasázanázadikázadázasázadikázad
+kilencszázfeléáz||felé
+kilencszázezres/×BŐV	áz||ezres
+kilencszázezrek/I)ázezer	áz||ezrek
+kilencszázas/AFUÚ)áz	ázas
+kilencszázan/)ázázan
+kilencszázadik/mŇŮAUÚ)áz	ázadik
+kilencszázad/AUÚ)áz	ázad
+kilencszáz/$UŮÖmŇSscÚ	ázasázanázadikázad	áz
 kilencpercenként
 kilencnaponta
 kilencnaponként
@@ -29756,7 +29809,7 @@ kilencezrek/Ibac)
 kilencezrek/Ibac)
 kilencezredik/nÓ×BVÜb)
 kilencezred/BVÜb)
-kilencezerfelé
+kilencezerfeléé
 kilencezer/ŐnBVÜjbcÓ×LlTts
 kilencesztendőnként
 kilencesztendei
@@ -29775,13 +29828,13 @@ kilencediki/BVÓŐĐś)
 kilencedikes/VËŻj×LÓnňéčłÄäTtYc¸źl
 kilencedike/BVÓŐĐś)
 kilencedik/c!VÓn×Llabh)
-kilencedféltrillió/AUŐĎŇKQxcˇĂżÇ
-kilencedfélszázad/AUÖmŇKkQcˇĂżÇ
-kilencedfélszáz/$UŮÖmŇSscÇ
-kilencedfélmillió/AUŐĎŇKQxcˇĂżÇ
-kilencedfélmilliárd/AUÖmŇKkQcˇĂżÇ
-kilencedfélezer/VÓn×LlTtcČ
-kilencedfélbillió/AUŐĎŇKQxcˇĂżÇ
+kilencedféltrillió/AUŐĎŇKQxcˇĂżÇ	él||trillió
+kilencedfélszázad/AUÖmŇKkQcˇĂżÇ	él||század
+kilencedfélszáz/$UŮÖmŇSscÇ	él||száz
+kilencedfélmillió/AUŐĎŇKQxcˇĂżÇ	él||millió
+kilencedfélmilliárd/AUÖmŇKkQcˇĂżÇ	él||milliárd
+kilencedfélezer/VÓn×LlTtcČ	él||ezer
+kilencedfélbillió/AUŐĎŇKQxcˇĂżÇ	él||billió
 kilencedfél/VÓnňyjYcČ)él	él
 kilencedannyian
 kilencedannyi/UŐĎŇ
@@ -29789,7 +29842,7 @@ kilenced/VÄÓn×LlRjTtabhz!)
 kilencbillióan/b)ó
 kilencbillió/ĎŇŐAUÚQbci	óan
 kilencbilliárd/mÖKkUÚQbci
-kilenc-tízmillió/ĎŇŐAUÚQbcw
+kilenc-tízmillió/ĎŇŐAUÚQbcw	íz|millió
 kilenc/nňVÜLlTtbhcÓ×a
 kiküldetés/VËŻj×LÓnňéčłÄäTtYc¸źl
 kiközösítés/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -30157,7 +30210,7 @@ kettőtrilliárd/mÖKkUÚQbci
 kettőszázas/AFUÚ)őszáz
 kettőszázadik/mŇŮAUÚ)őszáz
 kettőszázad/AUÚ)őszáz
-kettőszáz/$UŮÖmŇSsÚ	őszázasőszázadikőszázadőszázasőszázadikőszázad
+kettőszáz/$UŮÖmŇSsÚ	őszázasőszázadikőszázad
 kettőspont/UĘŽiÖKŇmôáyÇżßQYcť
 kettősnyelvűség/VËŻj×LÓnňéyČŔŕTtYcź
 kettőskúp/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -30236,10 +30289,10 @@ kerítő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 kerékvágás/UĘŽiÖKŇmôáyÇżßSsYcť
 keréktávolság/UĘŽiÖKŇmôáyÇżßSsYcť
 kerékpárút/UmôŇyiYcÇQ	ékpárutak
-kerékpárpálya/ŐAUQĘŽiĎŇáyÇżßYcť
+kerékpárpálya/ŐAUQĘŽiĎŇáyÇżßYcťék|pár||pálya
 kerékpározik
 kerékpáros/UĘŽiÖKŇmôáyÇżßSsYcť
-kerékpárkormány/UĘŽiÖKŇmôáyÇżßSsYcť
+kerékpárkormány/UĘŽiÖKŇmôáyÇżßSsYcťék|pár||kormány
 kerékpárbelső/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ék|pár||belső
 kerékpár/UĘŽiÖKŇmôáyÇżßQYcť
 keréklapát/UĘŽiÖKŇmôáyÇżßQYcť
@@ -30266,7 +30319,7 @@ keringő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 kergül
 kergetőzik
 kergetődzik
-kergemarhakór/UĘŽiÖKŇmôáyÇżßQYcť
+kergemarhakór/UĘŽiÖKŇmôáyÇżßQYcťór
 kergekór/UĘŽiÖKŇmôáyÇżßQYcť
 kerevet/VËŻj×LÓnňéčłÄäRTtYc¸źl
 kerettartó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -30329,7 +30382,7 @@ keresztes/VËŻj×LÓnňéčłÄäTtYc¸źl
 keresztelőkút/UmôŇyiYcÇQ	őkutak
 keresztelő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 keresztcsőrű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-keresztcsontfájás/UĘŽiÖKŇmôáyÇżßSsYcť
+keresztcsontfájás/UĘŽiÖKŇmôáyÇżßSsYcťájás
 keresztcsont/UĘŽiÖKŇmôáyÇżßQYcť
 keresztboltozat/UĘŽiÖKŇmôáyÇżßSsYcť
 keresztaty/uQ)
@@ -30394,7 +30447,7 @@ kenyérhéj/VÓnňyjYcČ	érhéjak
 kenyérgabona/ŐAUQĘŽiĎŇáyÇżßYcť
 kenyérfa/ŐAUQĘŽiĎŇáyÇżßYcť
 kenyérdarabka/ŐAUQĘŽiĎŇáyÇżßYcť
-kenyérbélvirág/UĘŽiÖKŇmôáyÇżßSsYcť
+kenyérbélvirág/UĘŽiÖKŇmôáyÇżßSsYcťér|bél||virág
 kenyérbél/VÓnňyjYcČ	érbelek
 kenyér/VÓnňčjYcłl
 kenyereslány/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -30658,6 +30711,7 @@ kaucsuk/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kaució/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 katód/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 katéter/VËŻj×LÓnňéčłÄäTtYc¸źl
+katázik
 katángkóró/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 katáng/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 katzenjammer/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -30794,7 +30848,7 @@ karmazsinbogár/UmôŇyiYcÇ
 karmazsinbogyó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 karmantyú/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 karma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-karkötőóra/ŐAUQĘŽiĎŇáyÇżßYcť
+karkötőóra/ŐAUQĘŽiĎŇáyÇżßYcťötő||óra
 karkötő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 karizom/UmôyiYcŽ
 karizma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -30810,7 +30864,7 @@ kariatida/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 karhatalom/UmôyiYcŽ
 karhatalmista/ŐAUQĘŽiĎŇáyÇżßYcť
 karfiol/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-karfatartó/ŐAUQĘŽiĎŇáyÇżßYcť
+karfatartó/ŐAUQĘŽiĎŇáyÇżßYcťó
 karfa/ŐAUQĘŽiĎŇáyÇżßYcť
 kardántengely/VËŻj×LÓnňéyČŔŕTtYcź
 kardáncsukló/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -30895,7 +30949,7 @@ kapuzat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kapusfülke/ŐBVRËŻjĐÓéčłÄäYc¸ź
 kapus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kapukulcs/UĘŽiÖKŇmôáyÇżßSsYcť
-kapufélfa/ŐAUQĘŽiĎŇáyÇżßYcť
+kapufélfa/ŐAUQĘŽiĎŇáyÇżßYcťél|fa
 kapufa/ŐAUQĘŽiĎŇáyÇżßYcť
 kapucíner/VËŻj×LÓnňéčłÄäRTtYc¸źl
 kapucsínó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ph:capuccino
@@ -31151,7 +31205,7 @@ kaland/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 kalamáris/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kalamitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kalamajka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-kakukkszegfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvek
+kakukkszegfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvekű
 kakukkol
 kakukkfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvek
 kakukk/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -31165,7 +31219,7 @@ kakaó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kakasviadal/UĘŽiÖKŇmôáyÇżßSsYcť
 kakastaréj/UĘŽiÖKŇmôáyÇżßSsYcť
 kakasmandikó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-kakaslábfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ábfüvek
+kakaslábfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ábfüvekáb||fű
 kakas/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 kakadu/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 kaka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť=
@@ -31637,7 +31691,7 @@ jászellenesség/VËŻj×LÓnňéyČŔŕTtYcź
 jászcentrikusság/UĘŽiÖKŇmôáyÇżßSsYcť
 jászbarátság/UĘŽiÖKŇmôáyÇżßSsYcť
 jászabb/mAD$UŮŇQ
-jász/UĘŽiÖKŇmôáçĂăSscY
+jász/UĘŽiÖKŇmôáçĂăSsvc
 jáspiskő/WŢŘÔyjYcČ	áspiskövek
 jáspis/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 járőr/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
@@ -31646,7 +31700,7 @@ járó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 járásmód/UĘŽiÖKŇmôáyÇżßQYcť
 járásjelentés/VËŻj×LÓnňéyČŔŕTtYcź
 járásbíróság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-járványkórház/UmôŇyiYcÇ	árványkórházak
+járványkórház/UmôŇyiYcÇ	árványkórházakárvány||kór|ház
 járvány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 járulék/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 jártunk/UŇmŮ)árta
@@ -31787,7 +31841,7 @@ jog/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
 jodát/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 jodoform/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 jodid/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
-jobbösszekötő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+jobbösszekötő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝össze|kötő
 jobbítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 jobbátlövő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 jobbára
@@ -31805,12 +31859,13 @@ jobboldalt
 jobboldal/UmôŇyiYcÇ
 jobblét/VËŻj×LÓnňéyČŔŕRYcź
 jobbközép/VÓnňyjYcČËŻ×LéŔŕRź	özepek
-jobbkéz-szabály/UĘŽiÖKŇmôáyÇżßSscť
+jobbkéz-szabály/UĘŽiÖKŇmôáyÇżßSscťéz-szabály
 jobbkezes/VËŻj×LÓnňéyČŔŕTtYcź
 jobbkeze/VÓŐĐ
 jobbkanyar/UĘŽiÖKŇmôáyÇżßQYcť
 jobbik/ŮmŇUDSs)ó
-jobbhátvéd/VËŻj×LÓnňéyČŔŕRYcź
+jobbhátvéd/VËŻj×LÓnňéyČŔŕRYcźát|véd
+jobbhorog/UmôyiYcŽQ
 jobbfedezet/VËŻj×LÓnňéyČŔŕTtYcź
 jobbegyenes/VËŻj×LÓnňéyČŔŕTtYcź
 jobban/D)ó
@@ -31848,7 +31903,7 @@ jelzőkaró/ŐAUQĘŽiĎŇáyÇżßYcť
 jelzőberendezés/VËŻj×LÓnňéyČŔŕTtYcź
 jelző/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X)Ó_PRESPART_adj
 jelző/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X
-jelzésrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+jelzésrendszer/VËŻj×LÓnňéyČŔŕTtYcźés||rend|szer
 jelzés/XVËŻj×LÓnňéčłÄäTtYc¸źl)Ás_PROCESS/RESULT_noun
 jelzés/XVËŻj×LÓnňéčłÄäTtYc¸źl
 jelzálog/UĘŽiÖKŇmôáyÇżßQSsYcť
@@ -31906,7 +31961,7 @@ jelen/VËŻj×LÓnňéčłÄäTtYc¸źl
 jelelés/VËŻj×LÓnňéčłÄäTtYc¸źl
 jelbeütő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 jelbeszéd/VËŻj×LÓnňéyČŔŕRTtYcź
-jeladókészülék/VËŻj×LÓnňéyČŔŕTtYcź
+jeladókészülék/VËŻj×LÓnňéyČŔŕTtYcźó||készülék
 jeladó/ŐAUQĘŽiĎŇáyÇżßYcť
 jeladás/UĘŽiÖKŇmôáyÇżßSsYcť
 jel/VËŻj×LÓnňéčłÄäTtYc¸ź
@@ -31926,13 +31981,13 @@ jegyzet/VËŻj×LÓnňéčłÄäTtYc¸źl
 jegyzendő/CÔŐŢDHWRMX)Ó_FUTPART_adj
 jegyz.
 jegyváltás/UĘŽiÖKŇmôáyÇżßSsYcť
-jegypénztár/UmôŇyiYcÇ	énztárak
+jegypénztár/UmôŇyiYcÇ	énztárakénz|tár
 jegylyukasztó/ŐAUQĘŽiĎŇáyÇżßYcť
 jegylyukasztás/UĘŽiÖKŇmôáyÇżßSsYcť
 jegygyűrű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 jegyespár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 jegyesoktatás/UĘŽiÖKŇmôáyÇżßSsYcť
-jegyelővétel/VËŻj×LÓnňéyČŔŕTtYcź
+jegyelővétel/VËŻj×LÓnňéyČŔŕTtYcźő|vétel
 jegyellenőr/WĚŻjŘMÝňÔíčłĹĺRTtYc¸˝l
 jegycsíptető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 jegy/VËŻj×LÓnňéčłÄäTtYc¸ź
@@ -32296,7 +32351,7 @@ irrigátor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 irrigál
 irrigáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 irrigoszkópia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-irreverzibilitás/UĘŽiÖKŇmôáyÇżßSsYcť
+irreverzibilitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 irrelevancia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 irregularitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 irreflexivitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -32562,7 +32617,7 @@ infánsnő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 infáns/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 infámia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 infraégő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-infratávvezérlés/VËŻj×LÓnňéyČŔŕTtYcź
+infratávvezérlés/VËŻj×LÓnňéyČŔŕTtYcźáv|vezérlés
 infrasütő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 infraszauna/ŐAUQĘŽiĎŇáyÇżßvcť
 infrasugárzó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -32836,6 +32891,7 @@ iksz/VËŻj×LÓnňéčłÄäTtc¸ź
 ikravirág/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ikra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ikozaéder/VËŻj×LÓnňéčłÄäRTtYc¸źl
+ikonosztázion/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 ikonosztáz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ikonográfia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ikon/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -32906,8 +32962,8 @@ igazítanivaló/ŐAUQĘŽiĎŇáyÇżßYcť
 igazándiból
 igazán
 igazul
-igazságügy-minisztérium/UĘŽiÖKŇmôáyÇżßSscťág|ügy-||mi-nisz-té-ri-um
-igazságügy-miniszter/VËŻj×LÓnňéyČŔŕTtcźág|ügy-||mi-nisz-ter
+igazságügy-minisztérium/UĘŽiÖKŇmôáyÇżßSscťág|ügy-||mi-nisz-té-ri-umág|ügy-minisztérium
+igazságügy-miniszter/VËŻj×LÓnňéyČŔŕTtcźág|ügy-||mi-nisz-terág|ügy-miniszter
 igazságszolgáltatás/UĘŽiÖKŇmôáyÇżßSsYcťág|szol-gál-ta-tás
 igazság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťkág
 igazolvány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -33030,7 +33086,7 @@ idegzet/VËŻj×LÓnňéčłÄäTtYc¸źl
 idegszerv/VËŻj×LÓnňéyČŔŕTtYcź
 idegroham/UĘŽiÖKŇmôáyÇżßSsYcť
 idegpezsdítő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-idegközpont/UĘŽiÖKŇmôáyÇżßQYcť
+idegközpont/UĘŽiÖKŇmôáyÇżßQYcťöz|pont
 idegkimerülés/VËŻj×LÓnňéčłÄäTtYc¸źl
 idegkimerültség/VËŻj×LÓnňéyČŔŕTtYcź
 idegingerület/VËŻj×LÓnňéyČŔŕTtYcź
@@ -33127,9 +33183,9 @@ hűha
 hűebben/D)ű
 hűebb/DVÓ×n)ű
 hűdés/VËŻj×LÓnňéčłÄäTtYc¸źl
-hűbérúr/UmôŇyiYcÇ	űbérurak
-hűbéruraság/UĘŽiÖKŇmôáyÇżßSsYcť
-hűbérbirtok/UĘŽiÖKŇmôáyÇżßSsYcť
+hűbérúr/UmôŇyiYcÇ	űbérurakű|bér||úr
+hűbéruraság/UĘŽiÖKŇmôáyÇżßSsYcťű|bér||uraság
+hűbérbirtok/UĘŽiÖKŇmôáyÇżßSsYcťű|bér||birtok
 hűbér/VËŻj×LÓnňéyČŔŕTtYcź
 hűbelebalázs/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 húzószilárdság/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -33200,7 +33256,7 @@ húslégy/VÓnňyjYcČ	úslegyek
 húslé/VÓĐ×yjYcČ	úslevek
 húslás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 húsleves/VËŻj×LÓnňéyČŔŕTtYcź
-húshagyókedd/VËŻj×LÓnňéyČŔŕRcź
+húshagyókedd/VËŻj×LÓnňéyČŔŕRcźús|hagyó||kedd
 húsgombóc/UĘŽiÖKŇmôáyÇżßSsYcť
 húsfüstölő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 húsdaráló/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -33277,11 +33333,11 @@ hőpalack/UĘŽiÖKŇmôáyÇżßQYcť
 hőmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 hőmérséklet/VËŻj×LÓnňéyČŔŕTtYcź
 hőmennyiség/VËŻj×LÓnňéyČŔŕTtYcź
-hőlégmotor/UĘŽiÖKŇmôáyÇżßQYcť
-hőlégbefúvó/ŐAUQĘŽiĎŇáyÇżßYcť
-hőlégballon/UĘŽiÖKŇmôáyÇżßQYcť
+hőlégmotor/UĘŽiÖKŇmôáyÇżßQYcťő|lég||motor
+hőlégbefúvó/ŐAUQĘŽiĎŇáyÇżßYcťő||lég||be|fúvó
+hőlégballon/UĘŽiÖKŇmôáyÇżßQYcťő|lég||ballon
 hőleadás/UĘŽiÖKŇmôáyÇżßSsYcť
-hőközpont/UĘŽiÖKŇmôáyÇżßQYcť
+hőközpont/UĘŽiÖKŇmôáyÇżßQYcťő||köz|pont
 hőköl
 hőingás/UĘŽiÖKŇmôáyÇżßSsYcť
 hőingadozás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -33294,7 +33350,7 @@ hőguta/ŐAUQĘŽiĎŇáyÇżßYcť
 hőfok/UĘŽiÖKŇmôáyÇżßSsYcť
 hőfejlesztő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 hőfejlesztés/VËŻj×LÓnňéyČŔŕTtYcź
-hőerőmű/WŢŘÔyjYcČR	őerőművek
+hőerőmű/WŢŘÔyjYcČR	őerőművekő||erő|mű
 hőenergia/ŐAUQĘŽiĎŇáyÇżßYcť
 hőemelkedés/VËŻj×LÓnňéyČŔŕTtYcź
 hődíj/UŇmôyiYcÇ	ődíjak
@@ -33409,7 +33465,7 @@ hírközlés/VËŻj×LÓnňéyČŔŕTtYcź
 híresül
 hírbehozás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 híradó/ŐAUQĘŽiĎŇáyÇżßYcť
-híradástechnika/ŐAUQĘŽiĎŇáyÇżßYcť
+híradástechnika/ŐAUQĘŽiĎŇáyÇżßYcťír|adás||technika
 híradás/UĘŽiÖKŇmôáyÇżßSsYcť
 hír/VËŻj×LÓnňéčłÄäTtYc¸ź
 hínárfajta/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -33464,14 +33520,14 @@ héttrillióan/b)éttrillió
 héttrillió/ĎŇŐAUÚQbci	éttrillióan
 héttrilliárd/mÖKkUÚQbci
 hétszög/VNËŻj×LÝňÔéyČŔŕTtYcź
-hétszázfelé
-hétszázezres/×BŐV
-hétszázezrek/I)étszázezer
+hétszázfeléét|száz||felé
+hétszázezres/×BŐV	ét|száz||ezres
+hétszázezrek/I)étszázezer	ét|száz||ezrek
 hétszázas/AFUÚ)étszáz
 hétszázan/)étszáz
 hétszázadik/mŇŮAUÚ)étszáz
 hétszázad/AUÚ)étszáz
-hétszáz/$UŮÖmŇSscÚ	étszázasétszázanétszázadikétszázadétszázasétszázadikétszázad
+hétszáz/$UŮÖmŇSscÚ	étszázasétszázanétszázadikétszázad
 hétszámra
 hétszentségnek
 hétszentségit
@@ -33500,7 +33556,7 @@ hétezrek/Iba)étezer
 hétezrek/Iba)
 hétezredik/nÓ×BVÜb)étezer
 hétezred/BVÜb)étezer
-hétezerfelé
+hétezerfeléét|ezer||felé
 hétezer/ŐnBVÜjbcÓ×LlTts	étezresétezrenétezrekétezredikétezred
 hétesztendőnként
 hétesztendei
@@ -33509,7 +33565,7 @@ hétbillió/ĎŇŐAUÚQbci	étbillióan
 hétbilliárd/mÖKkUÚQbci
 hét_közbeni
 hét_közben
-hét-nyolcmillió/ĎŇŐAUÚQbcw
+hét-nyolcmillió/ĎŇŐAUÚQbcw	ét-nyolc|millió
 hét/VÓnňčjcłÜbh×ax
 hét/VÓnňčjcłÜbh×ax
 hérosz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -33534,7 +33590,7 @@ hébe-korba
 hébe-hóba
 hé
 házőrző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-házvezetőnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+házvezetőnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝áz|vezető||nő
 háztömb/WĚŻjŘMÝňÔíyČÁ˙RYc˝
 háztartás/UĘŽiÖKŇmôáyÇżßSsYcť
 házsor/UĘŽiÖKŇmôáyÇżßSsYcťáz|sor
@@ -33560,7 +33616,7 @@ háziszarka/ŐAUQĘŽiĎŇáyÇżßYcť
 háziszappan/UĘŽiÖKŇmôáyÇżßQSsYcť
 házisertés/VËŻj×LÓnňéčłÄäTtYc¸źl
 házirend/VËŻj×LÓnňéčłÄäRYc¸źl
-házipénztár/UmôŇyiYcÇ	ázipénztárak
+házipénztár/UmôŇyiYcÇ	ázipénztárakázi||pénz|tár
 háziporatka-/=
 házipor-/=
 háziorvoslás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -33576,7 +33632,7 @@ háziköpeny/VËŻj×LÓnňéyČŔŕTtYcź
 háziköntös/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 házikó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 házikolbász/UĘŽiÖKŇmôáyÇżßSsYcť
-házikisasszony/UĘŽiÖKŇmôáyÇżßSsYcť
+házikisasszony/UĘŽiÖKŇmôáyÇżßSsYcťázi||kis|asszony
 házikert/VËŻj×LÓnňéyČŔŕRYcź
 házikenyér/VÓnňyjYcČ	ázikenyerek
 házikabát/UĘŽiÖKŇmôáyÇżßQYcť
@@ -33632,7 +33688,7 @@ házasember/VËŻj×LÓnňéčłÄäTtYc¸źl
 ház/UmôŇçiYc˛	ázak
 hátúszás/UĘŽiÖKŇmôáyÇżßSsYcť
 hátér/wYVÓnňčjcłl
-hátvéd/VËŻj×LÓnňéčłÄäRYc¸źl
+hátvéd/VËŻj×LÓnňéyČŔŕRTtYcź
 hátvakaró/ŐAUQĘŽiĎŇáyÇżßYcť
 hátulütő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 hátultöltő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
@@ -33645,7 +33701,7 @@ hátuljak/I)átulja
 hátulj/uSsˇ˛)átulja
 hátulgombolós/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hátul/D	átulrólátulra
-háttér-információ/ŐAUQĘŽiĎŇáyÇżßYcť
+háttér-információ/ŐAUQĘŽiĎŇáyÇżßYcťát|tér-információ
 háttér/VÓnňyjYcČ	átterek
 háttámasz/UĘŽiÖKŇmôáyÇżßSsYcť
 hátsókert/VËŻj×LÓnňéyČŔŕRYcź
@@ -33724,18 +33780,18 @@ háromság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 háromszögelés/VËŻj×LÓnňéčłÄäTtYc¸źl
 háromszög/VNËŻj×LÝňÔéyČŔŕTtYcź
 háromszínnyomás/UĘŽiÖKŇmôáyÇżßSsYcťá-rom|szín||nyo-más
-háromszázfelé
-háromszázezres/×BŐV
-háromszázezrek/I)áromszázezer
+háromszázfeléárom|száz||felé
+háromszázezres/×BŐV	árom|száz||ezres
+háromszázezrek/I)áromszázezer	árom|száz||ezrek
 háromszázas/AFUÚ)áromszáz
 háromszázan/)áromszáz
 háromszázadik/mŇŮAUÚ)áromszáz
 háromszázad/AUÚ)áromszáz
-háromszáz/$UŮÖmŇSscÚ	áromszázasáromszázanáromszázadikáromszázadáromszázasáromszázadikáromszázad
+háromszáz/$UŮÖmŇSscÚ	áromszázasáromszázanáromszázadikáromszázad
 hárompólus/UĘŽiÖKŇmôáyÇżßSsvcť
 hárompercenként
 hárompennys/VËŻj×LÓnňéčłÄäTtYc¸źlá-rom|pen-nys
-háromnegyedóra
+háromnegyed_óra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 háromnaponta
 háromnaponként
 hárommillióan/b)árommillió
@@ -33757,7 +33813,7 @@ háromezrek/Iba)áromezer
 háromezrek/Iba)
 háromezredik/nÓ×BVÜb)áromezer
 háromezred/BVÜb)áromezer
-háromezerfelé
+háromezerfeléárom|ezer||felé
 háromezer/ŐnBVÜjbcÓ×LlTts	áromezresáromezrenáromezrekáromezredikáromezred
 háromesztendőnként
 háromesztendei
@@ -33765,7 +33821,7 @@ hárombillióan/b)árombillió
 hárombillió/ĎŇŐAUÚQbci	árombillióan
 hárombilliárd/mÖKkUÚQbci
 háromannyi/UŐĎŇ
-három-négymillió/ĎŇŐAUÚQbcw
+három-négymillió/ĎŇŐAUÚQbcw	árom-négy|millió
 három/mUÚbhca	ármótokármótokármónkármónkármójukármójukármanármak
 hármótok/UŇŮm)árom
 hármótok/UŇŮm)árom
@@ -33830,7 +33886,7 @@ hálósapka/ŐAUQĘŽiĎŇáyÇżßYcť
 hálópizsama/ŐAUQĘŽiĎŇáyÇżßYcť
 hálóköntös/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 hálókészítés/VËŻj×LÓnňéyČŔŕTtYcź
-hálókocsipótjegy/VËŻj×LÓnňéyČŔŕTtYcź
+hálókocsipótjegy/VËŻj×LÓnňéyČŔŕTtYcźáló|kocsi||pót|jegy
 hálókocsi/ŐAUQĘŽiĎŇáyÇżßYcť
 hálóing/VËŻj×LÓnňéyČŔŕRTtYcź
 hálóhely/×VËŻjLÓnňéyČŔŕTtYcź
@@ -33882,26 +33938,33 @@ huszár/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 huszonötödiki/BVÓŐĐś)öt
 huszonötödike/BVÓŐĐś)öt
 huszonötödik/!VÓn×Llbh)öt
-huszonöttrillióan/b)öttrillió
-huszonöttrillió/ĎŇŐAUÚQbci	öttrillióan
-huszonöttrilliárd/mÖKkUÚQbci
-huszonötmillióan/b)ötmillió
-huszonötmillió/ĎŇŐAUÚQbcj	ötmillióan
-huszonötmilliárdan/b)ötmilliárd
-huszonötmilliárd/mÖKkUÚQbci	ötmilliárdan
-huszonötfelé
-huszonötezres/×BŐVb)ötezer
-huszonötezren/b)ötezer
-huszonötezrek/Ib)ötezer
-huszonötezredik/nÓ×BVÜb)ötezer
-huszonötezred/BVÜb)ötezer
-huszonötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred
+huszonöttrillióan/b)öttrillió	öt||trillióan
+huszonöttrillió/ĎŇŐAUÚQbci	öttrillióan	öt||trillió
+huszonöttrilliárd/mÖKkUÚQbci	öt||trilliárd
+huszonötmillióan/b)ötmillió	öt||millióan
+huszonötmillió/ĎŇŐAUÚQbcj	ötmillióan	öt||millió
+huszonötmilliárdan/b)ötmilliárd	öt||milliárdan
+huszonötmilliárd/mÖKkUÚQbci	ötmilliárdan	öt||milliárd
+huszonötfeléöt||felé
+huszonötezres/×BŐVb)ötezer	öt||ezres
+huszonötezren/b)ötezer	öt||ezren
+huszonötezrek/Ib)ötezer	öt||ezrek
+huszonötezredik/nÓ×BVÜb)ötezer	öt||ezredik
+huszonötezred/BVÜb)ötezer	öt||ezred
+huszonötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred	öt||ezer
 huszonöten/bh)öt
-huszonötbillióan/b)ötbillió
-huszonötbillió/ĎŇŐAUÚQbci	ötbillióan
-huszonötbilliárd/mÖKkUÚQbci
+huszonötbillióan/b)ötbillió	öt||billióan
+huszonötbillió/ĎŇŐAUÚQbci	ötbillióan	öt||billió
+huszonötbilliárd/mÖKkUÚQbci	öt||billiárd
 huszonöt/ÝWŰMRbhc	ötödikiötödikeötödiköten
 huszonéves/VËŻj×LÓnňéčłÄäTtYc¸źl
+huszonéve
+huszonvalahánymillió/ĎŇŐAUÚQbcj	ány||millió
+huszonvalahánymilliárd/mÖKkUÚQbci	ány||milliárd
+huszonvalahányfeléány||felé
+huszonvalahányezres/×BŐVb)ányezer	ány||ezres
+huszonvalahányezren/b)ányezer	ány||ezren
+huszonvalahányezer/ŐnBVÜjbc	ányezresányezren	ány||ezer
 huszonvalahányan/bh))ány
 huszonvalahányan/bh)
 huszonvalahányadiki/AUŇŐĎľ))ány
@@ -33910,42 +33973,42 @@ huszonvalahányadika/AUŇŐĎľ))ány
 huszonvalahányadik/!AUÖmŇŮKkbh))ány
 huszonvalahány/môA$UÚSsbhcŇŮ	ányanányadikiányadikakányadikaányadik
 huszonvalahány/môA$UÚSsbhcŇŮ	ányanányadikiányadikakányadikaányadik
-huszonnégytrillióan/b)égytrillió
-huszonnégytrillió/ĎŇŐAUÚQbci	égytrillióan
-huszonnégytrilliárd/mÖKkUÚQbci
-huszonnégymillióan/b)égymillió
-huszonnégymillió/ĎŇŐAUÚQbcj	égymillióan
-huszonnégymilliárdan/b)égymilliárd
-huszonnégymilliárd/mÖKkUÚQbci	égymilliárdan
-huszonnégyfelé
-huszonnégyezres/×BŐVb)égyezer
-huszonnégyezren/b)égyezer
-huszonnégyezrek/Ib)égyezer
-huszonnégyezredik/nÓ×BVÜb)égyezer
-huszonnégyezred/BVÜb)égyezer
-huszonnégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred
+huszonnégytrillióan/b)égytrillió	égy||trillióan
+huszonnégytrillió/ĎŇŐAUÚQbci	égytrillióan	égy||trillió
+huszonnégytrilliárd/mÖKkUÚQbci	égy||trilliárd
+huszonnégymillióan/b)égymillió	égy||millióan
+huszonnégymillió/ĎŇŐAUÚQbcj	égymillióan	égy||millió
+huszonnégymilliárdan/b)égymilliárd	égy||milliárdan
+huszonnégymilliárd/mÖKkUÚQbci	égymilliárdan	égy||milliárd
+huszonnégyfeléégy||felé
+huszonnégyezres/×BŐVb)égyezer	égy||ezres
+huszonnégyezren/b)égyezer	égy||ezren
+huszonnégyezrek/Ib)égyezer	égy||ezrek
+huszonnégyezredik/nÓ×BVÜb)égyezer	égy||ezredik
+huszonnégyezred/BVÜb)égyezer	égy||ezred
+huszonnégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred	égy||ezer
 huszonnégyen/bh)égy
-huszonnégybillióan/b)égybillió
-huszonnégybillió/ĎŇŐAUÚQbci	égybillióan
-huszonnégybilliárd/mÖKkUÚQbci
+huszonnégybillióan/b)égybillió	égy||billióan
+huszonnégybillió/ĎŇŐAUÚQbci	égybillióan	égy||billió
+huszonnégybilliárd/mÖKkUÚQbci	égy||billiárd
 huszonnégy/nVÜLlTtbhc	égyen
-huszonnyolctrillióan/b)ó
-huszonnyolctrillió/ĎŇŐAUÚQbci	óan
-huszonnyolctrilliárd/mÖKkUÚQbci
-huszonnyolcmillióan/b)ó
-huszonnyolcmillió/ĎŇŐAUÚQbcj	óan
-huszonnyolcmilliárdan/b)árd
-huszonnyolcmilliárd/mÖKkUÚQbci	árdan
-huszonnyolcfelé
+huszonnyolctrillióan/b)ó	óan
+huszonnyolctrillió/ĎŇŐAUÚQbci	óan	ó
+huszonnyolctrilliárd/mÖKkUÚQbci	árd
+huszonnyolcmillióan/b)ó	óan
+huszonnyolcmillió/ĎŇŐAUÚQbcj	óan	ó
+huszonnyolcmilliárdan/b)árd	árdan
+huszonnyolcmilliárd/mÖKkUÚQbci	árdan	árd
+huszonnyolcfeléé
 huszonnyolcezres/×BŐVb)
 huszonnyolcezren/b)
 huszonnyolcezrek/Ib)
 huszonnyolcezredik/nÓ×BVÜb)
 huszonnyolcezred/BVÜb)
 huszonnyolcezer/ŐnBVÜjbc
-huszonnyolcbillióan/b)ó
-huszonnyolcbillió/ĎŇŐAUÚQbci	óan
-huszonnyolcbilliárd/mÖKkUÚQbci
+huszonnyolcbillióan/b)ó	óan
+huszonnyolcbillió/ĎŇŐAUÚQbci	óan	ó
+huszonnyolcbilliárd/mÖKkUÚQbci	árd
 huszonnyolcan/bh)
 huszonnyolcadiki/AUŇŐĎľ)
 huszonnyolcadikak/nI)
@@ -33955,32 +34018,32 @@ huszonnyolc/môA$UÚSsbhc
 huszonnegyediki/BVÓŐĐś)égy
 huszonnegyedike/BVÓŐĐś)égy
 huszonnegyedik/!VÓn×Llbh)égy
-huszonkéttrillióan/b)éttrillió
-huszonkéttrillió/ĎŇŐAUÚQbci	éttrillióan
-huszonkéttrilliárd/mÖKkUÚQbci
-huszonkétmillióan/b)étmillió
-huszonkétmillió/ĎŇŐAUÚQbcj	étmillióan
-huszonkétmilliárdan/b)étmilliárd
-huszonkétmilliárd/mÖKkUÚQbci	étmilliárdan
-huszonkétfelé
-huszonkétezres/×BŐVb)étezer
-huszonkétezren/b)étezer
-huszonkétezrek/Ib)étezer
-huszonkétezredik/nÓ×BVÜb)étezer
-huszonkétezred/BVÜb)étezer
-huszonkétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-huszonkétbillióan/b)étbillió
-huszonkétbillió/ĎŇŐAUÚQbci	étbillióan
-huszonkétbilliárd/mÖKkUÚQbci
+huszonkéttrillióan/b)éttrillió	ét||trillióan
+huszonkéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+huszonkéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+huszonkétmillióan/b)étmillió	ét||millióan
+huszonkétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+huszonkétmilliárdan/b)étmilliárd	ét||milliárdan
+huszonkétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+huszonkétfeléét||felé
+huszonkétezres/×BŐVb)étezer	ét||ezres
+huszonkétezren/b)étezer	ét||ezren
+huszonkétezrek/Ib)étezer	ét||ezrek
+huszonkétezredik/nÓ×BVÜb)étezer	ét||ezredik
+huszonkétezred/BVÜb)étezer	ét||ezred
+huszonkétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+huszonkétbillióan/b)étbillió	ét||billióan
+huszonkétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+huszonkétbilliárd/mÖKkUÚQbci	ét||billiárd
 huszonkét/bÜhc
-huszonkilenctrillióan/b)ó
-huszonkilenctrillió/ĎŇŐAUÚQbci	óan
-huszonkilenctrilliárd/mÖKkUÚQbci
-huszonkilencmillióan/b)ó
-huszonkilencmillió/ĎŇŐAUÚQbcj	óan
-huszonkilencmilliárdan/b)árd
-huszonkilencmilliárd/mÖKkUÚQbci	árdan
-huszonkilencfelé
+huszonkilenctrillióan/b)ó	óan
+huszonkilenctrillió/ĎŇŐAUÚQbci	óan	ó
+huszonkilenctrilliárd/mÖKkUÚQbci	árd
+huszonkilencmillióan/b)ó	óan
+huszonkilencmillió/ĎŇŐAUÚQbcj	óan	ó
+huszonkilencmilliárdan/b)árd	árdan
+huszonkilencmilliárd/mÖKkUÚQbci	árdan	árd
+huszonkilencfeléé
 huszonkilencezres/×BŐVb)
 huszonkilencezren/b)
 huszonkilencezrek/Ib)
@@ -33991,67 +34054,67 @@ huszonkilencen/bh)
 huszonkilencediki/BVÓŐĐś)
 huszonkilencedike/BVÓŐĐś)
 huszonkilencedik/!VÓn×Llbh)
-huszonkilencbillióan/b)ó
-huszonkilencbillió/ĎŇŐAUÚQbci	óan
-huszonkilencbilliárd/mÖKkUÚQbci
+huszonkilencbillióan/b)ó	óan
+huszonkilencbillió/ĎŇŐAUÚQbci	óan	ó
+huszonkilencbilliárd/mÖKkUÚQbci	árd
 huszonkilenc/nňVÜLlTtbhc
-huszonkettőtrillióan/b)őtrillió
-huszonkettőtrillió/ĎŇŐAUÚQbci	őtrillióan
-huszonkettőtrilliárd/mÖKkUÚQbci
-huszonkettőmillióan/b)őmillió
-huszonkettőmillió/ĎŇŐAUÚQbcj	őmillióan
-huszonkettőmilliárdan/b)őmilliárd
-huszonkettőmilliárd/mÖKkUÚQbci	őmilliárdan
-huszonkettőfelé
-huszonkettőezres/×BŐVb)őezer
-huszonkettőezren/b)őezer
-huszonkettőezrek/Ib)őezer
-huszonkettőezredik/nÓ×BVÜb)őezer
-huszonkettőezred/BVÜb)őezer
-huszonkettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred
-huszonkettőbillióan/b)őbillió
-huszonkettőbillió/ĎŇŐAUÚQbci	őbillióan
-huszonkettőbilliárd/mÖKkUÚQbci
+huszonkettőtrillióan/b)őtrillió	ő||trillióan
+huszonkettőtrillió/ĎŇŐAUÚQbci	őtrillióan	ő||trillió
+huszonkettőtrilliárd/mÖKkUÚQbci	ő||trilliárd
+huszonkettőmillióan/b)őmillió	ő||millióan
+huszonkettőmillió/ĎŇŐAUÚQbcj	őmillióan	ő||millió
+huszonkettőmilliárdan/b)őmilliárd	ő||milliárdan
+huszonkettőmilliárd/mÖKkUÚQbci	őmilliárdan	ő||milliárd
+huszonkettőfeléő||felé
+huszonkettőezres/×BŐVb)őezer	ő||ezres
+huszonkettőezren/b)őezer	ő||ezren
+huszonkettőezrek/Ib)őezer	ő||ezrek
+huszonkettőezredik/nÓ×BVÜb)őezer	ő||ezredik
+huszonkettőezred/BVÜb)őezer	ő||ezred
+huszonkettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred	ő||ezer
+huszonkettőbillióan/b)őbillió	ő||billióan
+huszonkettőbillió/ĎŇŐAUÚQbci	őbillióan	ő||billió
+huszonkettőbilliárd/mÖKkUÚQbci	ő||billiárd
 huszonkettő/ŢWŰMRbhc
 huszonketten/bh)ő
 huszonkettediki/BVÓŐĐś)ő
 huszonkettedike/BVÓŐĐś)ő
 huszonkettedik/!VÓn×Llbh)ő
-huszonhéttrillióan/b)éttrillió
-huszonhéttrillió/ĎŇŐAUÚQbci	éttrillióan
-huszonhéttrilliárd/mÖKkUÚQbci
-huszonhétmillióan/b)étmillió
-huszonhétmillió/ĎŇŐAUÚQbcj	étmillióan
-huszonhétmilliárdan/b)étmilliárd
-huszonhétmilliárd/mÖKkUÚQbci	étmilliárdan
-huszonhétfelé
-huszonhétezres/×BŐVb)étezer
-huszonhétezren/b)étezer
-huszonhétezrek/Ib)étezer
-huszonhétezredik/nÓ×BVÜb)étezer
-huszonhétezred/BVÜb)étezer
-huszonhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-huszonhétbillióan/b)étbillió
-huszonhétbillió/ĎŇŐAUÚQbci	étbillióan
-huszonhétbilliárd/mÖKkUÚQbci
+huszonhéttrillióan/b)éttrillió	ét||trillióan
+huszonhéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+huszonhéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+huszonhétmillióan/b)étmillió	ét||millióan
+huszonhétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+huszonhétmilliárdan/b)étmilliárd	ét||milliárdan
+huszonhétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+huszonhétfeléét||felé
+huszonhétezres/×BŐVb)étezer	ét||ezres
+huszonhétezren/b)étezer	ét||ezren
+huszonhétezrek/Ib)étezer	ét||ezrek
+huszonhétezredik/nÓ×BVÜb)étezer	ét||ezredik
+huszonhétezred/BVÜb)étezer	ét||ezred
+huszonhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+huszonhétbillióan/b)étbillió	ét||billióan
+huszonhétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+huszonhétbilliárd/mÖKkUÚQbci	ét||billiárd
 huszonhét/nVÜbhc
-huszonháromtrillióan/b)áromtrillió
-huszonháromtrillió/ĎŇŐAUÚQbci	áromtrillióan
-huszonháromtrilliárd/mÖKkUÚQbci
-huszonhárommillióan/b)árommillió
-huszonhárommillió/ĎŇŐAUÚQbcj	árommillióan
-huszonhárommilliárdan/b)árommilliárd
-huszonhárommilliárd/mÖKkUÚQbci	árommilliárdan
-huszonháromfelé
-huszonháromezres/×BŐVb)áromezer
-huszonháromezren/b)áromezer
-huszonháromezrek/Ib)áromezer
-huszonháromezredik/nÓ×BVÜb)áromezer
-huszonháromezred/BVÜb)áromezer
-huszonháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred
-huszonhárombillióan/b)árombillió
-huszonhárombillió/ĎŇŐAUÚQbci	árombillióan
-huszonhárombilliárd/mÖKkUÚQbci
+huszonháromtrillióan/b)áromtrillió	árom||trillióan
+huszonháromtrillió/ĎŇŐAUÚQbci	áromtrillióan	árom||trillió
+huszonháromtrilliárd/mÖKkUÚQbci	árom||trilliárd
+huszonhárommillióan/b)árommillió	árom||millióan
+huszonhárommillió/ĎŇŐAUÚQbcj	árommillióan	árom||millió
+huszonhárommilliárdan/b)árommilliárd	árom||milliárdan
+huszonhárommilliárd/mÖKkUÚQbci	árommilliárdan	árom||milliárd
+huszonháromfeléárom||felé
+huszonháromezres/×BŐVb)áromezer	árom||ezres
+huszonháromezren/b)áromezer	árom||ezren
+huszonháromezrek/Ib)áromezer	árom||ezrek
+huszonháromezredik/nÓ×BVÜb)áromezer	árom||ezredik
+huszonháromezred/BVÜb)áromezer	árom||ezred
+huszonháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred	árom||ezer
+huszonhárombillióan/b)árombillió	árom||billióan
+huszonhárombillió/ĎŇŐAUÚQbci	árombillióan	árom||billió
+huszonhárombilliárd/mÖKkUÚQbci	árom||billiárd
 huszonhárom/mUÚbhc	ármanármak
 huszonhárman/bh)árom
 huszonhármak/Ibh)árom
@@ -34060,41 +34123,41 @@ huszonhetek/Ibh)ét
 huszonhetediki/BVÓŐĐś)ét
 huszonhetedike/BVÓŐĐś)ét
 huszonhetedik/!VÓn×Llbh)ét
-huszonhattrillióan/b)ó
-huszonhattrillió/ĎŇŐAUÚQbci	óan
-huszonhattrilliárd/mÖKkUÚQbci
+huszonhattrillióan/b)ó	óan
+huszonhattrillió/ĎŇŐAUÚQbci	óan	ó
+huszonhattrilliárd/mÖKkUÚQbci	árd
 huszonhatodiki/AUŇŐĎľ)
 huszonhatodikak/nI)
 huszonhatodika/AUŇŐĎľ)
 huszonhatodik/!AUÖmŇŮKkbh)
-huszonhatmillióan/b)ó
-huszonhatmillió/ĎŇŐAUÚQbcj	óan
-huszonhatmilliárdan/b)árd
-huszonhatmilliárd/mÖKkUÚQbci	árdan
-huszonhatfelé
+huszonhatmillióan/b)ó	óan
+huszonhatmillió/ĎŇŐAUÚQbcj	óan	ó
+huszonhatmilliárdan/b)árd	árdan
+huszonhatmilliárd/mÖKkUÚQbci	árdan	árd
+huszonhatfeléé
 huszonhatezres/×BŐVb)
 huszonhatezren/b)
 huszonhatezrek/Ib)
 huszonhatezredik/nÓ×BVÜb)
 huszonhatezred/BVÜb)
 huszonhatezer/ŐnBVÜjbc
-huszonhatbillióan/b)ó
-huszonhatbillió/ĎŇŐAUÚQbci	óan
-huszonhatbilliárd/mÖKkUÚQbci
+huszonhatbillióan/b)ó	óan
+huszonhatbillió/ĎŇŐAUÚQbci	óan	ó
+huszonhatbilliárd/mÖKkUÚQbci	árd
 huszonhatan/bh)
 huszonhat/mUÚKkbhc
 huszonharmadiki/AUŇŐĎľ)árom
 huszonharmadikak/nI)árom
 huszonharmadika/AUŇŐĎľ)árom
 huszonharmadik/!AUÖmŇŮKkbh)árom
-huszonegytrillióan/b)ó
-huszonegytrillió/ĎŇŐAUÚQbci	óan
-huszonegytrilliárd/mÖKkUÚQbci
-huszonegymillióan/b)ó
-huszonegymillió/ĎŇŐAUÚQbcj	óan
-huszonegymilliárdan/b)árd
-huszonegymilliárd/mÖKkUÚQbci	árdan
-huszonegyfelé
+huszonegytrillióan/b)ó	óan
+huszonegytrillió/ĎŇŐAUÚQbci	óan	ó
+huszonegytrilliárd/mÖKkUÚQbci	árd
+huszonegymillióan/b)ó	óan
+huszonegymillió/ĎŇŐAUÚQbcj	óan	ó
+huszonegymilliárdan/b)árd	árdan
+huszonegymilliárd/mÖKkUÚQbci	árdan	árd
+huszonegyfeléé
 huszonegyezres/×BŐVb)
 huszonegyezren/b)
 huszonegyezrek/Ib)
@@ -34107,9 +34170,9 @@ huszonegyen/bh)
 huszonegyediki/BVÓŐĐś)
 huszonegyedike/BVÓŐĐś)
 huszonegyedik/VÓn×Llbh)
-huszonegybillióan/b)ó
-huszonegybillió/ĎŇŐAUÚQbci	óan
-huszonegybilliárd/mÖKkUÚQbci
+huszonegybillióan/b)ó	óan
+huszonegybillió/ĎŇŐAUÚQbci	óan	ó
+huszonegybilliárd/mÖKkUÚQbci	árd
 huszonegy/nVÜLlbhc
 huszon-egynéhány
 huszitizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -34173,7 +34236,7 @@ humáninformatika/ŐAUQĘŽiĎŇáyÇżßYcť
 humángenetika/ŐAUQĘŽiĎŇáyÇżßYcť
 humánetológus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 humánetológia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-humánerőforrás/UĘŽiÖKŇmôáyÇżßSsYcť
+humánerőforrás/UĘŽiÖKŇmôáyÇżßSsYcťán||erő|forrás
 humusz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 humorizál
 humorista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -34287,8 +34350,8 @@ hot_dog/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hot_dog/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hot-dog/wUĘŽiÖKŇmôáç˛ĂăSsvcˇťk
 hosztesz/VËŻj×LÓnňéčłÄäTtYc¸źl	ph:hostess
-hosszútávfutó/ŐAUQĘŽiĎŇáyÇżßYcť
-hosszútáv/UĘŽiÖKŇmôáyÇżßSsYcť
+hosszútávfutó/ŐAUQĘŽiĎŇáyÇżßYcťú|táv||futó
+hosszútáv/UĘŽiÖKŇmôáyÇżßQYcť
 hosszúság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hosszúpecsét/VËŻj×LÓnňéyČŔŕRYcź
 hosszúnadrág/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -34296,7 +34359,7 @@ hosszúlépés/VËŻj×LÓnňéyČŔŕTtYcź
 hosszúkaraj/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hosszúhullám/UĘŽiÖKŇmôáyÇżßSsYcť
 hosszúhajtás/UĘŽiÖKŇmôáyÇżßSsYcť
-hosszúfülű-denevér/VËŻj×LÓnňéyČŔŕRTtYcź
+hosszúfülű-denevér/VËŻj×LÓnňéyČŔŕRTtYcźú|fülű-denevér
 hosszúfény/VËŻj×LÓnňéyČŔŕTtYcź
 hosszúcsőrű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 hosszú/AKUQŐĎŇ
@@ -34316,6 +34379,8 @@ hosszabban/D)ú
 hosszabb/ŮmŇAD$UQ)ú
 hossz/UmôŇçiYc˛ĘŽÖKáĂăSsˇť
 hospitál
+hospitalizáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+hospitalizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hospice-t/)	ph:hoszpiszt
 hospice-szá/)	ph:hoszpissz	ph:hoszpissá
 hospice-szal/)	ph:hoszpisszal
@@ -34405,7 +34470,7 @@ hopmester/VËŻj×LÓnňéyČŔŕRYcź
 hooke-os/ŇŮmAFUKQ)	ph:húkos
 hooke-i/ŃĎŐAFUKSs)	ph:húki
 honvédség/VËŻj×LÓnňéčłÄäTtYc¸źl
-honvéd/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRYcˇť¸źkl
+honvéd/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
 honvágy/UmôŇyiYcÇ	ágyak
 honv.
 honosul
@@ -34596,7 +34661,7 @@ hittétel/VËŻj×LÓnňéyČŔŕTtYcźételgyártó>
 hittérítés/VËŻj×LÓnňéyČŔŕTtYcź
 hittudomány/UĘŽiÖKŇmôáyÇżßSsYcť
 hittitok/UmôyiYcŽ
-hittanóra/ŐAUQĘŽiĎŇáyÇżßYcť
+hittanóra/ŐAUQĘŽiĎŇáyÇżßYcťóra
 hitszegés/VËŻj×LÓnňéyČŔŕTtYcź
 hitszakadás/UĘŽiÖKŇmôáyÇżßSsYcť
 hitrege/ŐBVRËŻjĐÓéyČŔŕYcź
@@ -34663,6 +34728,7 @@ hipnotizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hipnoterápia/ŐAUQĘŽiĎŇáyÇżßYcť
 hiphop/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 hiperóriás/UĘŽiÖKŇmôáyÇżßSsYcť
+hiperventiláció/ŐAUQĘŽiĎŇáyÇżßYcť
 hipervektor/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 hiperurbanizmus/UĘŽiÖKŇmôáyÇżßSsYcť
 hipertónia/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -34674,7 +34740,7 @@ hiperoxid/UĘŽiÖKŇmôáyÇżßQYcť
 hiperon/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 hipermédia/ŐAUQĘŽiĎŇáyÇżßYcť
 hipermátrix/UĘŽiÖKŇmôáyÇżßSsYcť
-hipermarket/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRTtYcťź
+hipermarket/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRTtYcťź
 hipermangán/UĘŽiÖKŇmôáyÇżßQYcť
 hipermanganát/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 hiperkorrekció/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -34791,6 +34857,8 @@ hidra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hidegül
 hidegétel/VËŻj×LÓnňéyČŔŕRYcź
 hidegérzet/VËŻj×LÓnňéyČŔŕTtYcź
+hidegvíz-mérő_óra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ph:hidegvízmérő-óra*
+hidegvíz-mérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝	ph:hidegvízmérő
 hidegvíz-/=
 hidegvíz/w
 hidegvér/VËŻj×LÓnňéyČŔŕTtYcź
@@ -34812,7 +34880,7 @@ hidegház/UmôŇyiYcÇ	ázak
 hidegháború/ŐAUQĘŽiĎŇáyÇżßYcť
 hideghullám/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hideghengersor/UĘŽiÖKŇmôáyÇżßSsYcť
-hideghengermű/WŢŘÔyjYcČ	űvek
+hideghengermű/WŢŘÔyjYcČ	űvekű
 hideggyanta/ŐAUQĘŽiĎŇáyÇżßYcť
 hidegfúzió/ŐAUQĘŽiĎŇáyÇżßYcť
 hidegfront/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -34821,6 +34889,7 @@ hidegcsap/UĘŽiÖKŇmôáyÇżßQSsYcť
 hidegbüfé/ŐBVRËŻjĐÓéyČŔŕYcź
 hidegburkoló/ŐAUQĘŽiĎŇáyÇżßYcť
 hidegburkolat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+hidegbetörés/VËŻj×LÓnňéyČŔŕTtYcźörés
 hidegalakítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hideg_víz/VÓnňcłl
 hidas/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -34857,30 +34926,36 @@ heuréka
 heurisztika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hetéra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hetvenötödik/!VÓn×Llbh)öt
-hetvenöttrillióan/b)öttrillió
-hetvenöttrillió/ĎŇŐAUÚQbci	öttrillióan
-hetvenöttrilliárd/mÖKkUÚQbci
-hetvenötmillióan/b)ötmillió
-hetvenötmillió/ĎŇŐAUÚQbcj	ötmillióan
-hetvenötmilliárdan/b)ötmilliárd
-hetvenötmilliárd/mÖKkUÚQbci	ötmilliárdan
-hetvenötfelé
-hetvenötezres/×BŐVb)ötezer
-hetvenötezren/b)ötezer
-hetvenötezrek/Ib)ötezer
-hetvenötezredik/nÓ×BVÜb)ötezer
-hetvenötezred/BVÜb)ötezer
-hetvenötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred
+hetvenöttrillióan/b)öttrillió	öt||trillióan
+hetvenöttrillió/ĎŇŐAUÚQbci	öttrillióan	öt||trillió
+hetvenöttrilliárd/mÖKkUÚQbci	öt||trilliárd
+hetvenötmillióan/b)ötmillió	öt||millióan
+hetvenötmillió/ĎŇŐAUÚQbcj	ötmillióan	öt||millió
+hetvenötmilliárdan/b)ötmilliárd	öt||milliárdan
+hetvenötmilliárd/mÖKkUÚQbci	ötmilliárdan	öt||milliárd
+hetvenötfeléöt||felé
+hetvenötezres/×BŐVb)ötezer	öt||ezres
+hetvenötezren/b)ötezer	öt||ezren
+hetvenötezrek/Ib)ötezer	öt||ezrek
+hetvenötezredik/nÓ×BVÜb)ötezer	öt||ezredik
+hetvenötezred/BVÜb)ötezer	öt||ezred
+hetvenötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred	öt||ezer
 hetvenöten/bh)öt
-hetvenötbillióan/b)ötbillió
-hetvenötbillió/ĎŇŐAUÚQbci	ötbillióan
-hetvenötbilliárd/mÖKkUÚQbci
+hetvenötbillióan/b)ötbillió	öt||billióan
+hetvenötbillió/ĎŇŐAUÚQbci	ötbillióan	öt||billió
+hetvenötbilliárd/mÖKkUÚQbci	öt||billiárd
 hetvenöt/ÝWŰMRbhc	ötödiköten
 hetvenóránként
 hetvenórai
 hetvenévi
 hetvenévente
 hetvenévenként
+hetvenvalahánymillió/ĎŇŐAUÚQbcj	ány||millió
+hetvenvalahánymilliárd/mÖKkUÚQbci	ány||milliárd
+hetvenvalahányfeléány||felé
+hetvenvalahányezres/×BŐVb)ányezer	ány||ezres
+hetvenvalahányezren/b)ányezer	ány||ezren
+hetvenvalahányezer/ŐnBVÜjbc	ányezresányezren	ány||ezer
 hetvenvalahányan/bh))ány
 hetvenvalahányan/bh)
 hetvenvalahányadikak/nI))ány
@@ -34891,42 +34966,42 @@ hetventrillióan/b)ó
 hetventrillió/ĎŇŐAUÚQbci	óan
 hetventrilliárd/mÖKkUÚQbci
 hetvenpercenként
-hetvennégytrillióan/b)égytrillió
-hetvennégytrillió/ĎŇŐAUÚQbci	égytrillióan
-hetvennégytrilliárd/mÖKkUÚQbci
-hetvennégymillióan/b)égymillió
-hetvennégymillió/ĎŇŐAUÚQbcj	égymillióan
-hetvennégymilliárdan/b)égymilliárd
-hetvennégymilliárd/mÖKkUÚQbci	égymilliárdan
-hetvennégyfelé
-hetvennégyezres/×BŐVb)égyezer
-hetvennégyezren/b)égyezer
-hetvennégyezrek/Ib)égyezer
-hetvennégyezredik/nÓ×BVÜb)égyezer
-hetvennégyezred/BVÜb)égyezer
-hetvennégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred
+hetvennégytrillióan/b)égytrillió	égy||trillióan
+hetvennégytrillió/ĎŇŐAUÚQbci	égytrillióan	égy||trillió
+hetvennégytrilliárd/mÖKkUÚQbci	égy||trilliárd
+hetvennégymillióan/b)égymillió	égy||millióan
+hetvennégymillió/ĎŇŐAUÚQbcj	égymillióan	égy||millió
+hetvennégymilliárdan/b)égymilliárd	égy||milliárdan
+hetvennégymilliárd/mÖKkUÚQbci	égymilliárdan	égy||milliárd
+hetvennégyfeléégy||felé
+hetvennégyezres/×BŐVb)égyezer	égy||ezres
+hetvennégyezren/b)égyezer	égy||ezren
+hetvennégyezrek/Ib)égyezer	égy||ezrek
+hetvennégyezredik/nÓ×BVÜb)égyezer	égy||ezredik
+hetvennégyezred/BVÜb)égyezer	égy||ezred
+hetvennégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred	égy||ezer
 hetvennégyen/bh)égy
-hetvennégybillióan/b)égybillió
-hetvennégybillió/ĎŇŐAUÚQbci	égybillióan
-hetvennégybilliárd/mÖKkUÚQbci
+hetvennégybillióan/b)égybillió	égy||billióan
+hetvennégybillió/ĎŇŐAUÚQbci	égybillióan	égy||billió
+hetvennégybilliárd/mÖKkUÚQbci	égy||billiárd
 hetvennégy/nVÜLlTtbhc	égyen
-hetvennyolctrillióan/b)ó
-hetvennyolctrillió/ĎŇŐAUÚQbci	óan
-hetvennyolctrilliárd/mÖKkUÚQbci
-hetvennyolcmillióan/b)ó
-hetvennyolcmillió/ĎŇŐAUÚQbcj	óan
-hetvennyolcmilliárdan/b)árd
-hetvennyolcmilliárd/mÖKkUÚQbci	árdan
-hetvennyolcfelé
+hetvennyolctrillióan/b)ó	óan
+hetvennyolctrillió/ĎŇŐAUÚQbci	óan	ó
+hetvennyolctrilliárd/mÖKkUÚQbci	árd
+hetvennyolcmillióan/b)ó	óan
+hetvennyolcmillió/ĎŇŐAUÚQbcj	óan	ó
+hetvennyolcmilliárdan/b)árd	árdan
+hetvennyolcmilliárd/mÖKkUÚQbci	árdan	árd
+hetvennyolcfeléé
 hetvennyolcezres/×BŐVb)
 hetvennyolcezren/b)
 hetvennyolcezrek/Ib)
 hetvennyolcezredik/nÓ×BVÜb)
 hetvennyolcezred/BVÜb)
 hetvennyolcezer/ŐnBVÜjbc
-hetvennyolcbillióan/b)ó
-hetvennyolcbillió/ĎŇŐAUÚQbci	óan
-hetvennyolcbilliárd/mÖKkUÚQbci
+hetvennyolcbillióan/b)ó	óan
+hetvennyolcbillió/ĎŇŐAUÚQbci	óan	ó
+hetvennyolcbilliárd/mÖKkUÚQbci	árd
 hetvennyolcan/bh)
 hetvennyolcadikak/nI)
 hetvennyolcadik/!AUÖmŇŮKkbh)
@@ -34938,32 +35013,32 @@ hetvenmillióan/b)ó
 hetvenmillió/ĎŇŐAUÚQbcj	óan
 hetvenmilliárdan/b)árd
 hetvenmilliárd/mÖKkUÚQbci	árdan
-hetvenkéttrillióan/b)éttrillió
-hetvenkéttrillió/ĎŇŐAUÚQbci	éttrillióan
-hetvenkéttrilliárd/mÖKkUÚQbci
-hetvenkétmillióan/b)étmillió
-hetvenkétmillió/ĎŇŐAUÚQbcj	étmillióan
-hetvenkétmilliárdan/b)étmilliárd
-hetvenkétmilliárd/mÖKkUÚQbci	étmilliárdan
-hetvenkétfelé
-hetvenkétezres/×BŐVb)étezer
-hetvenkétezren/b)étezer
-hetvenkétezrek/Ib)étezer
-hetvenkétezredik/nÓ×BVÜb)étezer
-hetvenkétezred/BVÜb)étezer
-hetvenkétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-hetvenkétbillióan/b)étbillió
-hetvenkétbillió/ĎŇŐAUÚQbci	étbillióan
-hetvenkétbilliárd/mÖKkUÚQbci
+hetvenkéttrillióan/b)éttrillió	ét||trillióan
+hetvenkéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+hetvenkéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+hetvenkétmillióan/b)étmillió	ét||millióan
+hetvenkétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+hetvenkétmilliárdan/b)étmilliárd	ét||milliárdan
+hetvenkétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+hetvenkétfeléét||felé
+hetvenkétezres/×BŐVb)étezer	ét||ezres
+hetvenkétezren/b)étezer	ét||ezren
+hetvenkétezrek/Ib)étezer	ét||ezrek
+hetvenkétezredik/nÓ×BVÜb)étezer	ét||ezredik
+hetvenkétezred/BVÜb)étezer	ét||ezred
+hetvenkétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+hetvenkétbillióan/b)étbillió	ét||billióan
+hetvenkétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+hetvenkétbilliárd/mÖKkUÚQbci	ét||billiárd
 hetvenkét/bÜhc
-hetvenkilenctrillióan/b)ó
-hetvenkilenctrillió/ĎŇŐAUÚQbci	óan
-hetvenkilenctrilliárd/mÖKkUÚQbci
-hetvenkilencmillióan/b)ó
-hetvenkilencmillió/ĎŇŐAUÚQbcj	óan
-hetvenkilencmilliárdan/b)árd
-hetvenkilencmilliárd/mÖKkUÚQbci	árdan
-hetvenkilencfelé
+hetvenkilenctrillióan/b)ó	óan
+hetvenkilenctrillió/ĎŇŐAUÚQbci	óan	ó
+hetvenkilenctrilliárd/mÖKkUÚQbci	árd
+hetvenkilencmillióan/b)ó	óan
+hetvenkilencmillió/ĎŇŐAUÚQbcj	óan	ó
+hetvenkilencmilliárdan/b)árd	árdan
+hetvenkilencmilliárd/mÖKkUÚQbci	árdan	árd
+hetvenkilencfeléé
 hetvenkilencezres/×BŐVb)
 hetvenkilencezren/b)
 hetvenkilencezrek/Ib)
@@ -34972,66 +35047,66 @@ hetvenkilencezred/BVÜb)
 hetvenkilencezer/ŐnBVÜjbc
 hetvenkilencen/bh)
 hetvenkilencedik/!VÓn×Llbh)
-hetvenkilencbillióan/b)ó
-hetvenkilencbillió/ĎŇŐAUÚQbci	óan
-hetvenkilencbilliárd/mÖKkUÚQbci
+hetvenkilencbillióan/b)ó	óan
+hetvenkilencbillió/ĎŇŐAUÚQbci	óan	ó
+hetvenkilencbilliárd/mÖKkUÚQbci	árd
 hetvenkilenc/nňVÜLlTtbhc
-hetvenkettőtrillióan/b)őtrillió
-hetvenkettőtrillió/ĎŇŐAUÚQbci	őtrillióan
-hetvenkettőtrilliárd/mÖKkUÚQbci
-hetvenkettőmillióan/b)őmillió
-hetvenkettőmillió/ĎŇŐAUÚQbcj	őmillióan
-hetvenkettőmilliárdan/b)őmilliárd
-hetvenkettőmilliárd/mÖKkUÚQbci	őmilliárdan
-hetvenkettőfelé
-hetvenkettőezres/×BŐVb)őezer
-hetvenkettőezren/b)őezer
-hetvenkettőezrek/Ib)őezer
-hetvenkettőezredik/nÓ×BVÜb)őezer
-hetvenkettőezred/BVÜb)őezer
-hetvenkettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred
-hetvenkettőbillióan/b)őbillió
-hetvenkettőbillió/ĎŇŐAUÚQbci	őbillióan
-hetvenkettőbilliárd/mÖKkUÚQbci
+hetvenkettőtrillióan/b)őtrillió	ő||trillióan
+hetvenkettőtrillió/ĎŇŐAUÚQbci	őtrillióan	ő||trillió
+hetvenkettőtrilliárd/mÖKkUÚQbci	ő||trilliárd
+hetvenkettőmillióan/b)őmillió	ő||millióan
+hetvenkettőmillió/ĎŇŐAUÚQbcj	őmillióan	ő||millió
+hetvenkettőmilliárdan/b)őmilliárd	ő||milliárdan
+hetvenkettőmilliárd/mÖKkUÚQbci	őmilliárdan	ő||milliárd
+hetvenkettőfeléő||felé
+hetvenkettőezres/×BŐVb)őezer	ő||ezres
+hetvenkettőezren/b)őezer	ő||ezren
+hetvenkettőezrek/Ib)őezer	ő||ezrek
+hetvenkettőezredik/nÓ×BVÜb)őezer	ő||ezredik
+hetvenkettőezred/BVÜb)őezer	ő||ezred
+hetvenkettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred	ő||ezer
+hetvenkettőbillióan/b)őbillió	ő||billióan
+hetvenkettőbillió/ĎŇŐAUÚQbci	őbillióan	ő||billió
+hetvenkettőbilliárd/mÖKkUÚQbci	ő||billiárd
 hetvenkettő/ŢWŰMRbhc
 hetvenketten/bh)ő
 hetvenkettedik/!VÓn×Llbh)ő
 hetvenkedő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
-hetvenhéttrillióan/b)éttrillió
-hetvenhéttrillió/ĎŇŐAUÚQbci	éttrillióan
-hetvenhéttrilliárd/mÖKkUÚQbci
-hetvenhétmillióan/b)étmillió
-hetvenhétmillió/ĎŇŐAUÚQbcj	étmillióan
-hetvenhétmilliárdan/b)étmilliárd
-hetvenhétmilliárd/mÖKkUÚQbci	étmilliárdan
-hetvenhétfelé
-hetvenhétezres/×BŐVb)étezer
-hetvenhétezren/b)étezer
-hetvenhétezrek/Ib)étezer
-hetvenhétezredik/nÓ×BVÜb)étezer
-hetvenhétezred/BVÜb)étezer
-hetvenhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-hetvenhétbillióan/b)étbillió
-hetvenhétbillió/ĎŇŐAUÚQbci	étbillióan
-hetvenhétbilliárd/mÖKkUÚQbci
+hetvenhéttrillióan/b)éttrillió	ét||trillióan
+hetvenhéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+hetvenhéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+hetvenhétmillióan/b)étmillió	ét||millióan
+hetvenhétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+hetvenhétmilliárdan/b)étmilliárd	ét||milliárdan
+hetvenhétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+hetvenhétfeléét||felé
+hetvenhétezres/×BŐVb)étezer	ét||ezres
+hetvenhétezren/b)étezer	ét||ezren
+hetvenhétezrek/Ib)étezer	ét||ezrek
+hetvenhétezredik/nÓ×BVÜb)étezer	ét||ezredik
+hetvenhétezred/BVÜb)étezer	ét||ezred
+hetvenhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+hetvenhétbillióan/b)étbillió	ét||billióan
+hetvenhétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+hetvenhétbilliárd/mÖKkUÚQbci	ét||billiárd
 hetvenhét/nVÜbhc
-hetvenháromtrillióan/b)áromtrillió
-hetvenháromtrillió/ĎŇŐAUÚQbci	áromtrillióan
-hetvenháromtrilliárd/mÖKkUÚQbci
-hetvenhárommillióan/b)árommillió
-hetvenhárommillió/ĎŇŐAUÚQbcj	árommillióan
-hetvenhárommilliárdan/b)árommilliárd
-hetvenhárommilliárd/mÖKkUÚQbci	árommilliárdan
-hetvenháromfelé
-hetvenháromezres/×BŐVb)áromezer
-hetvenháromezren/b)áromezer
-hetvenháromezrek/Ib)áromezer
-hetvenháromezredik/nÓ×BVÜb)áromezer
-hetvenháromezred/BVÜb)áromezer
-hetvenháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred
-hetvenhárombillióan/b)árombillió
-hetvenhárombillió/ĎŇŐAUÚQbci	árombillióan
-hetvenhárombilliárd/mÖKkUÚQbci
+hetvenháromtrillióan/b)áromtrillió	árom||trillióan
+hetvenháromtrillió/ĎŇŐAUÚQbci	áromtrillióan	árom||trillió
+hetvenháromtrilliárd/mÖKkUÚQbci	árom||trilliárd
+hetvenhárommillióan/b)árommillió	árom||millióan
+hetvenhárommillió/ĎŇŐAUÚQbcj	árommillióan	árom||millió
+hetvenhárommilliárdan/b)árommilliárd	árom||milliárdan
+hetvenhárommilliárd/mÖKkUÚQbci	árommilliárdan	árom||milliárd
+hetvenháromfeléárom||felé
+hetvenháromezres/×BŐVb)áromezer	árom||ezres
+hetvenháromezren/b)áromezer	árom||ezren
+hetvenháromezrek/Ib)áromezer	árom||ezrek
+hetvenháromezredik/nÓ×BVÜb)áromezer	árom||ezredik
+hetvenháromezred/BVÜb)áromezer	árom||ezred
+hetvenháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred	árom||ezer
+hetvenhárombillióan/b)árombillió	árom||billióan
+hetvenhárombillió/ĎŇŐAUÚQbci	árombillióan	árom||billió
+hetvenhárombilliárd/mÖKkUÚQbci	árom||billiárd
 hetvenhárom/mUÚbhc	ármanármak
 hetvenhárman/bh)árom
 hetvenhármak/Ibh)árom
@@ -35044,25 +35119,25 @@ hetvenhetedik/!VÓn×Llbh)ét
 hetvenhavonta
 hetvenhavonként
 hetvenhavi
-hetvenhattrillióan/b)ó
-hetvenhattrillió/ĎŇŐAUÚQbci	óan
-hetvenhattrilliárd/mÖKkUÚQbci
+hetvenhattrillióan/b)ó	óan
+hetvenhattrillió/ĎŇŐAUÚQbci	óan	ó
+hetvenhattrilliárd/mÖKkUÚQbci	árd
 hetvenhatodikak/nI)
 hetvenhatodik/!AUÖmŇŮKkbh)
-hetvenhatmillióan/b)ó
-hetvenhatmillió/ĎŇŐAUÚQbcj	óan
-hetvenhatmilliárdan/b)árd
-hetvenhatmilliárd/mÖKkUÚQbci	árdan
-hetvenhatfelé
+hetvenhatmillióan/b)ó	óan
+hetvenhatmillió/ĎŇŐAUÚQbcj	óan	ó
+hetvenhatmilliárdan/b)árd	árdan
+hetvenhatmilliárd/mÖKkUÚQbci	árdan	árd
+hetvenhatfeléé
 hetvenhatezres/×BŐVb)
 hetvenhatezren/b)
 hetvenhatezrek/Ib)
 hetvenhatezredik/nÓ×BVÜb)
 hetvenhatezred/BVÜb)
 hetvenhatezer/ŐnBVÜjbc
-hetvenhatbillióan/b)ó
-hetvenhatbillió/ĎŇŐAUÚQbci	óan
-hetvenhatbilliárd/mÖKkUÚQbci
+hetvenhatbillióan/b)ó	óan
+hetvenhatbillió/ĎŇŐAUÚQbci	óan	ó
+hetvenhatbilliárd/mÖKkUÚQbci	árd
 hetvenhatan/bh)
 hetvenhat/mUÚKkbhc
 hetvenharmadikak/nI)árom
@@ -35078,14 +35153,14 @@ hetvenesztendőnként
 hetvenesztendei
 hetvenes/VÓnň×DGTtabh
 hetvenen/bh)
-hetvenegytrillióan/b)ó
-hetvenegytrillió/ĎŇŐAUÚQbci	óan
-hetvenegytrilliárd/mÖKkUÚQbci
-hetvenegymillióan/b)ó
-hetvenegymillió/ĎŇŐAUÚQbcj	óan
-hetvenegymilliárdan/b)árd
-hetvenegymilliárd/mÖKkUÚQbci	árdan
-hetvenegyfelé
+hetvenegytrillióan/b)ó	óan
+hetvenegytrillió/ĎŇŐAUÚQbci	óan	ó
+hetvenegytrilliárd/mÖKkUÚQbci	árd
+hetvenegymillióan/b)ó	óan
+hetvenegymillió/ĎŇŐAUÚQbcj	óan	ó
+hetvenegymilliárdan/b)árd	árdan
+hetvenegymilliárd/mÖKkUÚQbci	árdan	árd
+hetvenegyfeléé
 hetvenegyezres/×BŐVb)
 hetvenegyezren/b)
 hetvenegyezrek/Ib)
@@ -35094,9 +35169,9 @@ hetvenegyezred/BVÜb)
 hetvenegyezer/ŐnBVÜjbc
 hetvenegyen/bh)
 hetvenegyedik/VÓn×Llbh)
-hetvenegybillióan/b)ó
-hetvenegybillió/ĎŇŐAUÚQbci	óan
-hetvenegybilliárd/mÖKkUÚQbci
+hetvenegybillióan/b)ó	óan
+hetvenegybillió/ĎŇŐAUÚQbci	óan	ó
+hetvenegybilliárd/mÖKkUÚQbci	árd
 hetvenegy/nVÜLlbhc
 hetvenedszerre/bh)
 hetvenedszeri/bh
@@ -35148,13 +35223,13 @@ hetedikes/VËŻj×LÓnňéčłÄäTtYc¸źl
 hetedike/BVÓŐĐś)ét
 hetedik/c!VÓn×Llabh)ét
 hetedhét/VËŻj×LÓnňéčłÄäRYc¸źl
-hetedféltrillió/AUŐĎŇKQxcˇĂżÇ
-hetedfélszázad/AUÖmŇKkQcˇĂżÇ
-hetedfélszáz/$UŮÖmŇSscÇ
-hetedfélmillió/AUŐĎŇKQxcˇĂżÇ
-hetedfélmilliárd/AUÖmŇKkQcˇĂżÇ
-hetedfélezer/VÓn×LlTtcČ
-hetedfélbillió/AUŐĎŇKQxcˇĂżÇ
+hetedféltrillió/AUŐĎŇKQxcˇĂżÇ	él||trillió
+hetedfélszázad/AUÖmŇKkQcˇĂżÇ	él||század
+hetedfélszáz/$UŮÖmŇSscÇ	él||száz
+hetedfélmillió/AUŐĎŇKQxcˇĂżÇ	él||millió
+hetedfélmilliárd/AUÖmŇKkQcˇĂżÇ	él||milliárd
+hetedfélezer/VÓn×LlTtcČ	él||ezer
+hetedfélbillió/AUŐĎŇKQxcˇĂżÇ	él||billió
 hetedfél/VÓnňyjYcČ)él	él
 hetedannyian
 hetedannyi/UŐĎŇ
@@ -35226,6 +35301,7 @@ henteregek/w
 hentereged/w
 henry/VËŻjŐBĐŃéčłÄäRc¸ź
 henna/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+hengerész/VËŻj×LÓnňéčłÄäTtYc¸źl
 hengermű/WŢŘÔyjYcČR	űvek
 hengerlő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X)Ó_PRESPART_adj
 hengerlés/XVËŻj×LÓnňéčłÄäTtYc¸źl)Ás_PROCESS/RESULT_noun
@@ -35273,12 +35349,12 @@ helytáll
 helytelenítő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 helytartóság/UĘŽiÖKŇmôáyÇżßSsYcť
 helységtábla/ŐAUQĘŽiĎŇáyÇżßYcť
-helységnévtár/UmôŇyiYcÇ	égnévtárak
-helységnévtábla/ŐAUQĘŽiĎŇáyÇżßYcť
+helységnévtár/UmôŇyiYcÇ	égnévtárakég|név||tár
+helységnévtábla/ŐAUQĘŽiĎŇáyÇżßYcťég|név||tábla
 helységnév/VÓnňyjYcČ	égnevek
 helység/VËŻj×LÓnňéčłÄäTtYc¸źl
 helyszűke/ŐBVRËŻjĐÓéčłÄäYc¸ź
-helyszínrajz/UĘŽiÖKŇmôáyÇżßSsYcť
+helyszínrajz/UĘŽiÖKŇmôáyÇżßSsYcťín||rajz
 helyszínelő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 helyszínelés/VËŻj×LÓnňéčłÄäTtYc¸źl
 helyszín/VËŻj×LÓnňéyČŔŕTtYcź
@@ -35323,7 +35399,7 @@ helybenhagyólag
 helybenhagyás/UĘŽiÖKŇmôáyÇżßSsYcť
 hely/×VËŻjLÓnňéčłÄäTtYc¸ź
 hellenizáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-hellenizmus/UĘŽiÖKŇmôáyÇżßSsYcť
+hellenizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hellenista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 heliotropizmus/UĘŽiÖKŇmôáyÇżßSsYcť
 helioszkóp/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -35349,7 +35425,7 @@ hehe
 heh
 hegyvonulat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hegytető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-hegységrendszer/VËŻj×LÓnňéyČŔŕRYcź
+hegységrendszer/VËŻj×LÓnňéyČŔŕRYcźég||rend|szer
 hegység/VËŻj×LÓnňéčłÄäTtYc¸źl
 hegyszoros/UĘŽiÖKŇmôáyÇżßSsYcť
 hegyrajz/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -35362,7 +35438,7 @@ hegylánc/UĘŽiÖKŇmôáyÇżßSsYcť
 hegyiüteg/VËŻj×LÓnňéyČŔŕRTtYcź
 hegyiágyú/ŐAUQĘŽiĎŇáyÇżßYcť
 hegyivadász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-hegyiszitakötő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+hegyiszitakötő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ötő
 hegyipáfrány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hegyimentő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 hegyikristály/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -35492,30 +35568,36 @@ hatály/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hatványkitevő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 hatvány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hatvanötödik/!VÓn×Llbh)öt
-hatvanöttrillióan/b)öttrillió
-hatvanöttrillió/ĎŇŐAUÚQbci	öttrillióan
-hatvanöttrilliárd/mÖKkUÚQbci
-hatvanötmillióan/b)ötmillió
-hatvanötmillió/ĎŇŐAUÚQbcj	ötmillióan
-hatvanötmilliárdan/b)ötmilliárd
-hatvanötmilliárd/mÖKkUÚQbci	ötmilliárdan
-hatvanötfelé
-hatvanötezres/×BŐVb)ötezer
-hatvanötezren/b)ötezer
-hatvanötezrek/Ib)ötezer
-hatvanötezredik/nÓ×BVÜb)ötezer
-hatvanötezred/BVÜb)ötezer
-hatvanötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred
+hatvanöttrillióan/b)öttrillió	öt||trillióan
+hatvanöttrillió/ĎŇŐAUÚQbci	öttrillióan	öt||trillió
+hatvanöttrilliárd/mÖKkUÚQbci	öt||trilliárd
+hatvanötmillióan/b)ötmillió	öt||millióan
+hatvanötmillió/ĎŇŐAUÚQbcj	ötmillióan	öt||millió
+hatvanötmilliárdan/b)ötmilliárd	öt||milliárdan
+hatvanötmilliárd/mÖKkUÚQbci	ötmilliárdan	öt||milliárd
+hatvanötfeléöt||felé
+hatvanötezres/×BŐVb)ötezer	öt||ezres
+hatvanötezren/b)ötezer	öt||ezren
+hatvanötezrek/Ib)ötezer	öt||ezrek
+hatvanötezredik/nÓ×BVÜb)ötezer	öt||ezredik
+hatvanötezred/BVÜb)ötezer	öt||ezred
+hatvanötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred	öt||ezer
 hatvanöten/bh)öt
-hatvanötbillióan/b)ötbillió
-hatvanötbillió/ĎŇŐAUÚQbci	ötbillióan
-hatvanötbilliárd/mÖKkUÚQbci
+hatvanötbillióan/b)ötbillió	öt||billióan
+hatvanötbillió/ĎŇŐAUÚQbci	ötbillióan	öt||billió
+hatvanötbilliárd/mÖKkUÚQbci	öt||billiárd
 hatvanöt/ÝWŰMRbhc	ötödiköten
 hatvanóránként
 hatvanórai
 hatvanévi
 hatvanévente
 hatvanévenként
+hatvanvalahánymillió/ĎŇŐAUÚQbcj	ány||millió
+hatvanvalahánymilliárd/mÖKkUÚQbci	ány||milliárd
+hatvanvalahányfeléány||felé
+hatvanvalahányezres/×BŐVb)ányezer	ány||ezres
+hatvanvalahányezren/b)ányezer	ány||ezren
+hatvanvalahányezer/ŐnBVÜjbc	ányezresányezren	ány||ezer
 hatvanvalahányan/bh))ány
 hatvanvalahányan/bh)
 hatvanvalahányadikak/nI))ány
@@ -35526,42 +35608,42 @@ hatvantrillióan/b)ó
 hatvantrillió/ĎŇŐAUÚQbci	óan
 hatvantrilliárd/mÖKkUÚQbci
 hatvanpercenként
-hatvannégytrillióan/b)égytrillió
-hatvannégytrillió/ĎŇŐAUÚQbci	égytrillióan
-hatvannégytrilliárd/mÖKkUÚQbci
-hatvannégymillióan/b)égymillió
-hatvannégymillió/ĎŇŐAUÚQbcj	égymillióan
-hatvannégymilliárdan/b)égymilliárd
-hatvannégymilliárd/mÖKkUÚQbci	égymilliárdan
-hatvannégyfelé
-hatvannégyezres/×BŐVb)égyezer
-hatvannégyezren/b)égyezer
-hatvannégyezrek/Ib)égyezer
-hatvannégyezredik/nÓ×BVÜb)égyezer
-hatvannégyezred/BVÜb)égyezer
-hatvannégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred
+hatvannégytrillióan/b)égytrillió	égy||trillióan
+hatvannégytrillió/ĎŇŐAUÚQbci	égytrillióan	égy||trillió
+hatvannégytrilliárd/mÖKkUÚQbci	égy||trilliárd
+hatvannégymillióan/b)égymillió	égy||millióan
+hatvannégymillió/ĎŇŐAUÚQbcj	égymillióan	égy||millió
+hatvannégymilliárdan/b)égymilliárd	égy||milliárdan
+hatvannégymilliárd/mÖKkUÚQbci	égymilliárdan	égy||milliárd
+hatvannégyfeléégy||felé
+hatvannégyezres/×BŐVb)égyezer	égy||ezres
+hatvannégyezren/b)égyezer	égy||ezren
+hatvannégyezrek/Ib)égyezer	égy||ezrek
+hatvannégyezredik/nÓ×BVÜb)égyezer	égy||ezredik
+hatvannégyezred/BVÜb)égyezer	égy||ezred
+hatvannégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred	égy||ezer
 hatvannégyen/bh)égy
-hatvannégybillióan/b)égybillió
-hatvannégybillió/ĎŇŐAUÚQbci	égybillióan
-hatvannégybilliárd/mÖKkUÚQbci
+hatvannégybillióan/b)égybillió	égy||billióan
+hatvannégybillió/ĎŇŐAUÚQbci	égybillióan	égy||billió
+hatvannégybilliárd/mÖKkUÚQbci	égy||billiárd
 hatvannégy/nVÜLlTtbhc	égyen
-hatvannyolctrillióan/b)ó
-hatvannyolctrillió/ĎŇŐAUÚQbci	óan
-hatvannyolctrilliárd/mÖKkUÚQbci
-hatvannyolcmillióan/b)ó
-hatvannyolcmillió/ĎŇŐAUÚQbcj	óan
-hatvannyolcmilliárdan/b)árd
-hatvannyolcmilliárd/mÖKkUÚQbci	árdan
-hatvannyolcfelé
+hatvannyolctrillióan/b)ó	óan
+hatvannyolctrillió/ĎŇŐAUÚQbci	óan	ó
+hatvannyolctrilliárd/mÖKkUÚQbci	árd
+hatvannyolcmillióan/b)ó	óan
+hatvannyolcmillió/ĎŇŐAUÚQbcj	óan	ó
+hatvannyolcmilliárdan/b)árd	árdan
+hatvannyolcmilliárd/mÖKkUÚQbci	árdan	árd
+hatvannyolcfeléé
 hatvannyolcezres/×BŐVb)
 hatvannyolcezren/b)
 hatvannyolcezrek/Ib)
 hatvannyolcezredik/nÓ×BVÜb)
 hatvannyolcezred/BVÜb)
 hatvannyolcezer/ŐnBVÜjbc
-hatvannyolcbillióan/b)ó
-hatvannyolcbillió/ĎŇŐAUÚQbci	óan
-hatvannyolcbilliárd/mÖKkUÚQbci
+hatvannyolcbillióan/b)ó	óan
+hatvannyolcbillió/ĎŇŐAUÚQbci	óan	ó
+hatvannyolcbilliárd/mÖKkUÚQbci	árd
 hatvannyolcan/bh)
 hatvannyolcadikak/nI)
 hatvannyolcadik/!AUÖmŇŮKkbh)
@@ -35573,32 +35655,32 @@ hatvanmillióan/b)ó
 hatvanmillió/ĎŇŐAUÚQbcj	óan
 hatvanmilliárdan/b)árd
 hatvanmilliárd/mÖKkUÚQbci	árdan
-hatvankéttrillióan/b)éttrillió
-hatvankéttrillió/ĎŇŐAUÚQbci	éttrillióan
-hatvankéttrilliárd/mÖKkUÚQbci
-hatvankétmillióan/b)étmillió
-hatvankétmillió/ĎŇŐAUÚQbcj	étmillióan
-hatvankétmilliárdan/b)étmilliárd
-hatvankétmilliárd/mÖKkUÚQbci	étmilliárdan
-hatvankétfelé
-hatvankétezres/×BŐVb)étezer
-hatvankétezren/b)étezer
-hatvankétezrek/Ib)étezer
-hatvankétezredik/nÓ×BVÜb)étezer
-hatvankétezred/BVÜb)étezer
-hatvankétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-hatvankétbillióan/b)étbillió
-hatvankétbillió/ĎŇŐAUÚQbci	étbillióan
-hatvankétbilliárd/mÖKkUÚQbci
+hatvankéttrillióan/b)éttrillió	ét||trillióan
+hatvankéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+hatvankéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+hatvankétmillióan/b)étmillió	ét||millióan
+hatvankétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+hatvankétmilliárdan/b)étmilliárd	ét||milliárdan
+hatvankétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+hatvankétfeléét||felé
+hatvankétezres/×BŐVb)étezer	ét||ezres
+hatvankétezren/b)étezer	ét||ezren
+hatvankétezrek/Ib)étezer	ét||ezrek
+hatvankétezredik/nÓ×BVÜb)étezer	ét||ezredik
+hatvankétezred/BVÜb)étezer	ét||ezred
+hatvankétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+hatvankétbillióan/b)étbillió	ét||billióan
+hatvankétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+hatvankétbilliárd/mÖKkUÚQbci	ét||billiárd
 hatvankét/bÜhc
-hatvankilenctrillióan/b)ó
-hatvankilenctrillió/ĎŇŐAUÚQbci	óan
-hatvankilenctrilliárd/mÖKkUÚQbci
-hatvankilencmillióan/b)ó
-hatvankilencmillió/ĎŇŐAUÚQbcj	óan
-hatvankilencmilliárdan/b)árd
-hatvankilencmilliárd/mÖKkUÚQbci	árdan
-hatvankilencfelé
+hatvankilenctrillióan/b)ó	óan
+hatvankilenctrillió/ĎŇŐAUÚQbci	óan	ó
+hatvankilenctrilliárd/mÖKkUÚQbci	árd
+hatvankilencmillióan/b)ó	óan
+hatvankilencmillió/ĎŇŐAUÚQbcj	óan	ó
+hatvankilencmilliárdan/b)árd	árdan
+hatvankilencmilliárd/mÖKkUÚQbci	árdan	árd
+hatvankilencfeléé
 hatvankilencezres/×BŐVb)
 hatvankilencezren/b)
 hatvankilencezrek/Ib)
@@ -35607,65 +35689,65 @@ hatvankilencezred/BVÜb)
 hatvankilencezer/ŐnBVÜjbc
 hatvankilencen/bh)
 hatvankilencedik/!VÓn×Llbh)
-hatvankilencbillióan/b)ó
-hatvankilencbillió/ĎŇŐAUÚQbci	óan
-hatvankilencbilliárd/mÖKkUÚQbci
+hatvankilencbillióan/b)ó	óan
+hatvankilencbillió/ĎŇŐAUÚQbci	óan	ó
+hatvankilencbilliárd/mÖKkUÚQbci	árd
 hatvankilenc/nňVÜLlTtbhc
-hatvankettőtrillióan/b)őtrillió
-hatvankettőtrillió/ĎŇŐAUÚQbci	őtrillióan
-hatvankettőtrilliárd/mÖKkUÚQbci
-hatvankettőmillióan/b)őmillió
-hatvankettőmillió/ĎŇŐAUÚQbcj	őmillióan
-hatvankettőmilliárdan/b)őmilliárd
-hatvankettőmilliárd/mÖKkUÚQbci	őmilliárdan
-hatvankettőfelé
-hatvankettőezres/×BŐVb)őezer
-hatvankettőezren/b)őezer
-hatvankettőezrek/Ib)őezer
-hatvankettőezredik/nÓ×BVÜb)őezer
-hatvankettőezred/BVÜb)őezer
-hatvankettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred
-hatvankettőbillióan/b)őbillió
-hatvankettőbillió/ĎŇŐAUÚQbci	őbillióan
-hatvankettőbilliárd/mÖKkUÚQbci
+hatvankettőtrillióan/b)őtrillió	ő||trillióan
+hatvankettőtrillió/ĎŇŐAUÚQbci	őtrillióan	ő||trillió
+hatvankettőtrilliárd/mÖKkUÚQbci	ő||trilliárd
+hatvankettőmillióan/b)őmillió	ő||millióan
+hatvankettőmillió/ĎŇŐAUÚQbcj	őmillióan	ő||millió
+hatvankettőmilliárdan/b)őmilliárd	ő||milliárdan
+hatvankettőmilliárd/mÖKkUÚQbci	őmilliárdan	ő||milliárd
+hatvankettőfeléő||felé
+hatvankettőezres/×BŐVb)őezer	ő||ezres
+hatvankettőezren/b)őezer	ő||ezren
+hatvankettőezrek/Ib)őezer	ő||ezrek
+hatvankettőezredik/nÓ×BVÜb)őezer	ő||ezredik
+hatvankettőezred/BVÜb)őezer	ő||ezred
+hatvankettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred	ő||ezer
+hatvankettőbillióan/b)őbillió	ő||billióan
+hatvankettőbillió/ĎŇŐAUÚQbci	őbillióan	ő||billió
+hatvankettőbilliárd/mÖKkUÚQbci	ő||billiárd
 hatvankettő/ŢWŰMRbhc
 hatvanketten/bh)ő
 hatvankettedik/!VÓn×Llbh)ő
-hatvanhéttrillióan/b)éttrillió
-hatvanhéttrillió/ĎŇŐAUÚQbci	éttrillióan
-hatvanhéttrilliárd/mÖKkUÚQbci
-hatvanhétmillióan/b)étmillió
-hatvanhétmillió/ĎŇŐAUÚQbcj	étmillióan
-hatvanhétmilliárdan/b)étmilliárd
-hatvanhétmilliárd/mÖKkUÚQbci	étmilliárdan
-hatvanhétfelé
-hatvanhétezres/×BŐVb)étezer
-hatvanhétezren/b)étezer
-hatvanhétezrek/Ib)étezer
-hatvanhétezredik/nÓ×BVÜb)étezer
-hatvanhétezred/BVÜb)étezer
-hatvanhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-hatvanhétbillióan/b)étbillió
-hatvanhétbillió/ĎŇŐAUÚQbci	étbillióan
-hatvanhétbilliárd/mÖKkUÚQbci
+hatvanhéttrillióan/b)éttrillió	ét||trillióan
+hatvanhéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+hatvanhéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+hatvanhétmillióan/b)étmillió	ét||millióan
+hatvanhétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+hatvanhétmilliárdan/b)étmilliárd	ét||milliárdan
+hatvanhétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+hatvanhétfeléét||felé
+hatvanhétezres/×BŐVb)étezer	ét||ezres
+hatvanhétezren/b)étezer	ét||ezren
+hatvanhétezrek/Ib)étezer	ét||ezrek
+hatvanhétezredik/nÓ×BVÜb)étezer	ét||ezredik
+hatvanhétezred/BVÜb)étezer	ét||ezred
+hatvanhétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+hatvanhétbillióan/b)étbillió	ét||billióan
+hatvanhétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+hatvanhétbilliárd/mÖKkUÚQbci	ét||billiárd
 hatvanhét/nVÜbhc
-hatvanháromtrillióan/b)áromtrillió
-hatvanháromtrillió/ĎŇŐAUÚQbci	áromtrillióan
-hatvanháromtrilliárd/mÖKkUÚQbci
-hatvanhárommillióan/b)árommillió
-hatvanhárommillió/ĎŇŐAUÚQbcj	árommillióan
-hatvanhárommilliárdan/b)árommilliárd
-hatvanhárommilliárd/mÖKkUÚQbci	árommilliárdan
-hatvanháromfelé
-hatvanháromezres/×BŐVb)áromezer
-hatvanháromezren/b)áromezer
-hatvanháromezrek/Ib)áromezer
-hatvanháromezredik/nÓ×BVÜb)áromezer
-hatvanháromezred/BVÜb)áromezer
-hatvanháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred
-hatvanhárombillióan/b)árombillió
-hatvanhárombillió/ĎŇŐAUÚQbci	árombillióan
-hatvanhárombilliárd/mÖKkUÚQbci
+hatvanháromtrillióan/b)áromtrillió	árom||trillióan
+hatvanháromtrillió/ĎŇŐAUÚQbci	áromtrillióan	árom||trillió
+hatvanháromtrilliárd/mÖKkUÚQbci	árom||trilliárd
+hatvanhárommillióan/b)árommillió	árom||millióan
+hatvanhárommillió/ĎŇŐAUÚQbcj	árommillióan	árom||millió
+hatvanhárommilliárdan/b)árommilliárd	árom||milliárdan
+hatvanhárommilliárd/mÖKkUÚQbci	árommilliárdan	árom||milliárd
+hatvanháromfeléárom||felé
+hatvanháromezres/×BŐVb)áromezer	árom||ezres
+hatvanháromezren/b)áromezer	árom||ezren
+hatvanháromezrek/Ib)áromezer	árom||ezrek
+hatvanháromezredik/nÓ×BVÜb)áromezer	árom||ezredik
+hatvanháromezred/BVÜb)áromezer	árom||ezred
+hatvanháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred	árom||ezer
+hatvanhárombillióan/b)árombillió	árom||billióan
+hatvanhárombillió/ĎŇŐAUÚQbci	árombillióan	árom||billió
+hatvanhárombilliárd/mÖKkUÚQbci	árom||billiárd
 hatvanhárom/mUÚbhc	ármanármak
 hatvanhárman/bh)árom
 hatvanhármak/Ibh)árom
@@ -35678,25 +35760,25 @@ hatvanhetedik/!VÓn×Llbh)ét
 hatvanhavonta
 hatvanhavonként
 hatvanhavi
-hatvanhattrillióan/b)ó
-hatvanhattrillió/ĎŇŐAUÚQbci	óan
-hatvanhattrilliárd/mÖKkUÚQbci
+hatvanhattrillióan/b)ó	óan
+hatvanhattrillió/ĎŇŐAUÚQbci	óan	ó
+hatvanhattrilliárd/mÖKkUÚQbci	árd
 hatvanhatodikak/nI)
 hatvanhatodik/!AUÖmŇŮKkbh)
-hatvanhatmillióan/b)ó
-hatvanhatmillió/ĎŇŐAUÚQbcj	óan
-hatvanhatmilliárdan/b)árd
-hatvanhatmilliárd/mÖKkUÚQbci	árdan
-hatvanhatfelé
+hatvanhatmillióan/b)ó	óan
+hatvanhatmillió/ĎŇŐAUÚQbcj	óan	ó
+hatvanhatmilliárdan/b)árd	árdan
+hatvanhatmilliárd/mÖKkUÚQbci	árdan	árd
+hatvanhatfeléé
 hatvanhatezres/×BŐVb)
 hatvanhatezren/b)
 hatvanhatezrek/Ib)
 hatvanhatezredik/nÓ×BVÜb)
 hatvanhatezred/BVÜb)
 hatvanhatezer/ŐnBVÜjbc
-hatvanhatbillióan/b)ó
-hatvanhatbillió/ĎŇŐAUÚQbci	óan
-hatvanhatbilliárd/mÖKkUÚQbci
+hatvanhatbillióan/b)ó	óan
+hatvanhatbillió/ĎŇŐAUÚQbci	óan	ó
+hatvanhatbilliárd/mÖKkUÚQbci	árd
 hatvanhatan/bh)
 hatvanhat/mUÚKkbhc
 hatvanharmadikak/nI)árom
@@ -35710,14 +35792,14 @@ hatvanezred/BVÜb)
 hatvanezer/ŐnBVÜjbc
 hatvanesztendőnként
 hatvanesztendei
-hatvanegytrillióan/b)ó
-hatvanegytrillió/ĎŇŐAUÚQbci	óan
-hatvanegytrilliárd/mÖKkUÚQbci
-hatvanegymillióan/b)ó
-hatvanegymillió/ĎŇŐAUÚQbcj	óan
-hatvanegymilliárdan/b)árd
-hatvanegymilliárd/mÖKkUÚQbci	árdan
-hatvanegyfelé
+hatvanegytrillióan/b)ó	óan
+hatvanegytrillió/ĎŇŐAUÚQbci	óan	ó
+hatvanegytrilliárd/mÖKkUÚQbci	árd
+hatvanegymillióan/b)ó	óan
+hatvanegymillió/ĎŇŐAUÚQbcj	óan	ó
+hatvanegymilliárdan/b)árd	árdan
+hatvanegymilliárd/mÖKkUÚQbci	árdan	árd
+hatvanegyfeléé
 hatvanegyezres/×BŐVb)
 hatvanegyezren/b)
 hatvanegyezrek/Ib)
@@ -35726,9 +35808,9 @@ hatvanegyezred/BVÜb)
 hatvanegyezer/ŐnBVÜjbc
 hatvanegyen/bh)
 hatvanegyedik/VÓn×Llbh)
-hatvanegybillióan/b)ó
-hatvanegybillió/ĎŇŐAUÚQbci	óan
-hatvanegybilliárd/mÖKkUÚQbci
+hatvanegybillióan/b)ó	óan
+hatvanegybillió/ĎŇŐAUÚQbci	óan	ó
+hatvanegybilliárd/mÖKkUÚQbci	árd
 hatvanegy/nVÜLlbhc
 hatvanbillióan/b)ó
 hatvanbillió/ĎŇŐAUÚQbci	óan
@@ -35736,7 +35818,7 @@ hatvanbilliárd/mÖKkUÚQbci
 hatvanas/UĘŽiÖKŇmôáç˛ĂăSscˇťkADFabh
 hatvanas/UĘŽiÖKŇmôáç˛ĂăSscˇťkADFabh
 hatvanan/bh)
-hatvanakfelé
+hatvanakfeléé
 hatvanadszorra/bh)
 hatvanadszori/bh
 hatvanadszor
@@ -35766,14 +35848,14 @@ hattak/wX
 hattad/wX
 hatta/wX
 hatszög/VNËŻj×LÝňÔéyČŔŕTtYcź
-hatszázfelé
-hatszázezres/×BŐV
-hatszázezrek/I)ázezer
+hatszázfeléáz||felé
+hatszázezres/×BŐV	áz||ezres
+hatszázezrek/I)ázezer	áz||ezrek
 hatszázas/AFUÚ)áz
 hatszázan/)áz
 hatszázadik/mŇŮAUÚ)áz
 hatszázad/AUÚ)áz
-hatszáz/$UŮÖmŇSscÚ	ázasázanázadikázadázasázadikázad
+hatszáz/$UŮÖmŇSscÚ	ázasázanázadikázad
 hatszemközt
 hatpercenként
 hatpennys/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -35806,13 +35888,13 @@ hatodiki/AUŇŐĎľ)
 hatodikak/nI)
 hatodika/AUŇŐĎľ)
 hatodik/c!AUÖmŇŮKkabh)
-hatodféltrillió/AUŐĎŇKQxcˇĂżÇ
-hatodfélszázad/AUÖmŇKkQcˇĂżÇ
-hatodfélszáz/$UŮÖmŇSscÇ
-hatodfélmillió/AUŐĎŇKQxcˇĂżÇ
-hatodfélmilliárd/AUÖmŇKkQcˇĂżÇ
-hatodfélezer/VÓn×LlTtcČ
-hatodfélbillió/AUŐĎŇKQxcˇĂżÇ
+hatodféltrillió/AUŐĎŇKQxcˇĂżÇ	él||trillió
+hatodfélszázad/AUÖmŇKkQcˇĂżÇ	él||század
+hatodfélszáz/$UŮÖmŇSscÇ	él||száz
+hatodfélmillió/AUŐĎŇKQxcˇĂżÇ	él||millió
+hatodfélmilliárd/AUÖmŇKkQcˇĂżÇ	él||milliárd
+hatodfélezer/VÓn×LlTtcČ	él||ezer
+hatodfélbillió/AUŐĎŇKQxcˇĂżÇ	él||billió
 hatodfél/VÓnňyjYcČ)él	él
 hatodannyian
 hatodannyi/UŐĎŇ
@@ -35838,7 +35920,7 @@ hatezrek/Iba)
 hatezrek/Iba)
 hatezredik/nÓ×BVÜb)
 hatezred/BVÜb)
-hatezerfelé
+hatezerfeléé
 hatezer/ŐnBVÜjbcÓ×LlTts
 hatesztendőnként
 hatesztendei
@@ -35850,7 +35932,7 @@ hatan/abh)
 hatalomátmentés/VËŻj×LÓnňéčłÄäTtYc¸źl
 hatalommegosztás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hatalom/UmôçiYcŽk
-hat-hétmillió/ĎŇŐAUÚQbcw
+hat-hétmillió/ĎŇŐAUÚQbcw	ét|millió
 hat/mUÚKkbhcÖŇSsa	átokálák
 hasüreg/VËŻj×LÓnňéyČŔŕTtYcź
 hasítóbárd/UĘŽiÖKŇmôáyÇżßQYcť
@@ -35876,12 +35958,12 @@ hasonul
 hasonmód
 hasonmás/UĘŽiÖKŇmôáyÇżßSsYcť
 hasonlat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-hasnyálmirigy/VËŻj×LÓnňéyČŔŕTtYcź
+hasnyálmirigy/VËŻj×LÓnňéyČŔŕTtYcźál||mirigy
 hasmánt
 hasmenés/VËŻj×LÓnňéyČŔŕTtYcź
 haskó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hasis/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-hashártyagyulladás/UĘŽiÖKŇmôáyÇżßSsYcť
+hashártyagyulladás/UĘŽiÖKŇmôáyÇżßSsYcťártya||gyulladás
 hashártya/ŐAUQĘŽiĎŇáyÇżßYcť
 hashtag/VËŻj×LnÓňéčłÄäRYc¸źl	ph:hesteg
 hashajtó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -35923,24 +36005,24 @@ harmonikázik
 harmonikás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 harmonika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 harmincötödik/!VÓn×Llbh)öt
-harmincöttrillióan/b)öttrillió
-harmincöttrillió/ĎŇŐAUÚQbci	öttrillióan
-harmincöttrilliárd/mÖKkUÚQbci
-harmincötmillióan/b)ötmillió
-harmincötmillió/ĎŇŐAUÚQbcj	ötmillióan
-harmincötmilliárdan/b)ötmilliárd
-harmincötmilliárd/mÖKkUÚQbci	ötmilliárdan
-harmincötfelé
-harmincötezres/×BŐVb)ötezer
-harmincötezren/b)ötezer
-harmincötezrek/Ib)ötezer
-harmincötezredik/nÓ×BVÜb)ötezer
-harmincötezred/BVÜb)ötezer
-harmincötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred
+harmincöttrillióan/b)öttrillió	öt||trillióan
+harmincöttrillió/ĎŇŐAUÚQbci	öttrillióan	öt||trillió
+harmincöttrilliárd/mÖKkUÚQbci	öt||trilliárd
+harmincötmillióan/b)ötmillió	öt||millióan
+harmincötmillió/ĎŇŐAUÚQbcj	ötmillióan	öt||millió
+harmincötmilliárdan/b)ötmilliárd	öt||milliárdan
+harmincötmilliárd/mÖKkUÚQbci	ötmilliárdan	öt||milliárd
+harmincötfeléöt||felé
+harmincötezres/×BŐVb)ötezer	öt||ezres
+harmincötezren/b)ötezer	öt||ezren
+harmincötezrek/Ib)ötezer	öt||ezrek
+harmincötezredik/nÓ×BVÜb)ötezer	öt||ezredik
+harmincötezred/BVÜb)ötezer	öt||ezred
+harmincötezer/ŐnBVÜjbc	ötezresötezrenötezrekötezredikötezred	öt||ezer
 harmincöten/bh)öt
-harmincötbillióan/b)ötbillió
-harmincötbillió/ĎŇŐAUÚQbci	ötbillióan
-harmincötbilliárd/mÖKkUÚQbci
+harmincötbillióan/b)ötbillió	öt||billióan
+harmincötbillió/ĎŇŐAUÚQbci	ötbillióan	öt||billió
+harmincötbilliárd/mÖKkUÚQbci	öt||billiárd
 harmincöt/ÝWŰMRbhc	ötödiköten
 harmincóránként
 harmincórai
@@ -35948,6 +36030,12 @@ harmincévi
 harmincévesforma
 harmincévente
 harmincévenként
+harmincvalahánymillió/ĎŇŐAUÚQbcj	ány||millió
+harmincvalahánymilliárd/mÖKkUÚQbci	ány||milliárd
+harmincvalahányfeléány||felé
+harmincvalahányezres/×BŐVb)ányezer	ány||ezres
+harmincvalahányezren/b)ányezer	ány||ezren
+harmincvalahányezer/ŐnBVÜjbc	ányezresányezren	ány||ezer
 harmincvalahányan/bh))ány
 harmincvalahányan/bh)
 harmincvalahányadiki/AUŇŐĎľ))ány
@@ -35961,42 +36049,42 @@ harminctrillióan/b)ó
 harminctrillió/ĎŇŐAUÚQbci	óan
 harminctrilliárd/mÖKkUÚQbci
 harmincpercenként
-harmincnégytrillióan/b)égytrillió
-harmincnégytrillió/ĎŇŐAUÚQbci	égytrillióan
-harmincnégytrilliárd/mÖKkUÚQbci
-harmincnégymillióan/b)égymillió
-harmincnégymillió/ĎŇŐAUÚQbcj	égymillióan
-harmincnégymilliárdan/b)égymilliárd
-harmincnégymilliárd/mÖKkUÚQbci	égymilliárdan
-harmincnégyfelé
-harmincnégyezres/×BŐVb)égyezer
-harmincnégyezren/b)égyezer
-harmincnégyezrek/Ib)égyezer
-harmincnégyezredik/nÓ×BVÜb)égyezer
-harmincnégyezred/BVÜb)égyezer
-harmincnégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred
+harmincnégytrillióan/b)égytrillió	égy||trillióan
+harmincnégytrillió/ĎŇŐAUÚQbci	égytrillióan	égy||trillió
+harmincnégytrilliárd/mÖKkUÚQbci	égy||trilliárd
+harmincnégymillióan/b)égymillió	égy||millióan
+harmincnégymillió/ĎŇŐAUÚQbcj	égymillióan	égy||millió
+harmincnégymilliárdan/b)égymilliárd	égy||milliárdan
+harmincnégymilliárd/mÖKkUÚQbci	égymilliárdan	égy||milliárd
+harmincnégyfeléégy||felé
+harmincnégyezres/×BŐVb)égyezer	égy||ezres
+harmincnégyezren/b)égyezer	égy||ezren
+harmincnégyezrek/Ib)égyezer	égy||ezrek
+harmincnégyezredik/nÓ×BVÜb)égyezer	égy||ezredik
+harmincnégyezred/BVÜb)égyezer	égy||ezred
+harmincnégyezer/ŐnBVÜjbc	égyezreségyezrenégyezrekégyezredikégyezred	égy||ezer
 harmincnégyen/bh)égy
-harmincnégybillióan/b)égybillió
-harmincnégybillió/ĎŇŐAUÚQbci	égybillióan
-harmincnégybilliárd/mÖKkUÚQbci
+harmincnégybillióan/b)égybillió	égy||billióan
+harmincnégybillió/ĎŇŐAUÚQbci	égybillióan	égy||billió
+harmincnégybilliárd/mÖKkUÚQbci	égy||billiárd
 harmincnégy/nVÜLlTtbhc	égyen
-harmincnyolctrillióan/b)ó
-harmincnyolctrillió/ĎŇŐAUÚQbci	óan
-harmincnyolctrilliárd/mÖKkUÚQbci
-harmincnyolcmillióan/b)ó
-harmincnyolcmillió/ĎŇŐAUÚQbcj	óan
-harmincnyolcmilliárdan/b)árd
-harmincnyolcmilliárd/mÖKkUÚQbci	árdan
-harmincnyolcfelé
+harmincnyolctrillióan/b)ó	óan
+harmincnyolctrillió/ĎŇŐAUÚQbci	óan	ó
+harmincnyolctrilliárd/mÖKkUÚQbci	árd
+harmincnyolcmillióan/b)ó	óan
+harmincnyolcmillió/ĎŇŐAUÚQbcj	óan	ó
+harmincnyolcmilliárdan/b)árd	árdan
+harmincnyolcmilliárd/mÖKkUÚQbci	árdan	árd
+harmincnyolcfeléé
 harmincnyolcezres/×BŐVb)
 harmincnyolcezren/b)
 harmincnyolcezrek/Ib)
 harmincnyolcezredik/nÓ×BVÜb)
 harmincnyolcezred/BVÜb)
 harmincnyolcezer/ŐnBVÜjbc
-harmincnyolcbillióan/b)ó
-harmincnyolcbillió/ĎŇŐAUÚQbci	óan
-harmincnyolcbilliárd/mÖKkUÚQbci
+harmincnyolcbillióan/b)ó	óan
+harmincnyolcbillió/ĎŇŐAUÚQbci	óan	ó
+harmincnyolcbilliárd/mÖKkUÚQbci	árd
 harmincnyolcan/bh)
 harmincnyolcadikak/nI)
 harmincnyolcadik/!AUÖmŇŮKkbh)
@@ -36008,32 +36096,32 @@ harmincmillióan/b)ó
 harmincmillió/ĎŇŐAUÚQbcj	óan
 harmincmilliárdan/b)árd
 harmincmilliárd/mÖKkUÚQbci	árdan
-harminckéttrillióan/b)éttrillió
-harminckéttrillió/ĎŇŐAUÚQbci	éttrillióan
-harminckéttrilliárd/mÖKkUÚQbci
-harminckétmillióan/b)étmillió
-harminckétmillió/ĎŇŐAUÚQbcj	étmillióan
-harminckétmilliárdan/b)étmilliárd
-harminckétmilliárd/mÖKkUÚQbci	étmilliárdan
-harminckétfelé
-harminckétezres/×BŐVb)étezer
-harminckétezren/b)étezer
-harminckétezrek/Ib)étezer
-harminckétezredik/nÓ×BVÜb)étezer
-harminckétezred/BVÜb)étezer
-harminckétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-harminckétbillióan/b)étbillió
-harminckétbillió/ĎŇŐAUÚQbci	étbillióan
-harminckétbilliárd/mÖKkUÚQbci
+harminckéttrillióan/b)éttrillió	ét||trillióan
+harminckéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+harminckéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+harminckétmillióan/b)étmillió	ét||millióan
+harminckétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+harminckétmilliárdan/b)étmilliárd	ét||milliárdan
+harminckétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+harminckétfeléét||felé
+harminckétezres/×BŐVb)étezer	ét||ezres
+harminckétezren/b)étezer	ét||ezren
+harminckétezrek/Ib)étezer	ét||ezrek
+harminckétezredik/nÓ×BVÜb)étezer	ét||ezredik
+harminckétezred/BVÜb)étezer	ét||ezred
+harminckétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+harminckétbillióan/b)étbillió	ét||billióan
+harminckétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+harminckétbilliárd/mÖKkUÚQbci	ét||billiárd
 harminckét/bÜhc
-harminckilenctrillióan/b)ó
-harminckilenctrillió/ĎŇŐAUÚQbci	óan
-harminckilenctrilliárd/mÖKkUÚQbci
-harminckilencmillióan/b)ó
-harminckilencmillió/ĎŇŐAUÚQbcj	óan
-harminckilencmilliárdan/b)árd
-harminckilencmilliárd/mÖKkUÚQbci	árdan
-harminckilencfelé
+harminckilenctrillióan/b)ó	óan
+harminckilenctrillió/ĎŇŐAUÚQbci	óan	ó
+harminckilenctrilliárd/mÖKkUÚQbci	árd
+harminckilencmillióan/b)ó	óan
+harminckilencmillió/ĎŇŐAUÚQbcj	óan	ó
+harminckilencmilliárdan/b)árd	árdan
+harminckilencmilliárd/mÖKkUÚQbci	árdan	árd
+harminckilencfeléé
 harminckilencezres/×BŐVb)
 harminckilencezren/b)
 harminckilencezrek/Ib)
@@ -36042,65 +36130,65 @@ harminckilencezred/BVÜb)
 harminckilencezer/ŐnBVÜjbc
 harminckilencen/bh)
 harminckilencedik/!VÓn×Llbh)
-harminckilencbillióan/b)ó
-harminckilencbillió/ĎŇŐAUÚQbci	óan
-harminckilencbilliárd/mÖKkUÚQbci
+harminckilencbillióan/b)ó	óan
+harminckilencbillió/ĎŇŐAUÚQbci	óan	ó
+harminckilencbilliárd/mÖKkUÚQbci	árd
 harminckilenc/nňVÜLlTtbhc
-harminckettőtrillióan/b)őtrillió
-harminckettőtrillió/ĎŇŐAUÚQbci	őtrillióan
-harminckettőtrilliárd/mÖKkUÚQbci
-harminckettőmillióan/b)őmillió
-harminckettőmillió/ĎŇŐAUÚQbcj	őmillióan
-harminckettőmilliárdan/b)őmilliárd
-harminckettőmilliárd/mÖKkUÚQbci	őmilliárdan
-harminckettőfelé
-harminckettőezres/×BŐVb)őezer
-harminckettőezren/b)őezer
-harminckettőezrek/Ib)őezer
-harminckettőezredik/nÓ×BVÜb)őezer
-harminckettőezred/BVÜb)őezer
-harminckettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred
-harminckettőbillióan/b)őbillió
-harminckettőbillió/ĎŇŐAUÚQbci	őbillióan
-harminckettőbilliárd/mÖKkUÚQbci
+harminckettőtrillióan/b)őtrillió	ő||trillióan
+harminckettőtrillió/ĎŇŐAUÚQbci	őtrillióan	ő||trillió
+harminckettőtrilliárd/mÖKkUÚQbci	ő||trilliárd
+harminckettőmillióan/b)őmillió	ő||millióan
+harminckettőmillió/ĎŇŐAUÚQbcj	őmillióan	ő||millió
+harminckettőmilliárdan/b)őmilliárd	ő||milliárdan
+harminckettőmilliárd/mÖKkUÚQbci	őmilliárdan	ő||milliárd
+harminckettőfeléő||felé
+harminckettőezres/×BŐVb)őezer	ő||ezres
+harminckettőezren/b)őezer	ő||ezren
+harminckettőezrek/Ib)őezer	ő||ezrek
+harminckettőezredik/nÓ×BVÜb)őezer	ő||ezredik
+harminckettőezred/BVÜb)őezer	ő||ezred
+harminckettőezer/ŐnBVÜjbc	őezresőezrenőezrekőezredikőezred	ő||ezer
+harminckettőbillióan/b)őbillió	ő||billióan
+harminckettőbillió/ĎŇŐAUÚQbci	őbillióan	ő||billió
+harminckettőbilliárd/mÖKkUÚQbci	ő||billiárd
 harminckettő/ŢWŰMRbhc
 harmincketten/bh)ő
 harminckettedik/!VÓn×Llbh)ő
-harminchéttrillióan/b)éttrillió
-harminchéttrillió/ĎŇŐAUÚQbci	éttrillióan
-harminchéttrilliárd/mÖKkUÚQbci
-harminchétmillióan/b)étmillió
-harminchétmillió/ĎŇŐAUÚQbcj	étmillióan
-harminchétmilliárdan/b)étmilliárd
-harminchétmilliárd/mÖKkUÚQbci	étmilliárdan
-harminchétfelé
-harminchétezres/×BŐVb)étezer
-harminchétezren/b)étezer
-harminchétezrek/Ib)étezer
-harminchétezredik/nÓ×BVÜb)étezer
-harminchétezred/BVÜb)étezer
-harminchétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred
-harminchétbillióan/b)étbillió
-harminchétbillió/ĎŇŐAUÚQbci	étbillióan
-harminchétbilliárd/mÖKkUÚQbci
+harminchéttrillióan/b)éttrillió	ét||trillióan
+harminchéttrillió/ĎŇŐAUÚQbci	éttrillióan	ét||trillió
+harminchéttrilliárd/mÖKkUÚQbci	ét||trilliárd
+harminchétmillióan/b)étmillió	ét||millióan
+harminchétmillió/ĎŇŐAUÚQbcj	étmillióan	ét||millió
+harminchétmilliárdan/b)étmilliárd	ét||milliárdan
+harminchétmilliárd/mÖKkUÚQbci	étmilliárdan	ét||milliárd
+harminchétfeléét||felé
+harminchétezres/×BŐVb)étezer	ét||ezres
+harminchétezren/b)étezer	ét||ezren
+harminchétezrek/Ib)étezer	ét||ezrek
+harminchétezredik/nÓ×BVÜb)étezer	ét||ezredik
+harminchétezred/BVÜb)étezer	ét||ezred
+harminchétezer/ŐnBVÜjbc	étezresétezrenétezrekétezredikétezred	ét||ezer
+harminchétbillióan/b)étbillió	ét||billióan
+harminchétbillió/ĎŇŐAUÚQbci	étbillióan	ét||billió
+harminchétbilliárd/mÖKkUÚQbci	ét||billiárd
 harminchét/nVÜbhc
-harmincháromtrillióan/b)áromtrillió
-harmincháromtrillió/ĎŇŐAUÚQbci	áromtrillióan
-harmincháromtrilliárd/mÖKkUÚQbci
-harminchárommillióan/b)árommillió
-harminchárommillió/ĎŇŐAUÚQbcj	árommillióan
-harminchárommilliárdan/b)árommilliárd
-harminchárommilliárd/mÖKkUÚQbci	árommilliárdan
-harmincháromfelé
-harmincháromezres/×BŐVb)áromezer
-harmincháromezren/b)áromezer
-harmincháromezrek/Ib)áromezer
-harmincháromezredik/nÓ×BVÜb)áromezer
-harmincháromezred/BVÜb)áromezer
-harmincháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred
-harminchárombillióan/b)árombillió
-harminchárombillió/ĎŇŐAUÚQbci	árombillióan
-harminchárombilliárd/mÖKkUÚQbci
+harmincháromtrillióan/b)áromtrillió	árom||trillióan
+harmincháromtrillió/ĎŇŐAUÚQbci	áromtrillióan	árom||trillió
+harmincháromtrilliárd/mÖKkUÚQbci	árom||trilliárd
+harminchárommillióan/b)árommillió	árom||millióan
+harminchárommillió/ĎŇŐAUÚQbcj	árommillióan	árom||millió
+harminchárommilliárdan/b)árommilliárd	árom||milliárdan
+harminchárommilliárd/mÖKkUÚQbci	árommilliárdan	árom||milliárd
+harmincháromfeléárom||felé
+harmincháromezres/×BŐVb)áromezer	árom||ezres
+harmincháromezren/b)áromezer	árom||ezren
+harmincháromezrek/Ib)áromezer	árom||ezrek
+harmincháromezredik/nÓ×BVÜb)áromezer	árom||ezredik
+harmincháromezred/BVÜb)áromezer	árom||ezred
+harmincháromezer/ŐnBVÜjbc	áromezresáromezrenáromezrekáromezredikáromezred	árom||ezer
+harminchárombillióan/b)árombillió	árom||billióan
+harminchárombillió/ĎŇŐAUÚQbci	árombillióan	árom||billió
+harminchárombilliárd/mÖKkUÚQbci	árom||billiárd
 harminchárom/mUÚbhc	ármanármak
 harminchárman/bh)árom
 harminchármak/Ibh)árom
@@ -36113,25 +36201,25 @@ harminchetedik/!VÓn×Llbh)ét
 harminchavonta
 harminchavonként
 harminchavi
-harminchattrillióan/b)ó
-harminchattrillió/ĎŇŐAUÚQbci	óan
-harminchattrilliárd/mÖKkUÚQbci
+harminchattrillióan/b)ó	óan
+harminchattrillió/ĎŇŐAUÚQbci	óan	ó
+harminchattrilliárd/mÖKkUÚQbci	árd
 harminchatodikak/nI)
 harminchatodik/!AUÖmŇŮKkbh)
-harminchatmillióan/b)ó
-harminchatmillió/ĎŇŐAUÚQbcj	óan
-harminchatmilliárdan/b)árd
-harminchatmilliárd/mÖKkUÚQbci	árdan
-harminchatfelé
+harminchatmillióan/b)ó	óan
+harminchatmillió/ĎŇŐAUÚQbcj	óan	ó
+harminchatmilliárdan/b)árd	árdan
+harminchatmilliárd/mÖKkUÚQbci	árdan	árd
+harminchatfeléé
 harminchatezres/×BŐVb)
 harminchatezren/b)
 harminchatezrek/Ib)
 harminchatezredik/nÓ×BVÜb)
 harminchatezred/BVÜb)
 harminchatezer/ŐnBVÜjbc
-harminchatbillióan/b)ó
-harminchatbillió/ĎŇŐAUÚQbci	óan
-harminchatbilliárd/mÖKkUÚQbci
+harminchatbillióan/b)ó	óan
+harminchatbillió/ĎŇŐAUÚQbci	óan	ó
+harminchatbilliárd/mÖKkUÚQbci	árd
 harminchatan/bh)
 harminchat/mUÚKkbhc
 harmincharmadikak/nI)árom
@@ -36145,14 +36233,14 @@ harmincezred/BVÜb)
 harmincezer/ŐnBVÜjbc
 harmincesztendőnként
 harmincesztendei
-harmincegytrillióan/b)ó
-harmincegytrillió/ĎŇŐAUÚQbci	óan
-harmincegytrilliárd/mÖKkUÚQbci
-harmincegymillióan/b)ó
-harmincegymillió/ĎŇŐAUÚQbcj	óan
-harmincegymilliárdan/b)árd
-harmincegymilliárd/mÖKkUÚQbci	árdan
-harmincegyfelé
+harmincegytrillióan/b)ó	óan
+harmincegytrillió/ĎŇŐAUÚQbci	óan	ó
+harmincegytrilliárd/mÖKkUÚQbci	árd
+harmincegymillióan/b)ó	óan
+harmincegymillió/ĎŇŐAUÚQbcj	óan	ó
+harmincegymilliárdan/b)árd	árdan
+harmincegymilliárd/mÖKkUÚQbci	árdan	árd
+harmincegyfeléé
 harmincegyezres/×BŐVb)
 harmincegyezren/b)
 harmincegyezrek/Ib)
@@ -36163,9 +36251,9 @@ harmincegyen/bh)
 harmincegyediki/BVÓŐĐś)
 harmincegyedike/BVÓŐĐś)
 harmincegyedik/VÓn×Llbh)
-harmincegybillióan/b)ó
-harmincegybillió/ĎŇŐAUÚQbci	óan
-harmincegybilliárd/mÖKkUÚQbci
+harmincegybillióan/b)ó	óan
+harmincegybillió/ĎŇŐAUÚQbci	óan	ó
+harmincegybilliárd/mÖKkUÚQbci	árd
 harmincegy/nVÜLlbhc
 harmincbillióan/b)ó
 harmincbillió/ĎŇŐAUÚQbci	óan
@@ -36173,7 +36261,7 @@ harmincbilliárd/mÖKkUÚQbci
 harmincas/UĘŽiÖKŇmôáç˛ĂăSscˇťkADFabh
 harmincas/UĘŽiÖKŇmôáç˛ĂăSscˇťkADFabh
 harmincan/bh)
-harmincakfelé
+harmincakfeléé
 harmincadszorra/bh)
 harmincadszori/bh
 harmincadszor
@@ -36212,13 +36300,13 @@ harmadika/AUŇŐĎľ)árom
 harmadik/c!AUÖmŇŮKkabh)árom
 harmadidőszak/UĘŽiÖKŇmôáyÇżßQYcť
 harmadfű
-harmadféltrillió/AUŐĎŇKQxcˇĂżÇ
-harmadfélszázad/AUÖmŇKkQcˇĂżÇ
-harmadfélszáz/$UŮÖmŇSscÇ
-harmadfélmillió/AUŐĎŇKQxcˇĂżÇ
-harmadfélmilliárd/AUÖmŇKkQcˇĂżÇ
-harmadfélezer/VÓn×LlTtcČ
-harmadfélbillió/AUŐĎŇKQxcˇĂżÇ
+harmadféltrillió/AUŐĎŇKQxcˇĂżÇ	él||trillió
+harmadfélszázad/AUÖmŇKkQcˇĂżÇ	él||század
+harmadfélszáz/$UŮÖmŇSscÇ	él||száz
+harmadfélmillió/AUŐĎŇKQxcˇĂżÇ	él||millió
+harmadfélmilliárd/AUÖmŇKkQcˇĂżÇ	él||milliárd
+harmadfélezer/VÓn×LlTtcČ	él||ezer
+harmadfélbillió/AUŐĎŇKQxcˇĂżÇ	él||billió
 harmadfél/VÓnňyjYcČ)él	él
 harmadesztendőnként
 harmadannyian
@@ -36290,7 +36378,7 @@ hangzó/ŐAUQĘŽiĎŇáç˛ĂăYcˇťX)Ó_PRESPART_adj
 hangzó/ŐAUQĘŽiĎŇáç˛ĂăYcˇťX
 hangzás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk)Ás_PROCESS/RESULT_noun
 hangzik	ék
-hangzavar/UĘŽiÖKŇmôáyÇżßQYcť
+hangzavar/UĘŽiÖKŇmôáyÇżßSsYcť
 hangzat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hangyászmedve/ŐBVRËŻjĐÓéyČŔŕYcź
 hangyász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -36314,7 +36402,7 @@ hangtörés/VËŻj×LÓnňéyČŔŕTtYcź
 hangtompító/ŐAUQĘŽiĎŇáyÇżßYcť
 hangterjedelem/VnňyjYcŻ
 hangtan/UĘŽiÖKŇmôáyÇżßSsYcť
-hangsúlyjelzés/VËŻj×LÓnňéyČŔŕTtYcź
+hangsúlyjelzés/VËŻj×LÓnňéyČŔŕTtYcźúly||jelzés
 hangsúly/UĘŽiÖKŇmôáyÇżßSsYcť
 hangsíp/UĘŽiÖKŇmôáyÇżßQYcť
 hangsáv/UĘŽiÖKŇmôáyÇżßQYcť
@@ -36324,7 +36412,7 @@ hangszín/VËŻj×LÓnňéyČŔŕTtYcź
 hangszál/UmôŇyiYcÇ	álak
 hangszimbolika/ŐAUQĘŽiĎŇáyÇżßYcť
 hangszigetelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-hangszerhangoló/ŐAUQĘŽiĎŇáyÇżßYcť
+hangszerhangoló/ŐAUQĘŽiĎŇáyÇżßYcťó
 hangszer/VËŻj×LÓnňéyČŔŕTtYcź
 hangsor/UĘŽiÖKŇmôáyÇżßSsYcť
 hangrés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -36435,7 +36523,7 @@ halványul
 halvaszülés/VËŻj×LÓnňéyČŔŕTtYcź
 halvaszületés/VËŻj×LÓnňéyČŔŕTtYcź
 haltenyészet/VËŻj×LÓnňéyČŔŕTtYcź
-halszálkaminta/ŐAUQĘŽiĎŇáyÇżßYcť
+halszálkaminta/ŐAUQĘŽiĎŇáyÇżßYcťálka||minta
 halszálka/ŐAUQĘŽiĎŇáyÇżßYcť
 halszeletelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 halpogácsa/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -36473,7 +36561,7 @@ halló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hallássérült/VNËŻj×LÝňÔéčłÄäRYc¸źl
 halláskárosult/UĘŽi$sŇmôáyÇżßQxcť
 hallás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk)Ás_PROCESS/RESULT_noun
-hallucináció/ŐAUQĘŽiĎŇáyÇżßYcť
+hallucináció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hallucinogén/VËŻj×LÓnňéčłÄäRYc¸źl
 hallszik
 halloween/VËŻj×LÓnňéčłÄäRYc¸źl	ph:helovín	ph:helovin
@@ -36492,6 +36580,7 @@ hallgatódzik
 hallgatócső/WŢŘÔyjYcČ	ócsövek
 hallgató/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hallgattassék/X)
+hallgatnivaló/ŐAUQĘŽiĎŇáyÇżßYcť
 hallga
 halleves/VËŻj×LÓnňéyČŔŕTtYcź
 halleluja/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -36585,7 +36674,7 @@ hajóvontatás/UĘŽiÖKŇmôáyÇżßSsYcť
 hajóvonta
 hajótörött/WĚŻjŘMÝňÔíčłĹĺRYc¸˝l
 hajótörés/VËŻj×LÓnňéyČŔŕTtYcź
-hajótérkapacitás/UĘŽiÖKŇmôáyÇżßSsYcť
+hajótérkapacitás/UĘŽiÖKŇmôáyÇżßSsYcťó|tér||kapacitás
 hajótest/VËŻj×LÓnňéyČŔŕRYcź
 hajósziréna/ŐAUQĘŽiĎŇáyÇżßYcť
 hajós/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -36641,8 +36730,8 @@ hajtó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hajtány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hajtogató/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hajsütés/VËŻj×LÓnňéyČŔŕTtYcź
-hajszálrugó/ŐAUQĘŽiĎŇáyÇżßYcť
-hajszálkereszt/VËŻj×LÓnňéyČŔŕRYcź
+hajszálrugó/ŐAUQĘŽiĎŇáyÇżßYcťál||rugó
+hajszálkereszt/VËŻj×LÓnňéyČŔŕRYcźál||kereszt
 hajszál/UmôŇyiYcÇ	álak
 hajszobrász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hajszesz/VËŻj×LÓnňéyČŔŕTtYcź
@@ -36729,7 +36818,7 @@ hagyatkozik
 hagyakozik
 hafnium/UĘŽiÖKŇmôáç˛ĂăSsvcˇťk
 hadügyér/VËŻj×LÓnňéyČŔŕTtYcź
-hadügyminisztérium/UĘŽiÖKŇmôáyÇżßSsYcť
+hadügyminisztérium/UĘŽiÖKŇmôáyÇżßSsYcťügy||minisztérium
 hadúr/UmôŇyiYcÇ
 hadászat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hadállás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -36755,8 +36844,8 @@ hadiérettségi/ŐBVRËŻjĐÓéyČŔŕYcź
 hadiárva/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hadiállapot/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hadizsákmány/UĘŽiÖKŇmôáyÇżßSsYcť
-haditörvényszék/VËŻj×LÓnňéyČŔŕTtYcź
-haditámaszpont/UĘŽiÖKŇmôáyÇżßQYcť
+haditörvényszék/VËŻj×LÓnňéyČŔŕTtYcźörvény|szék
+haditámaszpont/UĘŽiÖKŇmôáyÇżßQYcťámasz|pont
 haditudósító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 haditudósítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 haditorna/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -36776,7 +36865,7 @@ hadisegély/VËŻj×LÓnňéyČŔŕTtYcź
 hadisarc/UĘŽiÖKŇmôáyÇżßSsYcť
 hadirokkant/UĘŽi$sŇmôáyÇżßQYcť
 hadirepülőgép/VËŻj×LÓnňéyČŔŕRTtYcź
-hadipénztár/UmôŇyiYcÇ	énztárak
+hadipénztár/UmôŇyiYcÇ	énztárakénz|tár
 hadipotenciál/UĘŽiÖKŇmôáyÇżßQYcť
 hadiposta/ŐAUQĘŽiĎŇáyÇżßYcť
 hadiparancs/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -36784,11 +36873,11 @@ hadimúzeum/UĘŽiÖKŇmôáyÇżßQSsYcť
 hadimonopólium/UĘŽiÖKŇmôáyÇżßSsYcť
 hadilárma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hadilábon
-hadilevéltár/UmôŇyiYcÇ	éltárak
+hadilevéltár/UmôŇyiYcÇ	éltárakél|tár
 hadiközlemény/VËŻj×LÓnňéčłÄäTtYc¸źl
 hadiköltség/VËŻj×LÓnňéyČŔŕTtYcź
 hadikölcsön/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
-hadikórház/UmôŇyiYcÇ	órházak
+hadikórház/UmôŇyiYcÇ	órházakór|ház
 hadikommunizmus/UĘŽiÖKŇmôáyÇżßSsYcť
 hadikikötő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 hadijáték/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -36807,12 +36896,12 @@ hadigazdaság/UĘŽiÖKŇmôáyÇżßSsYcť
 hadifurfang/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 hadifortély/UĘŽiÖKŇmôáyÇżßSsYcť
 hadifogság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-hadifogolytábor/UĘŽiÖKŇmôáyÇżßSsYcť
+hadifogolytábor/UĘŽiÖKŇmôáyÇżßSsYcťábor
 hadifogoly/UmôyiYcŽ
 hadiflotta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 hadifelszerelés/VËŻj×LÓnňéčłÄäTtYc¸źl
 hadieszköz/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
-hadiemlékmű/WŢŘÔyjYcČ	ékművek
+hadiemlékmű/WŢŘÔyjYcČ	ékművekék|mű
 hadicél/UĘŽiÖKŇmôáyÇżßQYcť
 hadicsel/VËŻj×LÓnňéyČŔŕTtYcź
 hadianyag/UĘŽiÖKŇmôáyÇżßQSsYcť
@@ -36826,7 +36915,7 @@ hadd
 hadbíróság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 hadastyán/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 hadaró/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-hadapródiskola/ŐAUQĘŽiĎŇáyÇżßYcť
+hadapródiskola/ŐAUQĘŽiĎŇáyÇżßYcťód||iskola
 hadakozik
 had/UmôŇçiYc˛Sx
 hacuka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -36838,7 +36927,7 @@ habzó/ŐAUQĘŽiĎŇáç˛ĂăYcˇťX)Ó_PRESPART_adj
 habzás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk)Ás_PROCESS/RESULT_noun
 habzik	ék
 habverő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-habszegfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvek
+habszegfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvekű
 habozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 habozik
 habostorta-/=
@@ -36920,7 +37009,7 @@ görl/WĚŻjŘMÝňÔíčłĹĺRYc¸˝
 görkoris/UĘŽiÖKŇmôáyÇżßSsYcť
 görkori/ŐAUQĘŽiĎŇáyÇżßYcť
 görkorcsolya/ŐAUQĘŽiĎŇáyÇżßYcť
-görgőscsapágy/UmôŇyiYcÇ	örgőscsapágyak
+görgőscsapágy/UmôŇyiYcÇ	örgőscsapágyakörgős||csap|ágy
 görgősaru/ŐAUQĘŽiĎŇáyÇżßYcť
 görgő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X)örögÓ_PRESPART_adj
 görgő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X
@@ -36978,7 +37067,7 @@ gőzhajó/ŐAUQĘŽiĎŇáyÇżßYcť
 gőzgép/VËŻj×LÓnňéyČŔŕRTtYcź
 gőzfürdő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 gőzfűtés/VËŻj×LÓnňéyČŔŕTtYcź
-gőzfeszmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+gőzfeszmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝őz||fesz|mérő
 gőzelosztó/ŐAUQĘŽiĎŇáyÇżßYcť
 gőzdaru/ŐAUQĘŽiĎŇáyÇżßYcť
 gőz/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝
@@ -37076,23 +37165,23 @@ géprablás/UĘŽiÖKŇmôáyÇżßSsYcť
 géppuska/ŐAUQĘŽiĎŇáyÇżßYcť
 géppisztoly/UĘŽiÖKŇmôáyÇżßSsYcť
 gépközel/VËŻj×LÓnňéyČŔŕTtYcź
-gépkocsiszín/VËŻj×LÓnňéyČŔŕRYcź
-gépkocsikenőcs/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
+gépkocsiszín/VËŻj×LÓnňéyČŔŕRYcźép|kocsi||szín
+gépkocsikenőcs/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ép|kocsi||kenőcs
 gépkocsi/ŐAUQĘŽiĎŇáyÇżßYcť
 gépkezelés/VËŻj×LÓnňéyČŔŕTtYcź
-gépkenőolaj/UmôŇyiYcÇ	épkenőolajak
-gépjármű/WŢŘÔyjYcČ	épjárművek
+gépkenőolaj/UmôŇyiYcÇ	épkenőolajakép||kenő|olaj
+gépjármű/WŢŘÔyjYcČ	épjárművekép||jár|mű
 gépirat/UĘŽiÖKŇmôáyÇżßSsYcť
 gépiesül
 gépiesit/w
-gépháztető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+gépháztető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ép|ház||tető
 gépház/UmôŇyiYcÇ	épházak
 gépfelszerelés/VËŻj×LÓnňéyČŔŕTtYcź
 gépfegyveres/VËŻj×LÓnňéyČŔŕTtYcź
 gépfegyver/VËŻj×LÓnňéyČŔŕTtYcź
 gépezet/VËŻj×LÓnňéčłÄäTtYc¸źl
 gépelem/VËŻj×LÓnňéyČŔŕTtYcź
-gépalkatrész/VËŻj×LÓnňéyČŔŕTtYcź
+gépalkatrész/VËŻj×LÓnňéyČŔŕTtYcźép||alkat|rész
 gép/VËŻj×LÓnňéčłÄäRTtYc¸ź
 génpiszka/ŐAUQĘŽiĎŇáyÇżßYcť
 géniusz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -37106,22 +37195,22 @@ gégész/VËŻj×LÓnňéčłÄäTtYc¸źl
 gégetükör/WÝyjYcŻ	égetükrök
 gégekanül/WĚŻjŘMÝňÔíyČÁ˙Rvc˝
 gégehurut/UĘŽiÖKŇmôáyÇżßQYcť
-gégecsőmetszés/VËŻj×LÓnňéyČŔŕTtYcź
+gégecsőmetszés/VËŻj×LÓnňéyČŔŕTtYcźége|cső||metszés
 gége/ŐBVRËŻjĐÓéčłÄäYc¸ź
 gébics/VËŻj×LÓnňéčłÄäTtYc¸źl
 géb/VËŻj×LÓnňéčłÄäRYc¸ź
-gázöngyújtó/ŐAUQĘŽiĎŇáyÇżßYcť
+gázöngyújtó/ŐAUQĘŽiĎŇáyÇżßYcťáz||ön|gyújtó
 gázóra/ŐAUQĘŽiĎŇáyÇżßYcť
 gázégő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 gázár/UmôŇyiYcÇ	ázárak
-gázálarc/UĘŽiÖKŇmôáyÇżßSsYcť
-gáztűzhely/×VËŻjLÓnňéyČŔŕTtYcź
+gázálarc/UĘŽiÖKŇmôáyÇżßSsYcťáz||ál|arc
+gáztűzhely/×VËŻjLÓnňéyČŔŕTtYcźáz||tűz|hely
 gázturbina/ŐAUQĘŽiĎŇáyÇżßYcť
 gáztisztító/ŐAUQĘŽiĎŇáyÇżßYcť
 gáztartály/UĘŽiÖKŇmôáyÇżßSsYcť
 gázszolgáltató/ŐAUQĘŽiĎŇáyÇżßYcťáz|szol-gál-ta-tó
 gázszerelés/VËŻj×LÓnňéyČŔŕTtYcźáz|sze-re-lés
-gázsparhelt/VËŻj×LÓnňéyČŔŕRYcźáz|spar-helt
+gázsparhelt/VËŻj×LÓnňéyČŔŕRYcźáz|spar-heltáz|sparhelt
 gázsi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 gázrezsó/ŐAUQĘŽiĎŇáyÇżßYcť
 gázosító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -37136,7 +37225,7 @@ gázlámpa/ŐAUQĘŽiĎŇáyÇżßYcť
 gázképződés/VËŻj×LÓnňéyČŔŕTtYcź
 gázkályha/ŐAUQĘŽiĎŇáyÇżßYcť
 gázkromatográfia/ŐAUQĘŽiĎŇáyÇżßYcť
-gázfőzőlap/UĘŽiÖKŇmôáyÇżßQYcť
+gázfőzőlap/UĘŽiÖKŇmôáyÇżßQYcťáz||főző|lap
 gázfejlődés/VËŻj×LÓnňéyČŔŕTtYcź
 gázcső/WŢŘÔyjYcČ	ázcsövek
 gázbomba/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -37257,6 +37346,7 @@ gyöngydíszítés/VËŻj×LÓnňéyČŔŕTtYcź
 gyöngy/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝
 gyömbérgyökér/VÓnňyjYcČ	ömbérgyökerek
 gyömbér/VËŻj×LÓnňéčłÄäRYc¸źl
+gyökérzet/VËŻj×LÓnňéčłÄäTtYc¸źl
 gyökér/VÓnňčjYcłl	ökerek
 gyökkitevő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 gyökerezik
@@ -37271,25 +37361,25 @@ gyógyítólag
 gyógyír/UĘŽiÖKŇmôáyÇżßQYcť
 gyógyászat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gyógyász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-gyógyvízkúra/ŐAUQĘŽiĎŇáyÇżßYcť
+gyógyvízkúra/ŐAUQĘŽiĎŇáyÇżßYcťógy|víz||kúra
 gyógyvíz/VÓnňyjYcČ	ógyvizek
 gyógyul
 gyógytényező/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 gyógyturizmus/UĘŽiÖKŇmôáyÇżßSsYcť
 gyógytornász/UĘŽiÖKŇmôáyÇżßSsYcť
 gyógytorna/ŐAUQĘŽiĎŇáyÇżßYcť
-gyógytestnevelés/VËŻj×LÓnňéyČŔŕTtYcź
+gyógytestnevelés/VËŻj×LÓnňéyČŔŕTtYcźógy||test|nevelés
 gyógytea/ŐAUQĘŽiĎŇáyÇżßYcť
 gyógytan/UĘŽiÖKŇmôáyÇżßQYcť
 gyógyszálló/ŐAUQĘŽiĎŇáyÇżßYcť
 gyógyszálloda/ŐAUQĘŽiĎŇáyÇżßYcť
 gyógyszerészet/VËŻj×LÓnňéyČŔŕTtYcź
 gyógyszerész/VËŻj×LÓnňéyČŔŕTtYcź
-gyógyszerár/UmôŇyiYcÇ	ógyszerárak
+gyógyszerár/UmôŇyiYcÇ	ógyszerárakógy|szer||ár
 gyógyszertár/UmôŇyiYcÇ	ógyszertárak
-gyógyszertan/UĘŽiÖKŇmôáyÇżßSsYcť
-gyógyszeroldat/UĘŽiÖKŇmôáyÇżßSsYcť
-gyógyszerkönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
+gyógyszertan/UĘŽiÖKŇmôáyÇżßSsYcťógy|szer||tan
+gyógyszeroldat/UĘŽiÖKŇmôáyÇżßSsYcťógy|szer||oldat
+gyógyszerkönyv/VNËŻj×LÝňÔéyČŔŕTtYcźógy|szer||könyv
 gyógyszerelés/VËŻj×LÓnňéyČŔŕTtYcź
 gyógyszer/VËŻj×LÓnňéyČŔŕTtYcź
 gyógyszappan/UĘŽiÖKŇmôáyÇżßQSsYcť
@@ -37401,6 +37491,7 @@ gyorsíró/ŐAUQĘŽiĎŇáyÇżßYcť
 gyorsírás/UĘŽiÖKŇmôáyÇżßSsYcť
 gyorsétterem/VnňyjYcŻ	éttermekét|terem
 gyorsétkezde/ŐBVRËŻjĐÓéyČŔŕYcź
+gyorsétel/VËŻj×LÓnňéyČŔŕTtYcź
 gyorsáru/ŐAUQĘŽiĎŇáyÇżßYcť
 gyorsváltó/ŐAUQĘŽiĎŇáyÇżßYcť
 gyorsvágó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -37511,7 +37602,7 @@ gyermektápszer/VËŻj×LÓnňéyČŔŕTtYcź
 gyermekség/VËŻj×LÓnňéčłÄäTtYc¸źl
 gyermekszoba/ŐAUQĘŽiĎŇáyÇżßYcť
 gyermekmenhely/VËŻj×LÓnňéyČŔŕTtYcź
-gyermekláncfű/WŢŘÔyjYcČ	áncfüvek
+gyermekláncfű/WŢŘÔyjYcČ	áncfüvekánc||fű
 gyermekközpontúság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gyermekkor/UĘŽiÖKŇmôáyÇżßSsYcť
 gyermekkocsi/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -37529,7 +37620,7 @@ gyerekbolond/UĘŽiÖKŇmôáyÇżßQYcť
 gyerek/VËŻj×LÓnňéčłÄäTtYc¸źl
 gyere/X)ön
 gyepűrózsa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-gyepűrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+gyepűrendszer/VËŻj×LÓnňéyČŔŕTtYcźű||rend|szer
 gyepűbodza/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 gyepű/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 gyeptégla/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -37603,6 +37694,7 @@ gyakrabb/ŮmŇAD$UQ)
 gyakorító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 gyakorta
 gyakorolás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+gyakornokság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gyakornok/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gyakorlóév/VËŻj×LÓnňéčłÄäTtYc¸źl
 gyakorlótér/VÓnňyjYcČ	óterek
@@ -37824,7 +37916,7 @@ gomolyogod/w
 gomolygó/ŐAUQĘŽiĎŇáç˛ĂăYcˇťX)Ó_PRESPART_adj
 gomolygás/XUĘŽiÖKŇmôáç˛ĂăSsYcˇťk)Ás_PROCESS/RESULT_noun
 gomolyfelhő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-gomolyag/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+gomolyag/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 gomolya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 gomoly/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gombóc/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -37833,10 +37925,10 @@ gombászik
 gombászat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gombász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gombozik
-gombostűfej/VËŻj×LÓnňéyČŔŕTtYcź
+gombostűfej/VËŻj×LÓnňéyČŔŕTtYcźű||fej
 gombostű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 gombolyító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-gombolyag/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+gombolyag/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 gombolkozik
 gombnyomás/UĘŽiÖKŇmôáyÇżßSsYcť
 gomblyuk/UmôŇyiYcÇQ
@@ -37852,7 +37944,7 @@ golyóstollbetét/VËŻj×LÓnňéyČŔŕRYcź
 golyóstoll/UmôŇyiYcÇ	óstollak
 golyósszelep/VËŻj×LÓnňéyČŔŕRTtYcźós|sze-lep
 golyósmalom/UmôyiYcŽ	ósmalmok
-golyóscsapágy/UmôŇyiYcÇ	óscsapágyak
+golyóscsapágy/UmôŇyiYcÇ	óscsapágyakós||csap|ágy
 golyóscsap/UĘŽiÖKŇmôáyÇżßQYcť
 golyófogó/ŐAUQĘŽiĎŇáyÇżßYcť
 golyóbis/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -38015,6 +38107,7 @@ gezemice/ŐBVRËŻjĐÓéčłÄäYc¸ź
 geze/ŐBVRËŻjĐÓéčłÄäYc¸ź
 gezarol/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 gettó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+gesztáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 gesztus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gesztor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gesztikulál
@@ -38142,6 +38235,7 @@ geci/ŐBVRËŻjĐÓéčłÄäYc¸ź=
 gebedt/XBDGVną)
 gebedt/XBDGVną)
 gebe/ŐBVRËŻjĐÓéčłÄäYc¸ź
+gebasz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gaztett/VËŻj×LÓnňéyČŔŕTtYcź
 gazsulál
 gazométer/VËŻj×LÓnňéyČŔŕTtYcź
@@ -38182,11 +38276,11 @@ gasztrológus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 gasztrológia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 gasztroenterológus/UĘŽiÖKŇmôáyÇżßSsYcť
 gasztroenterológia/ŐAUQĘŽiĎŇáyÇżßYcť
-gasztroblogger/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRvcťź
+gasztroblogger/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRvcťź
 gasztroblog/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 gasztritisz/VËŻj×LÓnňéčłÄäTtYc¸źl
 garázs/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-garádics/VËŻj×LÓnňéčłÄäTtYc¸źl
+garádics/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 garzonlakás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 garzon/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 garral
@@ -38254,6 +38348,7 @@ gallbarátság/UĘŽiÖKŇmôáyÇżßSsYcť
 gallabb/mAD$UŮŇQ
 gall/UĘŽiÖKŇmôáçĂăQc
 galiba/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+galerista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 galeri/ŐAUBVLQRĘŽËŻijĎĐÓáéçč˛łÄäĂăYcˇť¸ź
 galenit/VËŻj×LÓnňéčłÄäRvc¸źl
 galaxis/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -38380,7 +38475,7 @@ fürdöl/X)ürdik
 fürdök/X)ürdik
 fürdőzik
 fürdőszoba/ŐAUQĘŽiĎŇáyÇżßYcť
-fürdőruhafelső/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+fürdőruhafelső/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ürdő|ruha||felső
 fürdőruha/ŐAUQĘŽiĎŇáyÇżßYcť
 fürdőpapucs/UĘŽiÖKŇmôáyÇżßSsYcť
 fürdőköpeny/VËŻj×LÓnňéyČŔŕTtYcź
@@ -38416,7 +38511,7 @@ fülészet/VËŻj×LÓnňéčłÄäTtYc¸źl
 fülész/VËŻj×LÓnňéčłÄäTtYc¸źl
 fülzsír/UĘŽiÖKŇmôáyÇżßQYcť
 fülvédő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-fültőmirigy/VËŻj×LÓnňéyČŔŕTtYcź
+fültőmirigy/VËŻj×LÓnňéyČŔŕTtYcźül|tő||mirigy
 fültő/WŢŘÔyjYcČ	ültövek
 fült/w
 fülszöveg/VËŻj×LÓnňéyČŔŕTtYcź
@@ -38465,9 +38560,9 @@ fűzőkészítő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 fűzőkarika/ŐAUQĘŽiĎŇáyÇżßYcť
 fűző/ŐCWRĚŻjŢÔčłĹĺYc¸˝
 fűzláp/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-fűzfavessző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+fűzfavessző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝űz|fa||vessző
 fűzfapoéta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-fűzfabarka/ŐAUQĘŽiĎŇáyÇżßYcť
+fűzfabarka/ŐAUQĘŽiĎŇáyÇżßYcťűz|fa||barka
 fűzfa/ŐAUQĘŽiĎŇyÇżßYcť
 fűz/WÝÔčjYcł	üziűzetüzek
 fűtőzik
@@ -38482,7 +38577,7 @@ fűtenivaló/ŐAUQĘŽiĎŇáyÇżßYcť
 fűszál/UmôŇyiYcÇ	űszálak
 fűszerezettség/VËŻj×LÓnňéčłÄäTtYc¸źl
 fűszeres/VËŻj×LÓnňéčłÄäTtYc¸źl
-fűszerdoboz/UĘŽiÖKŇmôáyÇżßSsYcť
+fűszerdoboz/UĘŽiÖKŇmôáyÇżßSsYcťű|szer||doboz
 fűszer/VËŻj×LÓnňéyČŔŕRTtYcź
 fűrészélesítő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 fűrészáru/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -38700,7 +38795,7 @@ főégő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 főárbóc/UĘŽiÖKŇmôáyÇżßSsYcť
 főáram/UĘŽiÖKŇmôáyÇżßSsYcť
 főállás/UĘŽiÖKŇmôáyÇżßSsYcť
-főállatorvos/UĘŽiÖKŇmôáyÇżßSsYcť
+főállatorvos/UĘŽiÖKŇmôáyÇżßSsYcťő||állat|orvos
 főág/UmôŇyiYcÇ	őágak
 főzőtök/WĚŻjŘMÝňÔíyČÁ˙RYc˝
 főzőmargarin/UĘŽiÖKŇmôáyÇżßQYcť
@@ -38711,7 +38806,6 @@ főzőalma/ŐAUQĘŽiĎŇáyÇżßYcť
 főzt/WĚŻjŘMÝňÔíčłĹĺRYc¸˝
 főznivaló/ŐAUQĘŽiĎŇáyÇżßYcť
 főzet/VËŻj×LÓnňéčłÄäTtYc¸źl
-főzeneigazgató/ŐAUQĘŽiĎŇáyÇżßYcť
 főzelék/VËŻj×LÓnňéčłÄäTtYc¸źl
 főzde/ŐBVRËŻjĐÓéčłÄäYc¸ź
 fővédnök/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
@@ -38724,7 +38818,7 @@ fővonal/UmôŇyiYcÇ	ővonalak
 fővezér/VËŻj×LÓnňéyČŔŕTtYcź
 főutca/ŐAUQĘŽiĎŇáyÇżßYcť
 főuralom/UmôyiYcŽ	őuralmak
-főtörzsőrmester/VËŻj×LÓnňéyČŔŕTtYcź
+főtörzsőrmester/VËŻj×LÓnňéyČŔŕTtYcźő|törzs||őr|mester
 főtétel/VËŻj×LÓnňéyČŔŕTtYcź
 főtér/VÓnňyjYcČ	őterek
 főtéma/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -38733,9 +38827,9 @@ főtárgy/UmôŇyiYcÇ	őtárgyak
 főtár/UmôŇyiYcÇ	őtárak
 főtámogató/ŐAUQĘŽiĎŇáyÇżßYcť
 főtámasz/UĘŽiÖKŇmôáyÇżßSsYcť
-főtitkárhelyettes/VËŻj×LÓnňéyČŔŕTtYcź
+főtitkárhelyettes/VËŻj×LÓnňéyČŔŕTtYcźő|titkár||helyettes
 főtitkár/UĘŽiÖKŇmôáyÇżßQSsYcť
-főtisztviselő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+főtisztviselő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő||tiszt|viselő
 főtisztelendő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 főtiszt/VËŻj×LÓnňéyČŔŕRYcź
 főtengely/VËŻj×LÓnňéyČŔŕTtYcź
@@ -38745,11 +38839,11 @@ főtanácsos/UĘŽiÖKŇmôáyÇżßSsYcť
 főtanácsadó/ŐAUQĘŽiĎŇáyÇżßYcť
 főtanács/UĘŽiÖKŇmôáyÇżßSsYcť
 fősík/UĘŽiÖKŇmôáyÇżßQYcť
-főszékesegyház/UmôŇyiYcÇ	őszékesegyházak
+főszékesegyház/UmôŇyiYcÇ	őszékesegyházakő||székes||egy|ház
 főszponzor/UĘŽiÖKŇmôáyÇżßQYcť
-főszolgabíró/ŐAUQĘŽiĎŇáyÇżßYcť
+főszolgabíró/ŐAUQĘŽiĎŇáyÇżßYcťő||szolga|bíró
 főszolgabírát/)ő+szolga+bíró
-főszolgabíra/uxAQˇ)ő+szolga+bíró
+főszolgabíra/uxAQˇ)ő+szolga+bíró	ő||szolga|bíró
 főszezon/UĘŽiÖKŇmôáyÇżßQYcť
 főszerkesztőúr/wYUmôŇçic˛k
 főszerkesztőség/VËŻj×LÓnňéyČŔŕTtYcź
@@ -38761,30 +38855,30 @@ főszerep/VËŻj×LÓnňéyČŔŕTtYcź
 főszakács/UĘŽiÖKŇmôáyÇżßSsYcť
 fősor/UĘŽiÖKŇmôáyÇżßSsYcť
 főrész/VËŻj×LÓnňéyČŔŕTtYcź
-főrendőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
-főrendiház/UmôŇyiYcÇ	őrendiházak
+főrendőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ő||rend|őr
+főrendiház/UmôŇyiYcÇ	őrendiházakő|rendi||ház
 főrendező/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 főrend/VËŻj×LÓnňéyČŔŕRYcź
 főrabbi/ŐAUQĘŽiĎŇáyÇżßYcť
 főpásztor/UĘŽiÖKŇmôáyÇżßSsYcť
 főpróba/ŐAUQĘŽiĎŇáyÇżßYcť
-főpolgármester/VËŻj×LÓnňéyČŔŕTtYcź
+főpolgármester/VËŻj×LÓnňéyČŔŕTtYcźő||polgár|mester
 főpincér/VËŻj×LÓnňéyČŔŕRYcź
 főparancsnokság/UĘŽiÖKŇmôáyÇżßSsYcť
 főparancsnok/UĘŽiÖKŇmôáyÇżßSsYcť
 főpap/UĘŽiÖKŇmôáyÇżßQYcť
-főosztályvezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+főosztályvezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő||osztály|vezető
 főosztály/UĘŽiÖKŇmôáyÇżßSsYcť
 főorvosúr/wYUmôŇçic˛k
-főorvosnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+főorvosnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő||orvos|nő
 főorvosasszony/wYUĘŽiÖKŇmôáç˛ĂăSscˇťk
 főorvos/UĘŽiÖKŇmôáyÇżßSsYcť
 főoltár/UmôŇyiYcÇ	őoltárak
 főoldal/UmôŇyiYcÇ	őoldalak
 főnökség/VËŻj×LÓnňéčłÄäTtYc¸źl
 főnök/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
-főnővér/VËŻj×LÓnňéyČŔŕTtYcź
-főnévragozás/UĘŽiÖKŇmôáyÇżßSsYcť
+főnővér/VËŻj×LÓnňéyČŔŕTtYcźő||nő|vér
+főnévragozás/UĘŽiÖKŇmôáyÇżßSsYcťő|név||ragozás
 főnév/VÓnňyjYcČ	őnevek
 főnyeremény/VËŻj×LÓnňéyČŔŕTtYcź
 főnszél/VËŻj×LÓnňéyČŔŕRYcź
@@ -38793,14 +38887,14 @@ főnix/VËŻj×LÓnňéčłÄäTtYc¸źl
 főnemesség/VËŻj×LÓnňéyČŔŕTtYcź
 főnemes/VËŻj×LÓnňéyČŔŕTtYcź
 főn/WĚŻjŘMÝňÔíčłĹĺRYc¸˝
-főműsoridő/ŐCWĚŻjŢÔíyČÁ˙Yc˝	őműsoridej
-főműsoridej/uxytT¸)őműsoridő
+főműsoridő/ŐCWĚŻjŢÔíyČÁ˙Yc˝	őműsoridejő||műsor|idő
+főműsoridej/uxytT¸)őműsoridő	ő||mű|sor||idő
 főmérnök/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
-főmunkatárs/UmôŇyiYcÇ	őmunkatársak
+főmunkatárs/UmôŇyiYcÇ	őmunkatársakő||munka|társ
 főmufti/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 főminor/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 főmenü/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-főmegbízott/UĘŽi$sŇmôáyÇżßQxcť
+főmegbízott/UĘŽi$sŇmôáyÇżßQxcťő||meg|bízott
 főleg
 főlap/UĘŽiÖKŇmôáyÇżßQYcť
 fől
@@ -38829,13 +38923,13 @@ főigazgatóúr/wYUmôŇçic˛k
 főigazgatóság/UĘŽiÖKŇmôáyÇżßSsYcť
 főigazgató/ŐAUQĘŽiĎŇáyÇżßYcť
 főideológus/UĘŽiÖKŇmôáyÇżßSsYcť
-főhősnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+főhősnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő||hős|nő
 főhős/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 főhomlokzat/UĘŽiÖKŇmôáyÇżßSsYcť
 főhivatás/UĘŽiÖKŇmôáyÇżßSsYcť
 főhetőség/XVËŻj×LÓnňéčłÄäTtYc¸źl)őÓ_ABLE_(adj,present_part)Ág_ABSTRACT_noun
 főhetőség/XVËŻj×LÓnňéčłÄäTtYc¸źl
-főhercegnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+főhercegnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő||herceg|nő
 főherceg/VËŻj×LÓnňéyČŔŕTtYcź
 főhatóság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 főhatalom/UmôyiYcŽ	őhatalmak
@@ -38846,7 +38940,7 @@ főhadiszállás/UĘŽiÖKŇmôáyÇżßSsYcť
 főgép/VËŻj×LÓnňéyČŔŕRYcź
 főgyűjtő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 főgyökér/VÓnňyjYcČ	őgyökerek
-főgyógyszerész/VËŻj×LÓnňéyČŔŕTtYcź
+főgyógyszerész/VËŻj×LÓnňéyČŔŕTtYcźő||gyógy|szerész
 főgondnok/UĘŽiÖKŇmôáyÇżßSsYcť
 főgimnázium/UĘŽiÖKŇmôáyÇżßSsYcť
 főforrás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -38861,8 +38955,8 @@ főerő/ŐCWĚŻjŢÔíyČÁ˙Yc˝	őerej
 főerej/uxyT¸)őerő
 főemlős/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 főember/VËŻj×LÓnňéyČŔŕTtYcź
-főelőadó/ŐAUQĘŽiĎŇáyÇżßYcť
-főegyházmegye/ŐBVRËŻjĐÓéyČŔŕYcź
+főelőadó/ŐAUQĘŽiĎŇáyÇżßYcťő||elő|adó
+főegyházmegye/ŐBVRËŻjĐÓéyČŔŕYcźő||egy|ház||megye
 fődögél
 fődíj/UŇmôyiYcÇ	ődíjak
 fődolog/UmôyiYcŽ	ődolgok
@@ -38890,7 +38984,7 @@ fő_hiba/ŐAUQĘŽiĎŇáç˛Ăăcˇť
 fő_elv/VËŻj×LÓnňéčłÄäTtc¸źl
 fő_cél/UĘŽiÖKŇmôáç˛ĂăQcˇťk
 fő_baj/UĘŽiÖKŇmôáç˛ĂăSscˇťk
-fő-építésvezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝	ph:főépítésvezető
+fő-építésvezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő-építés|vezető	ph:főépítésvezető
 fő/ŐCWRĚŻjŢÔčłĹĺYc¸˝	övésövetlenségőhetőségövünkövömövökövödöviteköviköviővénőveőtökőttünkőttükőttétekőttélőttékőttetekőttemőttemőttelekőttekőttedőtteőttőszőnünkőnötökőnömőnödőnétekőnétekőnénkőnénkőnénekőnémőnélekőnélőnékőnékőnédőnéőniükőniökőnieőniőnekőneőlekőjünkőjükőjükőjönőjétekőjélőjékőjetekőjenekőjemőjelekőjekőjedőjeőjőhetőddőövőövetlenövendőőttőhető
 fószer/VËŻj×LÓnňéčłÄäRYc¸źl
 fórum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -38932,10 +39026,11 @@ férfifodrászat/UĘŽiÖKŇmôáyÇżßSsYcť
 férfidivat/UĘŽiÖKŇmôáyÇżßQYcť
 férfialak/UĘŽiÖKŇmôáyÇżßQYcť
 férfiak/UmŇŮ)érfi
+férfiaink/UmŮŇ)érfi
 férfiai/UĎŇŐx)érfi
 férfia/UĎŇŐx)érfi
 férfi_módra
-férfi/ŐAUQĘŽiĎŇáç˛ĂăYcˇťVĐ	érfiakérfiaiérfia
+férfi/ŐAUQĘŽiĎŇáç˛ĂăYcˇťVĐ	érfiakérfiainkérfiaiérfia
 féregűző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 féregnyúlvány/UĘŽiÖKŇmôáyÇżßSsYcť
 féregirtó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -38956,10 +39051,10 @@ fényvisszaverődés/VËŻj×LÓnňéčłÄäTtYc¸źl
 fényvisszaverő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 fényvető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 fényudvar/UĘŽiÖKŇmôáyÇżßQSsYcť
-fénytávíró/ŐAUQĘŽiĎŇáyÇżßYcť
+fénytávíró/ŐAUQĘŽiĎŇáyÇżßYcťény||táv|író
 fénytompító/ŐAUQĘŽiĎŇáyÇżßYcť
 fénytan/UĘŽiÖKŇmôáyÇżßSsYcť
-fényszórólámpa/ŐAUQĘŽiĎŇáyÇżßYcť
+fényszórólámpa/ŐAUQĘŽiĎŇáyÇżßYcťény|szóró||lámpa
 fényszóró/ŐAUQĘŽiĎŇáyÇżßYcť
 fénysugár/UmôŇyiYcÇ	énysugarak
 fényreklám/UĘŽiÖKŇmôáyÇżßQYcť
@@ -38975,9 +39070,9 @@ fénymásolat/UĘŽiÖKŇmôáyÇżßSsYcť
 fénykéve/ŐBVRËŻjĐÓéyČŔŕYcź
 fényképészet/VËŻj×LÓnňéčłÄäTtYc¸źl
 fényképész/VËŻj×LÓnňéčłÄäTtYc¸źl
-fényképnyomás/UĘŽiÖKŇmôáyÇżßSsYcť
-fényképfixáló/ŐAUQĘŽiĎŇáyÇżßYcť
-fényképfelvétel/VËŻj×LÓnňéyČŔŕTtYcź
+fényképnyomás/UĘŽiÖKŇmôáyÇżßSsYcťény|kép||nyomás
+fényképfixáló/ŐAUQĘŽiĎŇáyÇżßYcťény|kép||fixáló
+fényképfelvétel/VËŻj×LÓnňéyČŔŕTtYcźény|kép||fel|vétel
 fényképezőlemez/VËŻj×LÓnňéyČŔŕTtYcź
 fényképezőgép/VËŻj×LÓnňéyČŔŕRTtYcź
 fénykép/VËŻj×LÓnňéyČŔŕTtYcź
@@ -39003,7 +39098,7 @@ fémművesség/VËŻj×LÓnňéčłÄäTtYc¸źl
 fémműves/VËŻj×LÓnňéčłÄäTtYc¸źl
 fémmű/WŢŘÔyjYcČR	émművek
 fémmunka/ŐAUQĘŽiĎŇáyÇżßYcť
-fémlemezvágó/ŐAUQĘŽiĎŇáyÇżßYcť
+fémlemezvágó/ŐAUQĘŽiĎŇáyÇżßYcťém|lemez||vágó
 fémlemezke/ŐBVRËŻjĐÓéčłÄäYc¸ź
 fémkupa/ŐAUQĘŽiĎŇáyÇżßYcť
 fémjelzünk/X)émjelez
@@ -39046,7 +39141,6 @@ félév_közben
 félév/VËŻj×LÓnňéyČŔŕTtYcź
 féláru/w
 félárbóc/UĘŽiÖKŇmôáyÇżßSsYcť
-félár/UmôŇyiYcÇ	élárak
 félvezető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 félvariogram/UĘŽiÖKŇmôáyÇżßSsYcť
 féltucatnyi/AUŃŐĎ
@@ -39699,8 +39793,8 @@ fogódzik
 fogócska/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 fogó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 fogív/VËŻj×LÓnňéyČŔŕTtYcź
-fogínysorvadás/UĘŽiÖKŇmôáyÇżßSsYcť
-fogínygyulladás/UĘŽiÖKŇmôáyÇżßSsYcť
+fogínysorvadás/UĘŽiÖKŇmôáyÇżßSsYcťíny||sorvadás
+fogínygyulladás/UĘŽiÖKŇmôáyÇżßSsYcťíny||gyulladás
 fogíny/VËŻj×LÓnňéyČŔŕTtYcź
 fogászat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 fogász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -39726,7 +39820,7 @@ fogva
 fogtömés/VËŻj×LÓnňéyČŔŕTtYcź
 fogtechnikus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 fogság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-fogsor/UĘŽiÖKŇmôáyÇżßQYcť
+fogsor/UĘŽiÖKŇmôáyÇżßQSsYcť
 fogpor/UĘŽiÖKŇmôáyÇżßSsYcť
 fogpiszkáló/ŐAUQĘŽiĎŇáyÇżßYcť
 fogoly/UmôçiYcŽk
@@ -39736,6 +39830,7 @@ foglyászik
 foglaló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 foglalkozás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 foglalkoztatottság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+foglalkoznivaló/ŐAUQĘŽiĎŇáyÇżßYcť
 foglalkozik
 foglalatosság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 foglalat/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
@@ -39859,6 +39954,7 @@ flaszter/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRTtYcˇť¸źkl
 flastrom/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 flaskó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 flaska/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+flashmob/UĘŽiÖKŇmôáç˛ĂăQYcˇťk	ph:flesmob
 flashmemória/ŐAUQĘŽiĎŇáyÇżßYcť
 flangál
 flanel/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRTtYcˇť¸źkl
@@ -39993,9 +40089,9 @@ finomszesz/VËŻj×LÓnňéyČŔŕTtYcź
 finomszerkezet/VËŻj×LÓnňéyČŔŕTtYcź
 finomstruktúra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 finomolaj/UmôŇyiYcÇĘŽÖKáżßSsť
-finomműszer/wYVËŻj×LÓnňéyČŔŕTtcź
+finomműszer/wYVËŻj×LÓnňéyČŔŕTtcźű|szer
 finommunka/ŐAUQĘŽiĎŇáyÇżßYcť
-finommosószer/VËŻj×LÓnňéyČŔŕTtYcź
+finommosószer/VËŻj×LÓnňéyČŔŕTtYcźó|szer
 finommetélt/VËŻj×LÓnňéčłÄäRYc¸źl
 finommegmunkálás/UĘŽiÖKŇmôáyÇżßSsYcť
 finommechanika/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -40007,7 +40103,7 @@ finomhangolás/UĘŽiÖKŇmôáyÇżßSsYcť
 finomfőzelék/VËŻj×LÓnňéyČŔŕTtYcź
 finomfajtázás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 finombeállító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-finombeállítás/UĘŽiÖKŇmôáyÇżßSsYcť
+finombeállítás/UĘŽiÖKŇmôáyÇżßSsYcťállítás
 finomacél/UĘŽiÖKŇmôáyÇżßQYcť
 finnüldözés/VËŻj×LÓnňéyČŔŕTtYcź
 finnugrisztika/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -40066,12 +40162,12 @@ filmkölcsönző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 filmkocka/ŐAUQĘŽiĎŇáyÇżßYcť
 filmjelenet/VËŻj×LÓnňéyČŔŕTtYcź
 filmipar/UĘŽiÖKŇmôáyÇżßSsYcť
-filmhíradó/ŐAUQĘŽiĎŇáyÇżßYcť
-filmforgatókönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
-filmfelvételezés/VËŻj×LÓnňéyČŔŕTtYcź
-filmfelvétel/VËŻj×LÓnňéyČŔŕTtYcź
+filmhíradó/ŐAUQĘŽiĎŇáyÇżßYcťír|adó
+filmforgatókönyv/VNËŻj×LÝňÔéyČŔŕTtYcźó|könyv
+filmfelvételezés/VËŻj×LÓnňéyČŔŕTtYcźételezés
+filmfelvétel/VËŻj×LÓnňéyČŔŕTtYcźétel
 filmfelvevő_gép/VËŻj×LÓnňéčłÄäRTtYc¸źl
-filmfelvevő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+filmfelvevő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő
 filmfelirat/UĘŽiÖKŇmôáyÇżßSsYcť
 filmezik
 filmesit/w
@@ -40151,6 +40247,7 @@ feudum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 feudalizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 feudalitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 fetisizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+fetisiszta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 feta/ŐAUQĘŽiĎŇáç˛Ăăvcˇť
 feszültségmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 feszültségkiegyenlítő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -40180,7 +40277,7 @@ fesz/wVËŻj×LÓnňéčłÄäTtc¸ź
 festőállvány/UĘŽiÖKŇmôáyÇżßSsYcť
 festősablon/UĘŽiÖKŇmôáyÇżßQYcť
 festőnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-festőműhely/×VËŻjLÓnňéyČŔŕTtYcź
+festőműhely/×VËŻjLÓnňéyČŔŕTtYcźő||mű|hely
 festőiség/VËŻj×LÓnňéčłÄäTtYc¸źl
 festőfű/WŢŘÔyjYcČ	őfüvek
 festőecset/VËŻj×LÓnňéyČŔŕRTtYcź
@@ -40322,7 +40419,9 @@ fengsuj/UĘŽiÖKŇmôáç˛ĂăSsvcˇťk	ph:fengshui
 feneség/VËŻj×LÓnňéčłÄäTtYc¸źl
 fene/ŐBVRËŻjĐÓéčłÄäYc¸ź
 fenantrén/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRYcˇť¸źkl
+femtoszekundum/UĘŽiÖKŇmôáyÇżßSsYcť
 femtolézer/VËŻj×LÓnňéyČŔŕRTtYcź
+femtokémia/ŐAUQĘŽiĎŇáyÇżßYcť
 feminizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 felülvizsgálat/UĘŽiÖKŇmôáyÇżßSsYcť
 felülvilágító/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -40413,7 +40512,7 @@ feltartóztatottság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 feltalálás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 felsülés/VËŻj×LÓnňéčłÄäTtYc¸źl
 felsőéves/VËŻj×LÓnňéčłÄäTtYc¸źl
-felsővégtag/wYUĘŽiÖKŇmôáyÇżßSscť
+felsővégtag/wYUĘŽiÖKŇmôáyÇżßSscťő||vég|tag
 felsőváros/UĘŽiÖKŇmôáyÇżßSsYcť
 felsővezeték/VËŻj×LÓnňéyČŔŕTtYcź
 felsőtábla/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -40423,7 +40522,7 @@ felsőrész/VËŻj×LÓnňéyČŔŕTtYcź
 felsőruházat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 felsőruha/ŐAUQĘŽiĎŇáyÇżßYcť
 felsőoktatás/UĘŽiÖKŇmôáyÇżßSsYcť
-felsőkarizom/UmôyiYcŽ	őkarizmok
+felsőkarizom/UmôyiYcŽ	őkarizmokő||kar|izom
 felsőkar/UĘŽiÖKŇmôáyÇżßQYcť
 felsőkabát/UĘŽiÖKŇmôáyÇżßQYcť
 felsőház/UmôŇyiYcÇ	őházak
@@ -40445,7 +40544,7 @@ felszólítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 felszívódás/UĘŽiÖKŇmôáyÇżßSsYcť
 felszívó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 felszívás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-felszínközel/VËŻj×LÓnňéyČŔŕTtYcź
+felszínközel/VËŻj×LÓnňéyČŔŕTtYcźín||közel
 felszín/VËŻj×LÓnňéyČŔŕTtYcź
 felszél/VËŻj×LÓnňéyČŔŕRYcź
 felszámolás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -40484,6 +40583,7 @@ felmagasztalás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 fellépés/VËŻj×LÓnňéčłÄäTtYc¸źl
 fellélegez/)élegzik
 fellázadás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+felláció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 fellobbanás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 fellobbantás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 fellevél/VÓnňyjYcČ
@@ -40538,7 +40638,6 @@ felhám/UĘŽiÖKŇmôáyÇżßSsYcť
 felhozatal/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 felhorzsolás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 felhorkanás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-felhevülés/VËŻj×LÓnňéyČŔŕTtYcź
 felhatalmazás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 felhasználó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 felhasználás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -40563,6 +40662,7 @@ felfegyverzés/VËŻj×LÓnňéčłÄäTtYc¸źl
 felfedés/VËŻj×LÓnňéčłÄäTtYc¸źl
 felfedező/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 felfedezés/VËŻj×LÓnňéčłÄäTtYc¸źl
+felfedeznivaló/ŐAUQĘŽiĎŇáyÇżßYcť
 feleúton
 felezőmerőleges/VËŻj×LÓnňéyČŔŕTtYcź
 felettünk/)
@@ -40719,7 +40819,7 @@ feketéscsésze/ŐBVRËŻjĐÓéyČŔŕYcź
 feketeüzlet/VËŻj×LÓnňéyČŔŕRYcź
 feketeárus/UĘŽiÖKŇmôáyÇżßSsYcť
 feketeáru/ŐAUQĘŽiĎŇáyÇżßYcť
-feketeárfolyam/UĘŽiÖKŇmôáyÇżßSsYcť
+feketeárfolyam/UĘŽiÖKŇmôáyÇżßSsYcťár|folyam
 feketeár/UmôŇyiYcÇ	árak
 feketevágás/UĘŽiÖKŇmôáyÇżßSsYcť
 feketevasárnap/UĘŽiÖKŇmôáyÇżßQYcť
@@ -40728,15 +40828,15 @@ feketetest/VËŻj×LÓnňéyČŔŕRTtvcź
 feketeszén/VÓnňyjYcČ
 feketeszáz/wUmôŇyiYcÇ	ázak
 feketesugárzó/ŐAUQĘŽiĎŇáyÇżßYcť
-feketerézérc/VËŻj×LÓnňéyČŔŕTtYcź
+feketerézérc/VËŻj×LÓnňéyČŔŕTtYcźéz|érc
 feketerigó/ŐAUQĘŽiĎŇáyÇżßYcť
 feketepiac/UĘŽiÖKŇmôáyÇżßSsYcť
 feketepenész/VËŻj×LÓnňéyČŔŕTtYcź
 feketemunka/ŐAUQĘŽiĎŇáyÇżßYcť
-feketelőpor/UĘŽiÖKŇmôáyÇżßQYcť
+feketelőpor/UĘŽiÖKŇmôáyÇżßQYcťő|por
 feketelista/ŐAUQĘŽiĎŇáyÇżßYcť
 feketeleves/VËŻj×LÓnňéyČŔŕTtYcź
-feketekőszén/VÓnňyjYcČ	őszenek
+feketekőszén/VÓnňyjYcČ	őszenekő|szén
 feketekávé/ŐAUQĘŽiĎŇáyÇżßYcť
 feketekereskedelem/VnňyjYcŻ
 feketejövedelem/VnňyjYcŻ	övedelmek
@@ -40777,7 +40877,7 @@ fejkötő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 fejkendő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 fejhallgató/ŐAUQĘŽiĎŇáyÇżßYcť
 fejgörcs/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
-fejgerinchúros/UĘŽiÖKŇmôáyÇżßSsYcť
+fejgerinchúros/UĘŽiÖKŇmôáyÇżßSsYcťúros
 fejgerenda/ŐAUQĘŽiĎŇáyÇżßYcť
 fejfájás/UĘŽiÖKŇmôáyÇżßSsYcť
 fejforma/ŐAUQĘŽiĎŇáyÇżßYcťétel>
@@ -40805,9 +40905,9 @@ fehérítő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 fehéráru/ŐAUQĘŽiĎŇáyÇżßYcť
 fehérállomány/UĘŽiÖKŇmôáyÇżßSsYcť
 fehérvérűség/VËŻj×LÓnňéčłÄäTtYc¸źl
-fehérvértest/VËŻj×LÓnňéyČŔŕRTtYcź
-fehérvérsejt/VËŻj×LÓnňéyČŔŕRYcź
-fehérvasöntvény/VËŻj×LÓnňéyČŔŕTtYcź
+fehérvértest/VËŻj×LÓnňéyČŔŕRTtYcźér||vér|test
+fehérvérsejt/VËŻj×LÓnňéyČŔŕRYcźér||vér|sejt
+fehérvasöntvény/VËŻj×LÓnňéyČŔŕTtYcźér||vas|öntvény
 fehérvasárnap/UĘŽiÖKŇmôáyÇżßQYcť
 fehértörés/VËŻj×LÓnňéyČŔŕTtYcź
 fehérterrorista/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -40819,7 +40919,7 @@ fehérpenész/VËŻj×LÓnňéyČŔŕTtYcź
 fehérpecsenye/ŐBVRËŻjĐÓéyČŔŕYcź
 fehérorosz/UĘŽiÖKŇmôáç˛ĂăSscˇťk
 fehérnép/VËŻj×LÓnňéčłÄäRYc¸źl
-fehérneműszekrény/VËŻj×LÓnňéyČŔŕTtYcź
+fehérneműszekrény/VËŻj×LÓnňéyČŔŕTtYcźér|nemű||szekrény
 fehérnemű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 fehérmályva/ŐAUQĘŽiĎŇáyÇżßYcť
 fehérmájvirág/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -40847,7 +40947,7 @@ fegyvertöltet/VËŻj×LÓnňéyČŔŕTtYcź
 fegyverterem/VnňyjYcŻ
 fegyverszünet/VËŻj×LÓnňéyČŔŕTtYcź
 fegyverravasz/UĘŽiÖKŇmôáyÇżßSsYcť
-fegyverraktár/UmôŇyiYcÇ	árak
+fegyverraktár/UmôŇyiYcÇ	árakár
 fegyvernök/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 fegyvermester/VËŻj×LÓnňéyČŔŕTtYcź
 fegyverkezik
@@ -40912,7 +41012,7 @@ fazsindely/VËŻj×LÓnňéyČŔŕTtYcź
 fazon/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 fazenda/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 fazekasság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-fazekasműhely/×VËŻjLÓnňéyČŔŕTtYcź
+fazekasműhely/×VËŻjLÓnňéyČŔŕTtYcźű|hely
 fazekaskorong/UĘŽiÖKŇmôáyÇżßQYcť
 fazekas/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 faxmodem/VËŻj×LÓnňéčłÄäRYc¸źl
@@ -41041,7 +41141,6 @@ falvédő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 falvak/Inx)
 faluz
 faluszépe/ŐBVRËŻjĐÓéyČŔŕYcź
-faluszerte
 falurossza/ŐAUQĘŽiĎŇáyÇżßYcť
 falu/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 faltörő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -41049,7 +41148,7 @@ falszakasz/UĘŽiÖKŇmôáyÇżßSsYcť
 falsarok/UmôyiYcŽ
 falrész/VËŻj×LÓnňéyČŔŕTtYcź
 falrengető/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
-falragasztábla/ŐAUQĘŽiĎŇáyÇżßYcť
+falragasztábla/ŐAUQĘŽiĎŇáyÇżßYcťábla
 falragasz/UĘŽiÖKŇmôáyÇżßSsYcť
 falpillér/VËŻj×LÓnňéyČŔŕRTtYcź
 falnivaló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -41062,13 +41161,13 @@ faliújság/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 falióra/ŐAUQĘŽiĎŇáyÇżßYcť
 faliállvány/UĘŽiÖKŇmôáyÇżßSsYcť
 falitükör/WÝyjYcŻ	ükrök
-falitérkép/VËŻj×LÓnňéyČŔŕTtYcź
+falitérkép/VËŻj×LÓnňéyČŔŕTtYcźér|kép
 falitányér/UĘŽiÖKŇmôáyÇżßQYcť
 falitábla/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 faliszőnyeg/VËŻj×LÓnňéyČŔŕTtYcź
 faliszekrényke/ŐBVRËŻjĐÓéyČŔŕYcź
 faliszekrény/VËŻj×LÓnňéyČŔŕTtYcź
-falinaptár/UmôŇyiYcÇ	árak
+falinaptár/UmôŇyiYcÇ	árakár
 falimosdó/ŐAUQĘŽiĎŇáyÇżßYcť
 falilámpa/ŐAUQĘŽiĎŇáyÇżßYcť
 falikút/UmôŇyiYcÇ
@@ -41257,8 +41356,8 @@ ezredsegédtiszt/VËŻj×LÓnňéyČŔŕRYcź
 ezredrész/VËŻj×LÓnňéyČŔŕTtYcź
 ezredparancsnok/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ezredorvos/UĘŽiÖKŇmôáyÇżßSsYcť
-ezredmásodperc/VËŻj×LÓnňéyČŔŕTtYcź
-ezredmilliméter/VËŻj×LÓnňéyČŔŕTtYcź
+ezredmásodperc/VËŻj×LÓnňéyČŔŕTtYcźásod|perc
+ezredmilliméter/VËŻj×LÓnňéyČŔŕTtYcźéter
 ezrediroda/ŐAUQĘŽiĎŇáyÇżßYcť
 ezredik/nÓ×BVÜbc!Ll)
 ezredforduló/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -41271,67 +41370,69 @@ ezred/VËŻj×LÓnňéčłÄäTtYc¸źlRz!BÜb
 ezotéria/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ezoterika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 eziránt
-ezerötszázas/AFUÚötszáz
-ezerötszázan/)ötszáz
-ezerötszázadik/mŇŮAUÚötszáz
-ezerötszázad/AUÚötszáz
-ezerötszáz/$UŮÖmŇSscÚ	ötszázan
+ezerötszázas/AFUÚ)ötszáz
+ezerötszázan/)ötszázöt|százan
+ezerötszázadik/mŇŮAUÚ)ötszáz
+ezerötszázad/AUÚ)ötszáz
+ezerötszáz/$UŮÖmŇSscÚ	ötszázasötszázanötszázadikötszázad	öt|száz
 ezeróránként
 ezerórai
 ezerévi
 ezerévente
 ezerévenként
 ezerzłotys/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-ezervalahányszázan/))ányszáz
-ezervalahányszáz/$UŮÖmŇSscÚ	ányszázan
+ezervalahányszázan/))ányszáz	ány|százan
+ezervalahányszáz/$UŮÖmŇSscÚ	ányszázan	ány|száz
+ezervalahányfeléány||felé
 ezervalahányan
+ezervalahány/UmŇŮÚ
 ezerszámra
 ezerszám
 ezerrubeles/VËŻj×LÓnňéčłÄäTtYc¸źl
 ezerpercenként
 ezernégyszázas/AFUÚ)égyszáz
-ezernégyszázan/)égyszáz
+ezernégyszázan/)égyszázégy|százan
 ezernégyszázadik/mŇŮAUÚ)égyszáz
 ezernégyszázad/AUÚ)égyszáz
-ezernégyszáz/$UŮÖmŇSscÚ	égyszázan
-ezernyolcszázas/AFUÚ)áz
-ezernyolcszázan/)áz
-ezernyolcszázadik/mŇŮAUÚ)áz
-ezernyolcszázad/AUÚ)áz
-ezernyolcszáz/$UŮÖmŇSscÚ	ázan
+ezernégyszáz/$UŮÖmŇSscÚ	égyszázaségyszázanégyszázadikégyszázad	égy|száz
+ezernyolcszázas/AFUÚ)áz	ázas
+ezernyolcszázan/)ázázan
+ezernyolcszázadik/mŇŮAUÚ)áz	ázadik
+ezernyolcszázad/AUÚ)áz	ázad
+ezernyolcszáz/$UŮÖmŇSscÚ	ázasázanázadikázad	áz
 ezernaponta
 ezernaponként
 ezermárkás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ezermillió/AUŐĎŇKkQacżÚ
 ezermilliárd/AUÖmŇKkQacżÚ
 ezermester/VËŻj×LÓnňéyČŔŕTtYcź
-ezermagtömeg/VËŻj×LÓnňéyČŔŕTtYcź
+ezermagtömeg/VËŻj×LÓnňéyČŔŕTtYcźömeg
 ezerkétszázas/AFUÚ)étszáz
-ezerkétszázan/)étszáz
+ezerkétszázan/)étszázét|százan
 ezerkétszázadik/mŇŮAUÚ)étszáz
 ezerkétszázad/AUÚ)étszáz
-ezerkétszáz/$UŮÖmŇSscÚ	étszázan
-ezerkilencszázas/AFUÚ)áz
-ezerkilencszázan/)áz
-ezerkilencszázadik/mŇŮAUÚ)áz
-ezerkilencszázad/AUÚ)áz
-ezerkilencszáz/$UŮÖmŇSscÚ	ázan
+ezerkétszáz/$UŮÖmŇSscÚ	étszázasétszázanétszázadikétszázad	ét|száz
+ezerkilencszázas/AFUÚ)áz	ázas
+ezerkilencszázan/)ázázan
+ezerkilencszázadik/mŇŮAUÚ)áz	ázadik
+ezerkilencszázad/AUÚ)áz	ázad
+ezerkilencszáz/$UŮÖmŇSscÚ	ázasázanázadikázad	áz
 ezerkettőszázas/AFUÚ)őszáz
 ezerkettőszázadik/mŇŮAUÚ)őszáz
 ezerkettőszázad/AUÚ)őszáz
-ezerkettőszáz/$UŮÖmŇSscÚ
+ezerkettőszáz/$UŮÖmŇSscÚ	őszázasőszázadikőszázad	ő|száz
 ezerjófű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ófüvek
 ezerjó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ezerhétszázas/AFUÚ)étszáz
-ezerhétszázan/)étszáz
+ezerhétszázan/)étszázét|százan
 ezerhétszázadik/mŇŮAUÚ)étszáz
 ezerhétszázad/AUÚ)étszáz
-ezerhétszáz/$UŮÖmŇSscÚ	étszázan
+ezerhétszáz/$UŮÖmŇSscÚ	étszázasétszázanétszázadikétszázad	ét|száz
 ezerháromszázas/AFUÚ)áromszáz
-ezerháromszázan/)áromszáz
+ezerháromszázan/)áromszázárom|százan
 ezerháromszázadik/mŇŮAUÚ)áromszáz
 ezerháromszázad/AUÚ)áromszáz
-ezerháromszáz/$UŮÖmŇSscÚ	áromszázan
+ezerháromszáz/$UŮÖmŇSscÚ	áromszázasáromszázanáromszázadikáromszázad	árom|száz
 ezerheti
 ezerhetente
 ezerhetenként
@@ -41339,10 +41440,10 @@ ezerhavonta
 ezerhavonként
 ezerhavi
 ezerhatszázas/AFUÚ)áz
-ezerhatszázan/)áz
+ezerhatszázan/)ázázan
 ezerhatszázadik/mŇŮAUÚ)áz
 ezerhatszázad/AUÚ)áz
-ezerhatszáz/$UŮÖmŇSscÚ	ázan
+ezerhatszáz/$UŮÖmŇSscÚ	ázasázanázadikázad	áz
 ezerforintos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ezerfontos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ezerfelől
@@ -41351,10 +41452,10 @@ ezereurós/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ezeresztendőnként
 ezeresztendei
 ezeregyszázas/AFUÚ)áz
-ezeregyszázan/)áz
+ezeregyszázan/)ázázan
 ezeregyszázadik/mŇŮAUÚ)áz
 ezeregyszázad/AUÚ)áz
-ezeregyszáz/$UŮÖmŇSscÚ	ázan
+ezeregyszáz/$UŮÖmŇSscÚ	ázasázanázadikázad	áz
 ezerdolláros/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ezerarcúság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ezerannyi/UŐĎŇ
@@ -41377,7 +41478,8 @@ ezalatt
 ez_ügyben
 ez/Ő	ééélől
 exállamtitkár/UĘŽiÖKŇmôáyÇżßQSsYcťállam|titkár
-exvilágbajnok/UĘŽiÖKŇmôáyÇżßSsYcť
+exvilágbajnok/UĘŽiÖKŇmôáyÇżßSsYcťág|bajnok
+extévés/VËŻj×LÓnňéyČŔŕTtYcź
 extázis/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 extremitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 extravagancia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -41398,8 +41500,10 @@ exteriőr/WĚŻjŘMÝňÔíčłĹĺRYc¸˝l
 extenzifikáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 extemporizál
 exszikkátor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+exrádiós/UĘŽiÖKŇmôáyÇżßSsYcť
 expó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 expénzügyminiszter/VËŻj×LÓnňéyČŔŕTtYcźénz|ügy||miniszter
+expártelnök/WĚŻjŘMÝňÔíyČÁ˙RYc˝árt|elnök
 expresszáru/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 expresszvonat/UĘŽiÖKŇmôáyÇżßSsYcť
 expresszlevél/VÓnňyjYcČ
@@ -41435,12 +41539,12 @@ exogámia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 exodus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 exobolygó/ŐAUQĘŽiĎŇáyÇżßYcť
 exnej/VËŻj×LÓnňéyČŔŕTtYcź
-exminiszterelnök/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
+exminiszterelnök/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ök
 exminiszter/VËŻj×LÓnňéyČŔŕTtYcź
 exkülügyminiszter/VËŻj×LÓnňéyČŔŕTtYcźül|ügy||miniszter
 exképviselő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ép|viselő
 exkormányzó/ŐAUQĘŽiĎŇáyÇżßYcť
-exkormányfő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+exkormányfő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ány|fő
 exkommunista/ŐAUQĘŽiĎŇáyÇżßYcť
 exkommunikáció/ŐAUQĘŽiĎŇáyÇżßYcť
 exklávé/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -41451,6 +41555,7 @@ exkatona/ŐAUQĘŽiĎŇáyÇżßYcť
 exkapitány/UĘŽiÖKŇmôáyÇżßSsYcť
 exitus/UĘŽiÖKŇmöáç˛ĂăSsYcˇťk
 exilium/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+exigazgató/ŐAUQĘŽiĎŇáyÇżßYcť
 exhibicionizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 exhibicionista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 exhausztor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -41469,7 +41574,7 @@ excenter/VËŻj×LÓnňéčłÄäTtYc¸źl
 excellál
 excellencia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 exbelügyminiszter/VËŻj×LÓnňéyČŔŕTtYcźügy||miniszter
-exbarátnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+exbarátnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝át|nő
 exbarát/UĘŽiÖKŇmôáyÇżßQYcť
 exbajnok/UĘŽiÖKŇmôáyÇżßSsYcť
 exarchátus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -41479,7 +41584,7 @@ ex/VËŻj×LÓnňéčłÄäTtc¸ź
 ex/VËŻj×LÓnňéčłÄäTtc¸ź
 evőpálcika/ŐAUQĘŽiĎŇáyÇżßYcť
 evőkészlet/VËŻj×LÓnňéyČŔŕTtYcź
-evőeszköztartó/ŐAUQĘŽiĎŇáyÇżßYcť
+evőeszköztartó/ŐAUQĘŽiĎŇáyÇżßYcťő|eszköz||tartó
 evőeszköz/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 evészet/VËŻj×LÓnňéčłÄäTtYc¸źl
 evés/XVËŻj×LÓnňéčłÄäTtYc¸źl)Ás_PROCESS/RESULT_noun
@@ -41594,7 +41699,7 @@ etanal/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 etalon/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 et_cetera
 esőzés/VËŻj×LÓnňéčłÄäTtYc¸źl
-esővízgyűjtő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+esővízgyűjtő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő|víz||gyűjtő
 esővíz/VÓnňyjYcČ	ővizek
 esőverte
 esőrétegfelhő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -41721,7 +41826,7 @@ erőszakoltság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 erőszak/UĘŽiÖKŇmôáyÇżßQYcť
 erőnlét/VËŻj×LÓnňéyČŔŕTtYcź
 erőművész/VËŻj×LÓnňéyČŔŕTtYcź
-erőműtelep/VËŻj×LÓnňéyČŔŕRTtYcź
+erőműtelep/VËŻj×LÓnňéyČŔŕRTtYcźő|mű||telep
 erőmű/WŢŘÔyjYcČR	őművek
 erőmérő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 erőkifejtés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -41852,7 +41957,7 @@ epeda/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 epe/ŐBVRËŻjĐÓéčłÄäYc¸ź
 eozinmáz/UmôŇyiYcÇ	ázak
 eozin/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-eolhárfa/ŐAUQĘŽiĎŇáyÇżßYcť
+eolhárfa/ŐAUQĘŽiĎŇáyÇżßYcťár|fa
 eocénkor/UĘŽiÖKŇmôáç˛ĂăSscˇťk
 eocén/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRYcˇť¸źkl
 enélkül
@@ -41932,6 +42037,7 @@ endoszkópia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 endoszkóp/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 endospóra/ŐAUQĘŽiĎŇáyÇżßYcť
 endorfin/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+endometriózis/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 endokrinológus/UĘŽiÖKŇmôáyÇżßSsYcť
 endokrinológia/ŐAUQĘŽiĎŇáyÇżßYcť
 endogámia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -42109,7 +42215,7 @@ előzék/VËŻj×LÓnňéčłÄäTtYc¸źl
 előzsűri/ŐBVRËŻjĐÓéyČŔŕYcź
 előzmény/VËŻj×LÓnňéčłÄäTtYc¸źl
 előzetes/VËŻj×LÓnňéčłÄäTtYc¸źl
-előzenekar/UĘŽiÖKŇmôáyÇżßSsYcť
+előzenekar/UĘŽiÖKŇmôáyÇżßSsYcťő||zene|kar
 elővétel/VËŻj×LÓnňéyČŔŕTtYcź
 előváros/UĘŽiÖKŇmôáyÇżßSsYcť
 előváladék/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -42156,6 +42262,7 @@ előszó/ŐAUQĘŽiĎŇáyÇżßYcťÖ	őszavak
 előszél/VÓnňyjYcČ	őszelek
 előszobázik
 előszoba/ŐAUQĘŽiĎŇáyÇżßYcť
+előszilveszter/VËŻj×LÓnňéyČŔŕTtYcź
 előszezon/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 előszeretet/VËŻj×LÓnňéyČŔŕTtYcź
 elősegítő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -42178,11 +42285,12 @@ előrefelé
 előrebillenés/VËŻj×LÓnňéyČŔŕTtYcź
 előre/D
 előrag/UĘŽiÖKŇmôáyÇżßQYcť
+előprivatizáció/ŐAUQĘŽiĎŇáyÇżßYcť
 előolimpia/ŐAUQĘŽiĎŇáyÇżßYcť
 előoldal/UmôŇyiYcÇ	őoldalak
 előnézet/VËŻj×LÓnňéčłÄäTtYc¸źl
 előnév/VÓnňyjYcČ	őnevek
-előnyugdíj/UŇmôyiYcÇ	őnyugdíjak
+előnyugdíj/UŇmôyiYcÇ	őnyugdíjakő||nyug|díj
 előnyomulás/UĘŽiÖKŇmôáyÇżßSsYcť
 előny/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 előmunkás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -42212,6 +42320,7 @@ előkicsapás/UĘŽiÖKŇmôáyÇżßSsYcťő||ki|csapás
 előkert/VËŻj×LÓnňéyČŔŕRYcź
 előkelőség/VËŻj×LÓnňéčłÄäTtYc¸źl
 előke/ŐBVRËŻjĐÓéčłÄäYc¸ź
+előkarácsony/UĘŽiÖKŇmôáyÇżßSsYcť
 előkalkuláció/ŐAUQĘŽiĎŇáyÇżßYcť
 előjövetel/VËŻj×LÓnňéyČŔŕRYcź
 előjáték/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -42243,7 +42352,7 @@ előhang/UĘŽiÖKŇmôáyÇżßQYcť
 előhad/UmôŇyiYcÇS	őhadak
 előgyújtás/UĘŽiÖKŇmôáyÇżßSsYcť
 előgyakorlat/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-előgerinchúros/UĘŽiÖKŇmôáyÇżßSsYcť
+előgerinchúros/UĘŽiÖKŇmôáyÇżßSsYcťő||gerinc|húros
 előfüggöny/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 előfutár/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 előfutam/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -42257,7 +42366,7 @@ előfeldolgozás/UĘŽiÖKŇmôáyÇżßSsYcťő||fel|dolgozás
 előeste/ŐBVRËŻjĐÓéyČŔŕYcź
 előember/VËŻj×LÓnňéčłÄäRYc¸źl
 elődöntő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-elődenitrifikáció/ŐAUQĘŽiĎŇáyÇżßYcť
+elődenitrifikáció/ŐAUQĘŽiĎŇáyÇżßYcťő||de|nitrifikáció
 előd/WĚŻjŘMÝňÔíčłĹĺRTtYc¸˝l
 előcsarnok/UĘŽiÖKŇmôáyÇżßSsYcť
 előcsahos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -42346,7 +42455,7 @@ elválasztó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 elválasztás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 elvágólag
 elvágás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-elvtársnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+elvtársnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝árs||nő
 elvtárs/UmôŇyiYcÇ	ársak
 elvonás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 elvonulás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -42409,7 +42518,7 @@ elsősorban/D
 elsősegély/VËŻj×LÓnňéyČŔŕTtYcź
 elsős/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 elsőpéntek/VËŻj×LÓnňéyČŔŕRcź
-elsőkerék-meghajtás/UĘŽiÖKŇmôáyÇżßSscť
+elsőkerék-meghajtás/UĘŽiÖKŇmôáyÇżßSscťő|kerék-meghajtás
 elsőkerék-hajtás/UĘŽiÖKŇmôáç˛ĂăSscˇťk
 elsőhegedű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 elsőcsütörtök/WĚŻjŘMÝňÔíyČÁ˙Rc˝
@@ -42441,6 +42550,7 @@ elrejtőzés/VËŻj×LÓnňéčłÄäTtYc¸źl
 elrejtés/VËŻj×LÓnňéčłÄäTtYc¸źl
 elragadás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 elragadtatás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+elrabló/ŐAUQĘŽiĎŇáç˛Ăăcˇť
 elrablás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 elpüfölés/VËŻj×LÓnňéčłÄäTtYc¸źl
 elpártolás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -42533,8 +42643,8 @@ ellenáram/UĘŽiÖKŇmôáyÇżßSsYcť
 ellenállás/UĘŽiÖKŇmôáyÇżßSsYcť
 ellenző/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X)Ó_PRESPART_adj
 ellenző/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X
-ellenzés/XVËŻj×LÓnňéyČŔŕTtYcź)Ás_PROCESS/RESULT_noun
-ellenzés/XVËŻj×LÓnňéyČŔŕTtYcź
+ellenzés/XVËŻj×LÓnňéčłÄäTtYc¸źl)Ás_PROCESS/RESULT_noun
+ellenzés/XVËŻj×LÓnňéčłÄäTtYc¸źl
 ellenzék/VËŻj×LÓnňéčłÄäTtYc¸źl
 ellenvélemény/VËŻj×LÓnňéčłÄäTtYc¸źl
 ellenvoks/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -42553,18 +42663,17 @@ ellentengernagy/UĘŽiÖKŇmôáyÇżßSsYcť
 ellent
 ellensúlyozó/ŐAUQĘŽiĎŇáyÇżßYcť
 ellensúly/UĘŽiÖKŇmôáyÇżßSsYcť
-ellenségeskedés/VËŻj×LÓnňéyČŔŕTtYcź
 ellenség/VËŻj×LÓnňéčłÄäTtYc¸źl
 ellenszérum/UĘŽiÖKŇmôáyÇżßSsYcť
 ellenszél/VÓnňyjYcČ
-ellenszámlakönyv/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
+ellenszámlakönyv/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ámla||könyv
 ellenszámla/ŐAUQĘŽiĎŇáyÇżßYcť
 ellenszolgáltatás/UĘŽiÖKŇmôáyÇżßSsYcť
 ellenszer/VËŻj×LÓnňéčłÄäTtYc¸źl
 ellenszenv/VËŻj×LÓnňéyČŔŕTtYcź
 ellenszegülés/VËŻj×LÓnňéyČŔŕTtYcź
 ellenszavazat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-ellenrendszabály/UĘŽiÖKŇmôáyÇżßSsYcť
+ellenrendszabály/UĘŽiÖKŇmôáyÇżßSsYcťály
 ellenreformáció/ŐAUQĘŽiĎŇáyÇżßYcť
 ellenreakció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ellenrakéta/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -42790,12 +42899,12 @@ elektrolizálócella/ŐAUQĘŽiĎŇáyÇżßYcť
 elektrolit/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 elektrokémia/ŐAUQĘŽiĎŇáyÇżßYcť
 elektrokardiográfia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-elektrokardiográf/UĘŽiÖKŇmôáyÇżßQYcť
+elektrokardiográf/UĘŽiÖKŇmôáyÇżßQYcťáf
 elektrokardiogram/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 elektrofiziológus/UĘŽiÖKŇmôáyÇżßSsYcť
 elektrofiziológia/ŐAUQĘŽiĎŇáyÇżßYcť
-elektroenkefalográfia/ŐAUQĘŽiĎŇáyÇżßYcť
-elektroenkefalográf/UĘŽiÖKŇmôáyÇżßQYcť
+elektroenkefalográfia/ŐAUQĘŽiĎŇáyÇżßYcťáfia
+elektroenkefalográf/UĘŽiÖKŇmôáyÇżßQYcťáf
 elektroenkefalogram/UĘŽiÖKŇmôáyÇżßSsYcť
 elektrodinamika/ŐAUQĘŽiĎŇáyÇżßYcť
 elektroakusztika/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -42925,9 +43034,8 @@ egérrágta
 egérlyuk/UmôŇyiYcÇQ	érlyukak
 egérke/ŐBVRËŻjĐÓéčłÄäYc¸ź
 egérfogó/ŐAUQĘŽiĎŇáyÇżßYcť
-egérfarkfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	érfarkfüvek
+egérfarkfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	érfarkfüvekér|fark||fű
 egér/VÓnňčjYcłl
-egárfarkfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	árfarkfüvek
 egzámen/VËŻj×LÓnňéčłÄäRTtYc¸źl
 egzotikum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 egzisztál
@@ -42970,7 +43078,7 @@ egyveleg/VËŻj×LÓnňéčłÄäTtYc¸źl
 egyvalami/ŐBVRËŻjĐÓéčłÄäYc¸ź
 egyvalaki/ŐBVRËŻjĐÓéčłÄäYc¸ź
 egyugyanazon
-egytálétel/VËŻj×LÓnňéyČŔŕRYcź
+egytálétel/VËŻj×LÓnňéyČŔŕRYcźál||étel
 egytrillióan/b)ó
 egytrillió/ĎŇŐAUÚQbci	óan
 egytrilliárd/mÖKkUÚQbci
@@ -42998,13 +43106,13 @@ egyszeregy/VËŻj×LÓnňéčłÄäTtYc¸źl
 egyszer_csak
 egyszer
 egysejtű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-egyrétűtapló/ŐAUQĘŽiĎŇáyÇżßYcť
+egyrétűtapló/ŐAUQĘŽiĎŇáyÇżßYcťétű||tapló
 egyrészt
 egyrészről
 egyrubeles/VËŻj×LÓnňéčłÄäTtYc¸źl
 egyre-másra
 egyre
-egypártrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+egypártrendszer/VËŻj×LÓnňéyČŔŕTtYcźárt||rendszer
 egypárszor/)ár
 egypárszor
 egypárevezős/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ár||evezős
@@ -43043,7 +43151,7 @@ egykoron
 egykor
 egykettőre
 egyketted/VËŻj×LÓnňéčłÄäTtc¸źl
-egyistenhívő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+egyistenhívő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ívő
 egyistenhit/VËŻj×LÓnňéyČŔŕTtYcź
 egyiptológus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 egyiptológia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -43053,12 +43161,12 @@ egyikőjük/WÔ×ÝTt)
 egyik/BÓ×nVLTt	őtökőnkőjük
 egyidőben
 egyidejűleg
-egyházmegye/ŐBVRËŻjĐÓéyČŔŕYcź
+egyházmegye/ŐBVRËŻjĐÓéyČŔŕYcźáz||megye
 egyházközség/VËŻj×LÓnňéyČŔŕTtYcźáz||köz-ség
-egyházfő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+egyházfő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝áz||fő
 egyházfi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 egyházatya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ázaty
-egyházaty/uQ)ázatya
+egyházaty/uQ)ázatya	áz||atya
 egyház/UmôŇyiYcÇĘŽÖKáżßSsť	ázak
 egyhuzamban
 egyhangúlag
@@ -43110,7 +43218,6 @@ egyenértékűség/VËŻj×LÓnňéyČŔŕTtYcź
 egyenérték/VËŻj×LÓnňéyČŔŕTtYcź
 egyenáram/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 egyenviselkedés/VËŻj×LÓnňéčłÄäTtYc¸źl
-egyensúlytészta/ŐAUQĘŽiĎŇáyÇżßYcť
 egyensúlyozó/ŐAUQĘŽiĎŇáyÇżßYcť
 egyensúly/UĘŽiÖKŇmôáyÇżßSsYcť
 egyensapka/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -43174,7 +43281,7 @@ egy_személyben
 egy_közös
 egy_helyben
 egy_csapásra
-egy-kétmillió/ĎŇŐAUÚQbcw
+egy-kétmillió/ĎŇŐAUÚQbcw	ét|millió
 egy-két
 egy-egy
 egy/nVÜLlbhcÓ×a	ő
@@ -43301,7 +43408,7 @@ ecetsavanhidrid/VËŻj×LÓnňéčłÄäRYc¸źl
 ecetesüveg/VËŻj×LÓnňéyČŔŕTtYcź
 eceteshordó/ŐAUQĘŽiĎŇáyÇżßYcť
 ecet/VËŻj×LÓnňéčłÄäRTtYc¸źl
-ebír/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRYcťź
+ebír/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
 ebédrevaló/ŐAUQĘŽiĎŇáyÇżßYcť
 ebédnekvaló/ŐAUQĘŽiĎŇáyÇżßYcť
 ebédlőasztal/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -43317,7 +43424,7 @@ ebszőlő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 ebszékfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ékfüvek
 ebonit/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 ebola/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-ebnyelvfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvek
+ebnyelvfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvekű
 ebihal/UmôŇyiYcÇ
 ebhús/UĘŽiÖKŇmôáyÇżßSsYcť
 ebből/)
@@ -43417,6 +43524,7 @@ dömper/VËŻj×LÓnňéčłÄäRTtYc¸źl
 dölyf/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝
 dögölés/XVËŻj×LÓnňéčłÄäTtYc¸źl
 dögöl	öglöttöglőöglés
+dögész/VËŻj×LÓnňéčłÄäTtYc¸źl
 dögvész/VËŻj×LÓnňéyČŔŕTtYcź
 döglött/X)ögöl
 döglő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X)ögölÓ_PRESPART_adj
@@ -43456,7 +43564,7 @@ dísztető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 díszszemle/ŐBVRËŻjĐÓéyČŔŕYcź
 díszruha/ŐAUQĘŽiĎŇáyÇżßYcť
 díszrepülés/VËŻj×LÓnňéyČŔŕTtYcź
-díszműáru/ŐAUQĘŽiĎŇáyÇżßYcť
+díszműáru/ŐAUQĘŽiĎŇáyÇżßYcťísz|mű||áru
 díszmenet/VËŻj×LÓnňéyČŔŕTtYcź
 díszmagyar/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 díszlépés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -43573,8 +43681,8 @@ dédnagyszüle/ŐBVRËŻjĐÓéyČŔŕYcź
 dédnagypapa/ŐAUQĘŽiĎŇáyÇżßYcť
 dédnagymama/ŐAUQĘŽiĎŇáyÇżßYcť
 dédnagyaty/uQ)édnagyatya
-dédnagyapa/ŐAUĘŽiĎŇáyÇżßYcť
-dédnagyap/uQ)édnagynagyapa
+dédnagyapa/ŐAUĘŽiĎŇáyÇżßYcť	édnagyap
+dédnagyap/uQ)édnagyapa
 dédnagyanya/ŐAUĘŽiĎŇáyÇżßYcť	édnagyany
 dédnagyany/uQ)édnagyanya
 dédmama/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -43681,7 +43789,7 @@ durvul
 durvareszelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 durvakerámia/ŐAUQĘŽiĎŇáyÇżßYcť
 durvahengersor/UĘŽiÖKŇmôáyÇżßQYcť
-durvahengermű/WŢŘÔyjYcČ	űvek
+durvahengermű/WŢŘÔyjYcČ	űvekű
 durvahengerlés/VËŻj×LÓnňéyČŔŕTtYcź
 durung/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 durumtészta/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -43730,6 +43838,7 @@ dughagyma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 dugattyúköpeny/VËŻj×LÓnňéyČŔŕTtYcź
 dugattyú/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 dugasz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+dugalj/UmôŇyiYcÇ
 duett/VËŻj×LÓnňéčłÄäRYc¸źl
 dudál
 dudva/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -43751,7 +43860,7 @@ du.
 drótüveg/VËŻj×LÓnňéyČŔŕRTtYcź
 drótszövet/VËŻj×LÓnňéyČŔŕRTtYcź
 drótostót/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-drótkötélpálya/ŐAUQĘŽiĎŇáyÇżßYcť
+drótkötélpálya/ŐAUQĘŽiĎŇáyÇżßYcťót|kötél||pálya
 drótkötél/VÓnňyjYcČ	ótkötelek
 drótkefe/ŐBVRËŻjĐÓéyČŔŕYcź
 drótkapocs/UmôyiYcŽ	ótkapcsok
@@ -43770,13 +43879,13 @@ dráma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 drágul
 drágit/w
 drágalátos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-drágakőutánzat/UĘŽiÖKŇmôáyÇżßSsYcť
-drágakőfoglalat/UĘŽiÖKŇmôáyÇżßSsYcť
+drágakőutánzat/UĘŽiÖKŇmôáyÇżßSsYcťága|kő||utánzat
+drágakőfoglalat/UĘŽiÖKŇmôáyÇżßSsYcťága|kő||foglalat
 drágakő/WŢŘÔyjYcČ	ágakövek
 drágagyöngy/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 drusza/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 drukkol
-drukker/VËŻj×LÓnňéčłÄäRYc¸źl
+drukker/VËŻj×LÓnňéčłÄäRTtYc¸źl
 drukk/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 druida/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 drosophila/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -43852,7 +43961,7 @@ dombság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 domborzat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 domborulat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 domborul
-dombortérkép/VËŻj×LÓnňéyČŔŕTtYcź
+dombortérkép/VËŻj×LÓnňéyČŔŕTtYcźér|kép
 domborodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 dombornyomás/UĘŽiÖKŇmôáyÇżßSsYcť
 dombormű/WŢŘÔyjYcČR	űvek
@@ -44076,7 +44185,7 @@ diszkrimináció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 diszkriminativitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 diszkretizáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 diszkrepancia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-diszkosz/UĘŽiÖKŇmôáyÇżßSsYcť
+diszkosz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 diszkontüzlet/VËŻj×LÓnňéčłÄäTtYc¸źl
 diszkontinuitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 diszkont/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -44155,7 +44264,7 @@ dinár/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 dinoszaurusz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 dinnye/ŐBVRËŻjĐÓéčłÄäYc¸ź
 dinitrát/UĘŽiÖKŇmôáyÇżßQYcť
-dinitrogén-oxid/UĘŽiÖKŇmôáyÇżßQcť
+dinitrogén-oxid/UĘŽiÖKŇmôáyÇżßQcťén-oxid
 dinitro
 dingó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 diner-vé/)	ph:dinévé
@@ -44187,7 +44296,7 @@ diktum-faktum
 diktatúra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 diktandó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 diktafon/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-dikrómsav/UmôŇyiYcÇ	ómsavak
+dikrómsav/UmôŇyiYcÇ	ómsavakóm||sav
 dikromát/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 dikroizmus/UĘŽiÖKŇmôáç˛ĂăSsvcˇťk
 diklór/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
@@ -44258,7 +44367,7 @@ diasztolé/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 diaszpóra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 diaszkóp/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 diaré/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-diapozitív/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRYcťź
+diapozitív/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
 diaporáma/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 diamino-
 dialógus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -44386,7 +44495,7 @@ derűlátás/UĘŽiÖKŇmôáyÇżßSsYcť
 derű/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 derékvonal/UmôŇyiYcÇ	ékvonalak
 derékvitorla/ŐAUQĘŽiĎŇáyÇżßYcť
-derékszögvonalzó/ŐAUQĘŽiĎŇáyÇżßYcť
+derékszögvonalzó/ŐAUQĘŽiĎŇáyÇżßYcťék|szög||vonalzó
 derékszög/VNËŻj×LÝňÔéyČŔŕTtYcź
 derékszíj/UŇmôyiYcÇ	ékszíjak
 derékfogás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -44523,6 +44632,7 @@ dehogyisnem
 dehogyis
 dehidrobenzol/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 dehidratáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+degusztáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 degu/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 degradáció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 degeszig
@@ -44621,7 +44731,7 @@ daltonizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 dalszöveg/VËŻj×LÓnňéyČŔŕTtYcź
 dalosverseny/VËŻj×LÓnňéyČŔŕTtYcź
 dalostalálkozó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-dalosszövetség/VËŻj×LÓnňéyČŔŕTtYcźö-vet-ség
+dalosszövetség/VËŻj×LÓnňéyČŔŕTtYcźö-vet-ségövetség
 daloskör/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 daloskönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
 daloscsapat/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -44733,7 +44843,7 @@ címszerep/VËŻj×LÓnňéyČŔŕTtYcź
 címrajz/UĘŽiÖKŇmôáyÇżßSsYcť
 címoldal/UmôŇyiYcÇ	ímoldalak
 címlet/VËŻj×LÓnňéčłÄäTtYc¸źl
-címlapkép/VËŻj×LÓnňéyČŔŕTtYcź
+címlapkép/VËŻj×LÓnňéyČŔŕTtYcźím|lap||kép
 címlap/UĘŽiÖKŇmôáyÇżßQYcť
 címke/ŐBVRËŻjĐÓéčłÄäYc¸ź
 címjegyzék/VËŻj×LÓnňéyČŔŕTtYcź
@@ -44963,7 +45073,7 @@ csőszház/UmôŇyiYcÇ	őszházak
 csősz/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝
 csőstül
 csőrkáva/ŐAUQĘŽiĎŇáyÇżßYcť
-csőrendszer/VËŻj×LÓnňéyČŔŕTtYcź
+csőrendszer/VËŻj×LÓnňéyČŔŕTtYcźő||rend|szer
 csőr/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝
 csőnaci/ŐAUQĘŽiĎŇáyÇżßYcť
 csőkötés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -45215,7 +45325,7 @@ csontnyúlvány/UĘŽiÖKŇmôáyÇżßSsYcť
 csontliszt/VËŻj×LÓnňéyČŔŕRYcź
 csontkollekció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 csonthéj/VÓnňyjYcČ	éjak
-csonthártyagyulladás/UĘŽiÖKŇmôáyÇżßSsYcť
+csonthártyagyulladás/UĘŽiÖKŇmôáyÇżßSsYcťártya||gyulladás
 csonthártya/ŐAUQĘŽiĎŇáyÇżßYcť
 csontdarab/UĘŽiÖKŇmôáyÇżßQYcť
 csont/UĘŽiÖKŇmôáç˛ĂăQYcˇť
@@ -45239,7 +45349,7 @@ csomagmegőrző/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 csomagkihordó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 csomag/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 csokréta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-csokornyakkendő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+csokornyakkendő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ő
 csokor/UmôçiYcŽk
 csokoládéöntet/VËŻj×LÓnňéyČŔŕTtYcź
 csokoládéflip/VËŻj×LÓnňéyČŔŕRYcź
@@ -45278,7 +45388,7 @@ csirátlan/w
 csirág/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 csirkefar-hát/wYUmôŇçic˛k
 csirkecomb/UĘŽiÖKŇmôáyÇżßQYcť
-csirkebecsinált/UĘŽi$sŇmôáyÇżßQxcť
+csirkebecsinált/UĘŽi$sŇmôáyÇżßQxcťált
 csirke_far&nbhp;hát/UmôŇçiYc˛k	átak	ph:csirkefarhát
 csirke/ŐBVRËŻjĐÓéčłÄäYc¸ź
 csirizestál/UmôŇyiYcÇ	álak
@@ -45450,6 +45560,15 @@ cserzendő/CÔŐŢDHWRMX)Ó_FUTPART_adj
 csertölgy/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 cserszömörce/ŐBVRËŻjĐÓéčłÄäYc¸ź
 csersav/UmôŇyiYcÇQ
+cserokiüldözés/VËŻj×LÓnňéyČŔŕTtYcź
+cserokitanítás/UĘŽiÖKŇmôáyÇżßSsYcť
+cserokinyelv-/vc
+cserokiimádat/UĘŽiÖKŇmôáyÇżßSsYcť
+cserokigyűlölet/VËŻj×LÓnňéyČŔŕTtYcź
+cserokiellenesség/VËŻj×LÓnňéyČŔŕTtYcź
+cserokicentrikusság/UĘŽiÖKŇmôáyÇżßSsYcť
+cserokibarátság/UĘŽiÖKŇmôáyÇżßSsYcť
+cseroki/ŐBVRËŻjĐÓéčłÄäc¸ź
 csernozjom/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 csermelyaszat/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 csermely/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -45492,8 +45611,8 @@ cserbenhagyás/UĘŽiÖKŇmôáyÇżßSsYcť
 cser/VËŻj×LÓnňéčłÄäRYc¸ź
 csepű/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 csepplen/VËŻj×LÓnňéyČŔŕRYcź
-cseppkőoszlop/UĘŽiÖKŇmôáyÇżßQYcť
-cseppkőbarlang/UĘŽiÖKŇmôáyÇżßQYcť
+cseppkőoszlop/UĘŽiÖKŇmôáyÇżßQYcťő||oszlop
+cseppkőbarlang/UĘŽiÖKŇmôáyÇżßQYcťő||barlang
 cseppkő/WŢŘÔyjYcČ	övek
 csepp/VËŻj×LÓnňéčłÄäRYc¸ź
 csepleszmeggy/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -45521,6 +45640,7 @@ csendit/w
 csendesül
 csendestárs/UmôŇyiYcÇ	ársak
 csendesit/w
+csenderes/VËŻj×LÓnňéčłÄäTtYc¸źl
 csend/VËŻj×LÓnňéčłÄäRYc¸ź
 csempészáru/ŐAUQĘŽiĎŇáyÇżßYcť
 csempészhajó/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -45664,7 +45784,7 @@ csatáz
 csatársor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 csatározik
 csatárjátékos/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-csatár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+csatár/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 csattanó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 csatt
 csatornatisztító/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -45952,8 +46072,8 @@ cipőpaszta/ŐAUQĘŽiĎŇáyÇżßYcť
 cipőkrém/VËŻj×LÓnňéyČŔŕRTtYcź
 cipőhúzó/ŐAUQĘŽiĎŇáyÇżßYcť
 cipőfűző/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-cipőfénymáz/UmôŇyiYcÇ	őfénymázak
-cipőegységár/UmôŇyiYcÇ	őegységárak
+cipőfénymáz/UmôŇyiYcÇ	őfénymázakő||fény|máz
+cipőegységár/UmôŇyiYcÇ	őegységárakő||egység|ár
 cipőcsat/UĘŽiÖKŇmôáyÇżßQYcť
 cipő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 cipó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -46033,7 +46153,7 @@ cigányügy/VNËŻj×LÝňÔéyČŔŕTtYcź
 cigányútra
 cigányélet/VËŻj×LÓnňéyČŔŕRYcź
 cigányzenész/VËŻj×LÓnňéyČŔŕTtYcź
-cigányzenekar/UĘŽiÖKŇmôáyÇżßQYcť
+cigányzenekar/UĘŽiÖKŇmôáyÇżßQYcťány||zene|kar
 cigányzene/ŐBVRËŻjĐÓéyČŔŕYcź
 cigányzab/UĘŽiÖKŇmôáyÇżßQYcť
 cigányvajda/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -46227,7 +46347,7 @@ caries/VËŻj×LÓnőéčłÄäTtvc¸źl
 capriccio/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 capoeira/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ph:kapoéra*
 cannes-i/ŃĎŐAFUKSs)	ph:kanni	ph:kánni
-cankópartfutó/ŐAUQĘŽiĎŇáyÇżßYcť
+cankópartfutó/ŐAUQĘŽiĎŇáyÇżßYcťó||part|futó
 cankógoda/ŐAUQĘŽiĎŇáyÇżßYcť
 cankó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 canga/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -46247,7 +46367,7 @@ cal-val/)
 cal-/AUQĎŃŐi&)
 cal	á
 cakpakk/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-cakompakk/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+cakompakk/UĘŽiÖKŇmôáç˛ĂăQYcˇťk	ph:cakkumpakk
 caklipakli/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 cakk/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 cajgnadrág/UĘŽiÖKŇmôáyÇżßQYcť
@@ -46299,6 +46419,7 @@ bükkmakk/UĘŽiÖKŇmôáyÇżßQYcť
 bükkfa/ŐAUQĘŽiĎŇáyÇżßYcť
 bükk/WĚŻjŘMÝňÔíčłĹĺRYc¸˝
 büfé/ŐBVRËŻjĐÓéčłÄäYc¸ź
+büfi/ŐBVRËŻjĐÓéčłÄäYc¸ź
 büdöskő/WŢŘÔyjYcČ	üdöskövek
 büdöske/ŐBVRËŻjĐÓéčłÄäYc¸ź
 büdösbarlang/UĘŽiÖKŇmôáyÇżßQYcť
@@ -46368,7 +46489,7 @@ bútorzat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 bútorzandó/AŇŐĎDFUQKX)útorozÓ_FUTPART_adj
 bútorvédő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 bútorszállító/ŐAUQĘŽiĎŇáyÇżßYcť
-bútorraktár/UmôŇyiYcÇ	útorraktárak
+bútorraktár/UmôŇyiYcÇ	útorraktárakútor||rak|tár
 bútorhuzat/UĘŽiÖKŇmôáyÇżßQSsYcť
 bútorfény/VËŻj×LÓnňéyČŔŕTtYcź
 bútordarab/UĘŽiÖKŇmôáyÇżßQYcť
@@ -46400,6 +46521,7 @@ börtönőr/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 börtönudvar/UĘŽiÖKŇmôáyÇżßQSsYcť
 börtön/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
 börberiszövet/VËŻj×LÓnňéyČŔŕRTtYcź
+böngésznivaló/ŐAUQĘŽiĎŇáyÇżßYcť
 böngészde/ŐBVRËŻjĐÓéčłÄäYc¸ź
 bömbölő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 bölömbika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -46594,16 +46716,24 @@ bérösszeg/VËŻj×LÓnňéyČŔŕTtYcź
 bérmálkozik
 bérmentve
 bérmegállapító/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-bérmaszülő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+bérmaszülőség/VËŻj×LÓnňéyČŔŕTtYcź
+bérmaszülő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝	érmaszüleitekérmaszüleinkérmaszüleimérmaszüleikérmaszüleidérmaszülei
+bérmaszüleitek/VnÓ×)érmaszülő
+bérmaszüleink/VnÓ×)érmaszülő
+bérmaszüleim/VnÓ×)érmaszülő
+bérmaszüleik/VnÓ×)érmaszülő
+bérmaszüleid/VnÓ×)érmaszülő
+bérmaszülei/VĐÓ×)érmaszülő
+bérmanév/VÓnňyjYcČ	érmanevek
 bérmakeresztaty/uQ)érmakeresztatya
 bérmakeresztapa/	érmakeresztap
-bérmakeresztap/uQ)érmakeresztapa
+bérmakeresztap/uQ)érmakeresztapa	érma||kereszt|apa
 bérmakeresztanya/	érmakeresztany
 bérmakeresztany/uQ)érmakeresztanya
 bérmaaty/uQ)érmaatya
-bérmaapa/	érmaap
+bérmaapa/ŐAUĘŽiĎŇáyÇżßYcť	érmaap
 bérmaap/uQ)érmaapa
-bérmaanya/	érmaany
+bérmaanya/ŐAUĘŽiĎŇáyÇżßYcť	érmaany
 bérmaany/uQ)érmaanya
 bérlő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X)érelÓ_PRESPART_adj
 bérlő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝X
@@ -46658,7 +46788,7 @@ bélyegautomata/ŐAUQĘŽiĎŇáyÇżßYcť
 bélyegalbum/UĘŽiÖKŇmôáyÇżßQSsYcť
 bélyeg/VËŻj×LÓnňéčłÄäRTtYc¸źl
 bélsár/UmôŇyiYcÇ	élsarak
-bélszínszelet/VËŻj×LÓnňéyČŔŕRTtYcź
+bélszínszelet/VËŻj×LÓnňéyČŔŕRTtYcźél|szín||szelet
 bélszín/VËŻj×LÓnňéyČŔŕTtYcź
 bélmozgás/UĘŽiÖKŇmôáyÇżßSsYcť
 béllet/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -46828,7 +46958,7 @@ bálozik
 bálnazsír/UĘŽiÖKŇmôáyÇżßQYcť
 bálnavadász/UĘŽiÖKŇmôáyÇżßSsYcť
 bálnaolaj/UmôŇyiYcÇ	álnaolajak
-bálnahátbucka/ŐAUQĘŽiĎŇáyÇżßYcť
+bálnahátbucka/ŐAUQĘŽiĎŇáyÇżßYcťálna|hát||bucka
 bálna/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 bála/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 bál/UĘŽiÖKŇmôáç˛ĂăQYcˇť
@@ -46854,7 +46984,7 @@ bádog/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 bácsika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 bácsi/ŐAUQĘŽiĎŇáç˛Ăăcˇť
 bábu/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-bábszínház/UmôŇyiYcÇ	ábszínházak
+bábszínház/UmôŇyiYcÇ	ábszínházakáb||szín|ház
 bábozás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 bábosmesterség/VËŻj×LÓnňéyČŔŕTtYcź
 bábaság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -46906,7 +47036,7 @@ butanon/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 butanol/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 butanal/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 butadién/VËŻj×LÓnňéčłÄäRvc¸źl
-busóálarc/UĘŽiÖKŇmôáyÇżßSsYcť
+busóálarc/UĘŽiÖKŇmôáyÇżßSsYcťó||ál|arc
 busójárás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 busó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 busás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -47025,7 +47155,7 @@ budoár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 budi/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 buddhizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 budavirág/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-budaiföldbánya/ŐAUQĘŽiĎŇáyÇżßYcť
+budaiföldbánya/ŐAUQĘŽiĎŇáyÇżßYcťöld||bánya
 budaiföld/WĚŻjŘMÝňÔíyČÁ˙RYc˝
 bucó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 bucka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -47055,7 +47185,7 @@ brávó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 brácsázik
 brácsa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 bruttósítás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-bruttóregisztertonna/ŐAUQĘŽiĎŇáyÇżßcť
+bruttóregisztertonna/ŐAUQĘŽiĎŇáyÇżßcťó||regiszter|tonna
 brutalitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 bruhaha
 brucellózis/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -47206,7 +47336,7 @@ borsóhüvely/VËŻj×LÓnňéyČŔŕTtYcź
 borsóféreg/VnňyjYcŻ	óférgek
 borsódzik
 borsó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-borszeszégő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+borszeszégő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝égő
 borszesz/VËŻj×LÓnňéyČŔŕTtYcź
 borsszóró/ŐAUQĘŽiĎŇáyÇżßYcťó-ró
 borsszem/VËŻj×LÓnňéyČŔŕTtYcź
@@ -47250,7 +47380,7 @@ borjúnyúzó
 borjúmirigy/VËŻj×LÓnňéyČŔŕTtYcź
 borjúhús/UĘŽiÖKŇmôáyÇżßSsYcť
 borjúbőr/WĚŻjŘMÝňÔíyČÁ˙RTtYc˝
-borjúbecsinált/UĘŽi$sŇmôáyÇżßQxcť
+borjúbecsinált/UĘŽi$sŇmôáyÇżßQxcťú||be|csinált
 borjú/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 borjazik
 borjak/Inx)ú
@@ -47378,6 +47508,7 @@ bokszeralsó/ŐAUQĘŽiĎŇáyÇżßYcť
 bokszer/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRTtYcˇť¸źkl
 boksz/UĘŽiÖKŇmôáç˛ĂăSsYcˇť
 boksakemence/ŐBVRËŻjĐÓéyČŔŕYcź
+boksa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 bokréta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 bokrosgomba/ŐAUQĘŽiĎŇáyÇżßYcť
 bokorerdő/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
@@ -47652,7 +47783,7 @@ birka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 bipolarizmus/UĘŽiÖKŇmôáyÇżßSsYcť
 bipolaritás/UĘŽiÖKŇmôáyÇżßSsYcť
 biplán/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-bioüzemanyag/UĘŽiÖKŇmôáyÇżßQSsYcť
+bioüzemanyag/UĘŽiÖKŇmôáyÇżßQSsYcťüzem|anyag
 bioélelmiszer/VËŻj×LÓnňéyČŔŕRYcźélelmi|szer
 bioáram/UĘŽiÖKŇmôáyÇżßSsYcť
 biozöldség/VËŻj×LÓnňéyČŔŕTtYcź
@@ -47695,7 +47826,7 @@ biogáz/UĘŽiÖKŇmôáyÇżßSsYcť
 biogyümölcs/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 biográfus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 biográfia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-biogeográfia/ŐAUQĘŽiĎŇáyÇżßYcť
+biogeográfia/ŐAUQĘŽiĎŇáyÇżßYcťáfia
 biogenezis/VËŻj×LÓnňéyČŔŕTtYcź
 biogenetika/ŐAUQĘŽiĎŇáyÇżßYcť
 biogazdálkodás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -47915,7 +48046,7 @@ beszéltnyelviség/VËŻj×LÓnňéyČŔŕTtYcź
 beszélnivaló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 beszélgetés/VËŻj×LÓnňéčłÄäTtYc¸źl
 beszédmód/UĘŽiÖKŇmôáyÇżßQYcť
-beszédmodor/UĘŽiÖKŇmôáyÇżßQYcť
+beszédmodor/UĘŽiÖKŇmôáyÇżßSsYcť
 beszédképtelenség/VËŻj×LÓnňéyČŔŕTtYcź
 beszédhiba/ŐAUQĘŽiĎŇáyÇżßYcť
 beszéd/VËŻj×LÓnňéčłÄäRTtYc¸źl
@@ -48105,7 +48236,7 @@ belüli/BĐÓŐVRD	üliek
 belül/D	ülrőlülrőlülreülre
 belül/D	ülrőlülrőlülreülre
 belügyér/VËŻj×LÓnňéyČŔŕTtYcź
-belügyminisztérium/UĘŽiÖKŇmôáyÇżßSsYcť
+belügyminisztérium/UĘŽiÖKŇmôáyÇżßSsYcťügy||minisztérium
 belügyis/VËŻj×LÓnňéyČŔŕTtYcź
 belügy/VNËŻj×LÝňÔéyČŔŕTtYcź
 belőlünk/)őle
@@ -48121,7 +48252,7 @@ belépés/VËŻj×LÓnňéčłÄäTtYc¸źl
 belénk/)é
 beléndek/VËŻj×LÓnňéčłÄäTtYc¸źl
 belém/)é
-belélegzés/VËŻj×LÓnňéyČŔŕTtYcź
+belélegzés/VËŻj×LÓnňéčłÄäTtYc¸źl
 belélegez/)élegzik	égzéségzitekégzőégzettégzendő
 beléjük/)é
 beléje/)é
@@ -48142,16 +48273,16 @@ belvíz/VÓnňyjYcČ
 belváros/UĘŽiÖKŇmôáyÇżßSsYcť
 belviszály/UĘŽiÖKŇmôáyÇżßSsYcť
 belvilág/UĘŽiÖKŇmôáyÇżßSsYcť
-belvillongás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+belvillongás/UĘŽiÖKŇmôáyÇżßSsYcť
 belvederei-i/ŃĐŐBGVLTt)
 belvedere/ŐBVRËŻjĐÓéčłÄävc¸ź
 beltér/VÓnňyjYcČ
-belterület/VËŻj×LÓnňéčłÄäTtYc¸źl
+belterület/VËŻj×LÓnňéyČŔŕTtYcź
 beltenyésztés/VËŻj×LÓnňéyČŔŕTtYcź
 beltenyészet/VËŻj×LÓnňéyČŔŕTtYcź
 beltenger/VËŻj×LÓnňéyČŔŕRYcź
 beltartalom/UmôyiYcŽ
-beltag/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+beltag/UĘŽiÖKŇmôáyÇżßQYcť
 belsőépítészet/VËŻj×LÓnňéyČŔŕTtYcź
 belsőépítész/VËŻj×LÓnňéyČŔŕTtYcź
 belsőség/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -48165,7 +48296,7 @@ belpolitika/ŐAUQĘŽiĎŇáyÇżßYcť
 belpiac/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 belorusz/UĘŽiÖKŇmôáç˛ĂăSscˇťk
 beloldal/UmôŇyiYcÇ
-belmagasság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+belmagasság/UĘŽiÖKŇmôáyÇżßSsYcť
 belletrisztika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 belklinika/ŐAUQĘŽiĎŇáyÇżßYcť
 belkereskedelem/VnňyjYcŻ
@@ -48175,7 +48306,7 @@ beljebbiek/DVÓ×n)
 beljebbi/DBĐÓŐVR
 beljebb/D	ől
 belhártya/ŐAUQĘŽiĎŇáyÇżßYcť
-belháború/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+belháború/ŐAUQĘŽiĎŇáyÇżßYcť
 belharc/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 belgyógyászat/UĘŽiÖKŇmôáyÇżßSsYcť
 belgyógyász/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -48201,6 +48332,15 @@ belefoglalás/UĘŽiÖKŇmôáyÇżßSsYcť
 beleegyezés/VËŻj×LÓnňéyČŔŕTtYcź
 belbiztonság/UĘŽiÖKŇmôáyÇżßSsYcť
 belbecs/VËŻj×LÓnňéyČŔŕTtYcź
+belaruszüldözés/VËŻj×LÓnňéyČŔŕTtYcź
+belarusztanítás/UĘŽiÖKŇmôáyÇżßSsYcť
+belarusznyelv-/vc
+belaruszimádat/UĘŽiÖKŇmôáyÇżßSsYcť
+belaruszgyűlölet/VËŻj×LÓnňéyČŔŕTtYcź
+belaruszellenesség/VËŻj×LÓnňéyČŔŕTtYcź
+belaruszcentrikusság/UĘŽiÖKŇmôáyÇżßSsYcť
+belaruszbarátság/UĘŽiÖKŇmôáyÇżßSsYcť
+belarusz/UĘŽiÖKŇmôáç˛ĂăSscˇťk
 belakkozás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 bel-
 bekövetkeztük/VÔ×Ý)övetkezte
@@ -48288,7 +48428,7 @@ beeresztés/VËŻj×LÓnňéčłÄäTtYc¸źl
 beerdősítés/VËŻj×LÓnňéčłÄäTtYc¸źl
 beengedés/VËŻj×LÓnňéčłÄäTtYc¸źl
 bedörzsölés/VËŻj×LÓnňéčłÄäTtYc¸źl
-bedórendszer/VËŻj×LÓnňéyČŔŕTtYcź
+bedórendszer/VËŻj×LÓnňéyČŔŕTtYcźó||rend|szer
 bedurrantás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 beduin/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 bedolgozás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -48379,6 +48519,7 @@ bastille-i/ŃĎŐAFUKSs)	ph:basztíji
 basszusszólam/wYUĘŽiÖKŇmôáç˛ĂăSscˇťk
 basszuskürt/WĚŻjŘMÝňÔíyČÁ˙RYc˝
 basszushang/wYUĘŽiÖKŇmôáç˛ĂăSscˇťk
+basszusgitár/UĘŽiÖKŇmôáyÇżßQYcť
 basszus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 basszista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 basszbariton/UĘŽiÖKŇmôáyÇżßQYcť
@@ -48388,7 +48529,7 @@ basa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 barázdásmoszat/UĘŽiÖKŇmôáyÇżßQYcť
 barázdabillegető/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 barázda/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-barátszegfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	átszegfüvek
+barátszegfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	átszegfüvekát||szeg|fű
 barátnő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 barátkozik
 barátkeselyű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -48414,8 +48555,8 @@ barom/UmôçiYcŽk
 barokk/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 barnul
 barnaövezet/VËŻj×LÓnňéyČŔŕRYcź
-barnaólomérc/VËŻj×LÓnňéyČŔŕTtYcź
-barnavasérc/VËŻj×LÓnňéyČŔŕTtYcź
+barnaólomérc/VËŻj×LÓnňéyČŔŕTtYcźólom|érc
+barnavasérc/VËŻj×LÓnňéyČŔŕTtYcźérc
 barnatörés/VËŻj×LÓnňéyČŔŕTtYcź
 barnaszén/VÓnňyjYcČ
 barnapát/UĘŽiÖKŇmôáyÇżßQvcť
@@ -48439,15 +48580,15 @@ barkóca/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 barkó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 barkán/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 barkácsüzlet/VËŻj×LÓnňéyČŔŕTtYcź
-barkácsáruház/UmôŇyiYcÇ	ácsáruházak
+barkácsáruház/UmôŇyiYcÇ	ácsáruházakács||áru|ház
 barkácsáru/ŐAUQĘŽiĎŇáyÇżßYcť
 barkácsszoba/ŐAUQĘŽiĎŇáyÇżßYcťács|szo-ba
 barkácsszerszám/UĘŽiÖKŇmôáyÇżßQSsYcťács||szer|szám
 barkácsszaküzlet/VËŻj×LÓnňéyČŔŕTtYcźács||szak|üz-let
-barkácsszakkör/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ács|szak-kör
+barkácsszakkör/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ács|szak-körács||szak|kör
 barkácssarok/UmôyiYcŽ	ácssarkak
 barkácspiac/UĘŽiÖKŇmôáyÇżßSsYcť
-barkácsműhely/VËŻj×LÓnňéyČŔŕTtYcź
+barkácsműhely/VËŻj×LÓnňéyČŔŕTtYcźács||mű|hely
 barkácsmunka/ŐAUQĘŽiĎŇáyÇżßYcť
 barkácsmester/VËŻj×LÓnňéyČŔŕTtYcź
 barkácskészlet/VËŻj×LÓnňéyČŔŕTtYcź
@@ -48505,15 +48646,15 @@ banlonanyag/UĘŽiÖKŇmôáyÇżßSsYcť
 banlon/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 bankügylet/VËŻj×LÓnňéyČŔŕTtYcź
 bankó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-bankár/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+bankár/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 bankutalvány/UĘŽiÖKŇmôáyÇżßSsYcť
 bankokrácia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 banklikviditás/UĘŽiÖKŇmôáyÇżßSsYcť
 bankkölcsön/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
 bankkonzorcium/UĘŽiÖKŇmôáyÇżßSsYcť
-bankjegyköteg/VËŻj×LÓnňéyČŔŕTtYcź
+bankjegyköteg/VËŻj×LÓnňéyČŔŕTtYcźöteg
 bankjegyforgalom/UmôyiYcŽ
-bankjegycsomó/ŐAUQĘŽiĎŇáyÇżßYcť
+bankjegycsomó/ŐAUQĘŽiĎŇáyÇżßYcťó
 bankjegy/VËŻj×LÓnňéyČŔŕTtYcź
 bankinkasszó/ŐAUQĘŽiĎŇáyÇżßYcť
 bankház/UmôŇyiYcÇ	ázak
@@ -48579,6 +48720,7 @@ balhír/VËŻj×LÓnňéyČŔŕTtYcź
 balhés/VËŻj×LÓnňéčłÄäTtYc¸źl
 balhé/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 balhátvéd/VËŻj×LÓnňéyČŔŕRYcź
+balhorog/UmôyiYcŽQ
 balhit/VËŻj×LÓnňéčłÄäTtYc¸źl
 balhiedelem/VnňyjYcŻ
 balgatag/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -48636,13 +48778,14 @@ bak/UĘŽiÖKŇmôáç˛ĂăQYcˇť
 bajvívó/ŐAUQĘŽiĎŇáyÇżßYcť
 bajvívás/UĘŽiÖKŇmôáyÇżßSsYcť
 bajuszpázsit/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-bajuszoskásafű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ásafüvek
+bajuszoskásafű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	ásafüvekása|fű
 bajuszfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	üvek
 bajusz/UmôçiYcŽkĘÖKŇá˛ĂăSsˇť
 bajtársiasság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 bajor/UĘŽiÖKŇmôáç˛ĂăQcˇťk
 bajonett/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRYcˇť¸źkl
 bajnokság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+bajnoki/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 bajnok/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 bajbajutott/UĘŽi$sŇmôáyÇżßQYcť
 bajazzo/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ph:bajaddzó
@@ -48679,12 +48822,12 @@ babuci/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 babramunka/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 babonaság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 babona/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-babgulyáskonzerv/VËŻj×LÓnňéyČŔŕRYcź
+babgulyáskonzerv/VËŻj×LÓnňéyČŔŕRYcźás||konzerv
 babakelengye/ŐBVRËŻjĐÓéyČŔŕYcź
 babacipő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 baba/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 bab/UĘŽiÖKŇmôáç˛ĂăQYcˇť
-b.-pengő/ŐCWRĚŻjŢÔíyČÁ˙c˝
+b.-pengő/ŐCWRĚŻjŢÔíyČÁ˙c˝ő
 b-vé/)
 b-vel/)
 b-/BVRĐŃŐj&)
@@ -48802,7 +48945,7 @@ autóhűtő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 autógumi/ŐAUQĘŽiĎŇáyÇżßYcť
 autóemelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 autóduda/ŐAUQĘŽiĎŇáyÇżßYcť
-autóbuszmegálló/ŐAUQĘŽiĎŇáyÇżßcťw
+autóbuszmegálló/ŐAUQĘŽiĎŇáyÇżßcťwó|busz||megálló
 autóbusz/UĘŽiÖKŇmôáyÇżßSsYcť
 autóbenzin/VËŻj×LÓnňéyČŔŕRYcź
 autó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -48841,7 +48984,7 @@ autogejzír/VËŻj×LÓnňéčłÄäRYc¸źl
 autodróm/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 autodafé/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 autochton/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-autobiográfia/ŐAUQĘŽiĎŇáyÇżßYcť
+autobiográfia/ŐAUQĘŽiĎŇáyÇżßYcťáfia
 autoanamnézis/VËŻj×LÓnňéyČŔŕTtYcź
 autizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 autista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -48905,6 +49048,8 @@ attribútum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 attraktor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 attraktivitás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 attrakció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+attoszekundum/UĘŽiÖKŇmôáyÇżßSsYcť
+attofizika/ŐAUQĘŽiĎŇáyÇżßYcť
 attitűd/WĚŻjŘMÝňÔíčłĹĺRYc¸˝l
 attika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 attenborough-s/ŇŮmAFUKQ)	ph:etenborós
@@ -48940,10 +49085,9 @@ ateizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 ateista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 atavizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 atamán/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
-aszúszegfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	úszegfüvek
-aszúsodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-aszúbor/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-aszú/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
+aszúszegfű/ŐCWRĚŻjŢÔíyČÁ˙Yc˝Ř	úszegfüvekú||szeg|fű
+aszúbor/UĘŽiÖKŇmôáyÇżßSsYcť
+aszú/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	ph:assz	ph:assú
 aszálykárosult/UĘŽi$sŇmôáyÇżßQxcť
 aszály/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 aszténia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -48986,6 +49130,7 @@ asztag/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 aszpirin/UVĘŽËŻijÖ×KLŇÓnňmôáéçč˛ĂăłÄäQRYcˇť¸źkl
 aszpik/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 aszparágusz/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+aszpartám/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 aszparaginsav/UmôŇyiYcÇQ
 aszparagin/UĘŽiÖKŇmôáç˛ĂăQvcˇťk
 aszongya
@@ -49131,13 +49276,13 @@ arcrángás/UĘŽiÖKŇmôáyÇżßSsYcť
 arcrándulás/UĘŽiÖKŇmôáyÇżßSsYcť
 arcpirulva
 arcmás/UĘŽiÖKŇmôáyÇżßSsYcť
-arcképfestés/VËŻj×LÓnňéyČŔŕTtYcź
+arcképfestés/VËŻj×LÓnňéyČŔŕTtYcźép||festés
 arckép/VËŻj×LÓnňéyČŔŕTtYcź
 arckrém/VËŻj×LÓnňéyČŔŕRTtYcź
 arckikészítés/VËŻj×LÓnňéyČŔŕTtYcź
 arckifejezés/VËŻj×LÓnňéyČŔŕTtYcź
 arcjáték/UĘŽiÖKŇmôáyÇżßSsYcť
-arcidegzsába/ŐAUQĘŽiĎŇáyÇżßYcť
+arcidegzsába/ŐAUQĘŽiĎŇáyÇżßYcťába
 archívum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 architektúra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 architektus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -49149,6 +49294,7 @@ archeológus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 archeológia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 archea/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 archaizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
+archaikum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 arcfátyol/UmôyiYcŽ	átylak
 arcfintor/UĘŽiÖKŇmôáyÇżßQSsYcť
 arcfesték/VËŻj×LÓnňéyČŔŕTtYcź
@@ -49290,6 +49436,7 @@ aperitívum/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 aperitif/VËŻj×LÓnňéčłÄäRYc¸źl
 apelláta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 apellál
+apelláció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 apatit/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 apaság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 apartman/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
@@ -49308,7 +49455,7 @@ apache-os/ŇŮmAFUKQ)	ph:apacsos
 apa/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	áék
 ap/uQ)
 aorta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-anódáramkör/WĚŻjŘMÝňÔíyČÁ˙TtYc˝
+anódáramkör/WĚŻjŘMÝňÔíyČÁ˙TtYc˝ód||áram|kör
 anód/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 anémia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 anélkül
@@ -49341,7 +49488,7 @@ anyagvizsgáló/ŐAUQĘŽiĎŇáyÇżßYcť
 anyagvizsgálat/UĘŽiÖKŇmôáyÇżßSsYcť
 anyagtároló/ŐAUQĘŽiĎŇáyÇżßYcť
 anyagszolgáltatás/UĘŽiÖKŇmôáyÇżßSsYcť
-anyagraktár/UmôŇyiYcÇ	árak
+anyagraktár/UmôŇyiYcÇ	árakár
 anyaglerakó/ŐAUQĘŽiĎŇáyÇżßYcť
 anyagiasul
 anyagfelhasználás/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -49350,7 +49497,7 @@ anyagelosztás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 anyagcsere/ŐBVRËŻjĐÓéyČŔŕYcź
 anyagbeszerző/ŐCWRĚŻjŢÔíčłĹĺYc¸˝
 anyag/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
-anyaegyház/UmôŇyiYcÇ	ázak
+anyaegyház/UmôŇyiYcÇ	ázakáz
 anyacsavar/UĘŽiÖKŇmôáyÇżßQYcť
 anya/ŐAUQĘŽiĎŇáç˛ĂăYcˇť	áék
 any/uQ)
@@ -49488,7 +49635,7 @@ angoltudás/UĘŽiÖKŇmôáyÇżßSsYcť
 angoltapasz/UĘŽiÖKŇmôáyÇżßSsYcť
 angoltanítás/UĘŽiÖKŇmôáyÇżßSsYcť
 angoltanár/UĘŽiÖKŇmôáyÇżßQSsYcť
-angoltankönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
+angoltankönyv/VNËŻj×LÝňÔéyČŔŕTtYcźönyv
 angolság/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 angolszász/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 angolszalonna/ŐAUQĘŽiĎŇáyÇżßYcť
@@ -49499,7 +49646,7 @@ angolna/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 angolkürt/WĚŻjŘMÝňÔíyČÁ˙RYc˝
 angolkönyv/VNËŻj×LÝňÔéyČŔŕTtYcź
 angolkór/UĘŽiÖKŇmôáyÇżßQYcť
-angolklozet/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRYcťź
+angolklozet/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
 angolkisasszony/UĘŽiÖKŇmôáyÇżßSsYcť
 angolkert/VËŻj×LÓnňéyČŔŕRYcź
 angolkeringő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
@@ -49753,7 +49900,7 @@ aláékelés/VËŻj×LÓnňéyČŔŕTtYcź
 alázat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 alávetés/VËŻj×LÓnňéyČŔŕTtYcź
 alávetettség/VËŻj×LÓnňéčłÄäTtYc¸źl
-alátétlemez/VËŻj×LÓnňéyČŔŕTtYcź
+alátétlemez/VËŻj×LÓnňéyČŔŕTtYcźá|tét||lemez
 alátét/VËŻj×LÓnňéyČŔŕRTtYcź
 alátámasztás/UĘŽiÖKŇmôáyÇżßSsYcť
 alátok/)áá)
@@ -49903,7 +50050,7 @@ altér/VnňyjYcŻ
 altéma/ŐAUQĘŽiĎŇáyÇżßYcť
 altáró/ŐAUQĘŽiĎŇáyÇżßYcť
 altáj/UmôŇyiYcÇ	ájak
-altábornagy/UĘŽiÖKŇmôáyÇżßSsYcť
+altábornagy/UĘŽiÖKŇmôáyÇżßSsYcťábor|nagy
 altszólam/wYUĘŽiÖKŇmôáç˛ĂăSscˇťk
 altróz/UĘŽiÖKŇmôáç˛ĂăSsvcˇťk
 altruizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -49926,7 +50073,7 @@ altalaj/UĘŽiÖKŇmôáyÇżßSsYcť
 altajisztika/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 alt/UĘŽiÖKŇmôáç˛ĂăQvcˇť
 alsózik
-alsóvégtag/wYUĘŽiÖKŇmôáyÇżßSscť
+alsóvégtag/wYUĘŽiÖKŇmôáyÇżßSscťó||vég|tag
 alsóváros/UĘŽiÖKŇmôáyÇżßSsYcť
 alsótábla/ŐAUQĘŽiĎŇáyÇżßYcť
 alsótest/VËŻj×LÓnňéyČŔŕRYcź
@@ -49965,11 +50112,11 @@ alrés/VËŻj×LÓnňéyČŔŕTtYcź
 alrovat/UĘŽiÖKŇmôáyÇżßSsYcť
 alrendszer/VËŻj×LÓnňéyČŔŕTtYcź
 alrend/VËŻj×LÓnňéyČŔŕRYcź
-alprojekt/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRYcťź
+alprojekt/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
 alprogram/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 alpont/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 alpolgármesterúr/wYUmôŇçic˛k
-alpolgármester/VËŻj×LÓnňéyČŔŕTtYcź
+alpolgármester/VËŻj×LÓnňéyČŔŕTtYcźár|mester
 alpinizmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 alpinista/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 alperes/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -49983,7 +50130,7 @@ aloldal/UmôŇyiYcÇ
 alnézet/VËŻj×LÓnňéyČŔŕRYcź
 alnemzetség/VËŻj×LÓnňéyČŔŕTtYcź
 alnem/VËŻj×LÓnňéyČŔŕTtYcź
-almásszürke/ŐBVRËŻjĐÓéyČŔŕcźás|szür-ke
+almásszürke/ŐBVRËŻjĐÓéyČŔŕcźás|szür-keás|szürke
 almáskert/VËŻj×LÓnňéyČŔŕRYcź
 almárium/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 alminta/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -50018,7 +50165,7 @@ allegro/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 allegretto
 alközpont/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 alkörmös/WĚŻjŘMÝňÔíčłĹĺTtYc¸˝l
-alkönyvtár/UmôŇyiYcÇ	önyvtárak
+alkönyvtár/UmôŇyiYcÇ	önyvtárakönyv|tár
 alkóv/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
 alkímia/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 alkérdés/VËŻj×LÓnňéyČŔŕTtYcź
@@ -50041,7 +50188,7 @@ alkotmányoz
 alkotmány/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 alkormányzó/ŐAUQĘŽiĎŇáyÇżßYcť
 alkonzul/UĘŽiÖKŇmôáyÇżßQYcť
-alkonyulat/UĘŽiÖKŇmôáyÇżßSsYcť
+alkonyulat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 alkonyul
 alkonypír/UĘŽiÖKŇmôáyÇżßSsYcť
 alkonyattájt
@@ -50100,6 +50247,7 @@ alias
 alhálózat/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 alhas/ÖUmôŇyiYcÇ
 alhadnagy/UĘŽiÖKŇmôáyÇżßSsYcť
+algráf/UĘŽiÖKŇmôáyÇżßQYcť
 algoritmus/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 algimnázium/UĘŽiÖKŇmôáyÇżßSsYcť
 algebra/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
@@ -50427,7 +50575,7 @@ akceleráció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 akasztókapocs/UmôyiYcŽ	ókapcsok
 akasztóhorog/UmôyiYcŽQ	óhorgok
 akasztófáravaló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
-akasztófakötél/VÓnňyjYcČ	ófakötelek
+akasztófakötél/VÓnňyjYcČ	ófakötelekó|fa||kötél
 akasztófa/ŐAUQĘŽiĎŇáyÇżßYcť
 akasztó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 akasztás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
@@ -50464,14 +50612,14 @@ ajtónálló/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ajtónyílás/UĘŽiÖKŇmôáyÇżßSsYcť
 ajtókopogtató/ŐAUQĘŽiĎŇáyÇżßYcť
 ajtókilincs/VËŻj×LÓnňéyČŔŕTtYcź
-ajtófélfa/ŐAUQĘŽiĎŇáyÇżßYcť
+ajtófélfa/ŐAUQĘŽiĎŇáyÇżßYcťó||fél|fa
 ajtóbelső/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
 ajtó/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 ajtaj/uxSsˇ)ó
 ajkbiggyesztve
 ajjaj
 ajatollah/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
-ajakír/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČQRYcťź
+ajakír/UVĘŽËŻijÖ×KLŇÓnňmôáéyÇżßČŔŕQRYcťź
 ajakunk/UŇŮm)
 ajakuk/UŇŮm)
 ajakrúzs/UĘŽiÖKŇmôáyÇżßSsYcť
@@ -50539,10 +50687,11 @@ agyar/UmôŇçiYc˛k
 agyagtál/UmôŇyiYcÇQ	álak
 agyagosodás/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 agyagművesség/VËŻj×LÓnňéčłÄäTtYc¸źl
+agyaggát/UmôŇyiYcÇQ	átak
 agyaggalamb/UĘŽiÖKŇmôáyÇżßQYcť
 agyagedény/VËŻj×LÓnňéyČŔŕTtYcź
 agyagbánya/ŐAUQĘŽiĎŇáyÇżßYcť
-agyag/UĘŽiÖKŇmôáç˛ĂăQYcˇťk
+agyag/UĘŽiÖKŇmôáç˛ĂăQSsYcˇťk
 agy/UmôŇçiYc˛
 aguti/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 agrárértelmiség/VËŻj×LÓnňéčłÄäTtYc¸źl
@@ -50841,7 +50990,7 @@ ablakmélyedés/VËŻj×LÓnňéyČŔŕTtYcź
 ablakkeret/VËŻj×LÓnňéyČŔŕTtYcź
 ablakfülke/ŐBVRËŻjĐÓéyČŔŕYcź
 ablakemelő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
-ablakelsötétítő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝
+ablakelsötétítő/ŐCWRĚŻjŢÔíyČÁ˙Yc˝ötétítő
 ablak/UĘŽiÖKŇmôáç˛ĂăSsYcˇťk
 aberráció/ŐAUQĘŽiĎŇáç˛ĂăYcˇť
 abcúg
@@ -51278,6 +51427,7 @@ a	á
 átall/Š§ĽŁĄOoŤX
 ásítozik/Š§ĽŁĄOŤX
 ásít/ŠĽŁĄOoŤX
+ászokol/Š§ĽŁĄOoŤX
 ászkol/Š§ĽŁĄOoŤX
 áskálódik/ŠŁOŤX
 áskál/Š§ĽŁĄOoŤX
@@ -51829,7 +51979,7 @@ viszem/X)
 viszel/X)
 viszek/X)
 viszed/X)
-visz/X	ésőségégívéníveígyünkükétekélékünkükünkőkétekétekénkénkénekémélekélékékédéükökünkükétekélékőő
+visz/X	ésőségégívéníveígyünkükétekélékünkükünkőkétekétekénkénkénekémélekélékékédéükökünkükétekélékőőő
 visszük/X)
 visszleszámítol/Š§ĽŁĄOoŤX
 visszhangzik/ŠĽŁOŤX
@@ -51962,7 +52112,7 @@ vicsorog/ĽŁĄOoŤd'X	óás
 vicsorgat/ŠĽŁĄOoŤX
 vickándozik/Š§ĽŁĄOŤX
 vicceskedik/Ş¤EŹX
-viccelődik/Ş¤P­X
+viccelődik/ŞŚ¤˘Pp­X
 viccel/Ş¨Ś¤˘EeŹX
 vibrál/Š§ĽŁĄOoŤX
 viaszoz/Š§ĽŁĄOoŤX
@@ -52623,6 +52773,7 @@ tömjénez/Ş¨Ś¤˘EeŹX
 tömet/ŞŚ¤EeŹX)öm
 tömet/ŞŚ¤EeŹX
 tömegesül/Ş¨Ś¤˘P­X
+tömedékel/Ş¨Ś¤˘EeŹX
 töm/ŞŚ¤Pp­X	ömet
 töltöget/ŞŚ¤˘EeŹX
 töltődik/Ş¤P­X
@@ -52979,6 +53130,7 @@ tilt/ŠĽŁOoŤX
 tilol/Š§ĽŁĄOoŤX
 tilinkózik/Š§ĽŁĄOŤX
 tilalmaz/Š§ĽŁĄOoŤX
+tiktokozik/Š§ĽŁĄOoŤX
 tiktakol/Š§ĽŁĄOoŤX
 tikkel/Ş¨Ś¤˘EŹX
 tikkasztat/ŠĽŁOoŤX)
@@ -53781,6 +53933,7 @@ szárnyaz/Š§ĽŁĄOoŤX
 szárnyal/Š§ĽŁĄOoŤX
 származtat/ŠĽŁĄOoŤX
 származik/Š§ĽŁĄOŤX
+szárazodik/ŠŁOŤX
 szárasztat/ŠĽŁOoŤX)áraszt
 szárasztat/ŠĽŁOoŤX
 száraszt/Š§ĽŁOoŤX	árasztat
@@ -54397,6 +54550,7 @@ sodorint/Š§ĽŁOoŤX
 sodor/ĽŁĄOoŤd'X	óás
 snúroz/Š§ĽŁĄOoŤX
 snóblizik/Š§ĽŁĄOŤX
+smúzol/Š§ĽŁĄOŤX
 smárol/Š§ĽŁĄOoŤX
 sms-ezik/ŞŚ¤˘EeŹ
 smirgliz/Ş¨Ś¤˘EeŹX
@@ -54576,6 +54730,7 @@ rúgkapál/Š§ĽŁĄOŤX
 rúgat/ŠĽŁOoŤX)úg
 rúgat/ŠĽŁOoŤX
 rúg/ŠĽŁOoŤX	úgat
+rúdtáncol/Š§ĽŁĄOoŤXy
 rövidül/Ş¨Ś¤˘P­X
 rövidít/ŞŚ¤˘EeŹX
 rövidell/Ş¨Ś¤˘EeŹX
@@ -54909,6 +55064,7 @@ rogyadozik/Š§ĽŁĄOŤX
 rogy/ŠŁOŤX
 roggyan/ŠŁOŤX
 robotol/Š§ĽŁĄOŤX
+robotizál/Š§ĽŁĄOoŤX
 roborál/Š§ĽŁĄOoŤX
 robog/ŠŁOŤX
 robbantat/ŠĽŁOoŤX)
@@ -54934,6 +55090,7 @@ riszál/Š§ĽŁĄOoŤX
 riposztozik/Š§ĽŁĄOoŤX
 riposztoz/Š§ĽŁĄOoŤX
 riposztol/Š§ĽŁĄOoŤX
+riporterkedik/Ş¤EŹX
 ripakodik/ŠŁOŤX
 ripacskodik/ŠŁOŤX
 riogat/ŠĽŁĄOoŤX
@@ -55219,6 +55376,7 @@ púderez/Ş¨Ś¤˘EeŹX
 pötyögtet/ŞŚ¤˘EeŹX
 pötyög/ŞŚ¤˘Pp­X
 pöttyöz/Ş¨Ś¤˘Pp­X
+pöttyint/Ş¨Ś¤EeŹX
 pöttyent/Ş¨Ś¤˘EeŹX
 pöszít/ŞŚ¤˘EeŹX
 pöszéz/Ş¨Ś¤˘EeŹX
@@ -55627,7 +55785,7 @@ pigmentál/Š§ĽŁĄOoŤX
 picsog/ŠĽŁĄOoŤX
 piacozik/Š§ĽŁĄOŤX
 piacol/Š§ĽŁĄOŤX
-photoshoppol/Š§ĽŁĄOoŤX
+photoshoppol/Š§ĽŁĄOoŤX	ph:fotosoppol
 pfujoz/Š§ĽŁĄOoŤX
 pfujol/Š§ĽŁĄOoŤX
 pezsgőzik/Ş¨Ś¤˘P­X
@@ -56392,6 +56550,7 @@ neveletlenkedik/Ş¤EŹX
 nevel/Ş¨Ś¤˘EeŹX
 neutralizál/Š§ĽŁĄOoŤX
 nettósít/ŠĽŁĄOoŤX
+netflixezik/Ş¨Ś¤˘EeŹX
 neszez/Ş¨Ś¤˘EŹX
 neszel/Ş¨Ś¤˘EeŹX
 nemzetköziesít/ŞŚ¤˘EeŹXy
@@ -57202,6 +57361,7 @@ lumineszkál/Š§ĽŁĄOoŤX
 lukaszt/Š§ĽŁĄOoŤX
 lukad/ŠŁOŤX
 luggat/ŠĽŁĄOoŤX
+lucázik/Š§ĽŁĄOŤX
 lucskol/Š§ĽŁĄOoŤX
 lubickol/Š§ĽŁĄOŤX
 lovászkodik/ŠŁOŤX
@@ -57228,6 +57388,7 @@ lopat/ŠĽŁOoŤX
 lopakodik/ŠŁOŤX
 lop/ŠĽŁOoŤX
 lomtalanít/ŠĽŁĄOoŤX
+lomizik/Ş¨Ś¤˘EŹX
 lomhul/Š§ĽŁĄOŤX
 lombtalanít/ŠĽŁĄOoŤX
 lombozódik/ŠŁOŤX
@@ -58381,8 +58542,10 @@ kavargat/ŠĽŁĄOoŤX
 kavar/ŠĽŁĄOoŤX
 kauterez/Ş¨Ś¤˘EeŹX
 katéterez/Ş¨Ś¤˘EeŹX
+katázik/Š§ĽŁĄOŤX
 kattogtat/ŠĽŁOoŤX
 kattog/ŠŁOŤX
+kattintgat/
 kattintat/ŠĽŁOoŤX)
 kattintat/ŠĽŁOoŤX
 kattint/Š§ĽŁOoŤX
@@ -58783,6 +58946,7 @@ integrálódik/ŠŁOŤX
 integrál/Š§ĽŁĄOoŤX
 integet/ŞŚ¤˘EeŹX
 int/ŞŚ¤EeŹX
+instázik/Š§ĽŁĄOoŤX
 instál/Š§ĽŁĄOoŤX
 instruál/Š§ĽŁĄOoŤX
 instrumentalizál/Š§ĽŁĄOoŤX
@@ -60436,6 +60600,7 @@ fuvolázgat/ŠŁOŤX
 fuvaroz/Š§ĽŁĄOoŤX	ó
 fuvall/Š§ĽŁĄOŤX
 fuvalkodik/ŠŁOŤX
+futárkodik/ŠŁOŤX
 futtat/ŠĽŁĄOoŤX
 futkározik/Š§ĽŁĄOoŤX
 futkároz/Š§ĽŁĄOŤX
@@ -60490,6 +60655,7 @@ frottíroz/Š§ĽŁĄOoŤX
 frocliz/Š§ĽŁĄOoŤX
 frizíroz/Š§ĽŁĄOoŤX
 frissül/Ş¨Ś¤˘P­X
+frissítget/ŞŚ¤˘EeŹX
 frissít/ŞŚ¤˘EeŹX
 fricskáz/Š§ĽŁĄOoŤX
 frekventál/Š§ĽŁĄOoŤX
@@ -60902,7 +61068,7 @@ facsarít/ŠĽŁĄOoŤX
 facsarodik/ŠŁOŤX
 facsar/ŠĽŁĄOoŤX
 facilitál/Š§ĽŁĄOoŤX
-facebookozik/Š§ĽŁĄOoŤX
+facebookozik/Š§ĽŁĄOoŤX	ph:fészbúkozik
 fabuláz/Š§ĽŁĄOŤX
 fabrikál/Š§ĽŁĄOoŤX
 ezüstöz/Ş¨Ś¤˘Pp­X
@@ -61245,6 +61411,7 @@ egységesít/ŞŚ¤˘EeŹX
 egységesedik/Ş¤EŹX
 egyszerűsödik/Ş¤P­X
 egyszerűsít/ŞŚ¤˘EeŹX
+egyneműsít/ŞŚ¤˘EeŹy
 egymásra_utal/Š§ĽŁĄOoŤX
 egykézik/Ş¨Ś¤˘EŹX
 egyeztet/ŞŚ¤˘EeŹX
@@ -61888,6 +62055,7 @@ csontoz/Š§ĽŁĄOoŤX
 csontosít/ŠĽŁĄOoŤX
 csontosodik/ŠŁOŤX
 csonkít/ŠĽŁĄOoŤX
+csonkázik/Š§ĽŁĄOoŤX
 csonkul/Š§ĽŁĄOŤX
 csonkol/Š§ĽŁĄOoŤX
 csomózódik/ŠŁOŤX
@@ -62039,6 +62207,7 @@ csempész/ŞŚ¤˘EeŹX
 csemegézik/Ş¨Ś¤˘EŹX
 csemegéz/Ş¨Ś¤˘EeŹX
 cselédkedik/Ş¤EŹX
+cselédeskedik/Ş¤EŹX
 csellózik/Š§ĽŁĄOŤX
 csellóz/Š§ĽŁĄOŤX
 cselleng/Ş¤EŹX
@@ -62261,6 +62430,7 @@ bődül/Ş¨Ś¤˘P­X
 bóvliz/Š§ĽŁĄOoŤX
 bólongat/ŠĽŁĄOoŤX
 bólogat/ŠŁOŤX
+bólintgat/
 bólint/Š§ĽŁOoŤX
 bólingat/ŠŁOŤX
 bókol/Š§ĽŁĄOŤX
@@ -63077,7 +63247,7 @@ harmadfelek/)él
 üzletházak/IóÍžyÂâxüzletház
 üzletfelek/IóÍžyÂâxüzletfél
 üzemárak/IóÍžyÂâxüzemár
-üzemanyagárak/IóÍžyÂâxüzemanyagár
+üzemanyagárak/IóÍžyÂâxüzemanyagárüzem|anyag||ár
 üvegpoharak/IóÍžyÂâxüvegpohár
 üvegnyakak/IóÍžyÂâxüvegnyak
 üvegmázak/IóÍžyÂâxüvegmáz
@@ -63090,7 +63260,7 @@ harmadfelek/)él
 ürmök/IóÍžJĆćş´xüröm
 üledékvizek/IóÍžyÂâxüledékvíz
 ügyvezetőurak/wIóÍžĆćşxügyvezetőúr
-ügyféloldalak/IóÍžyÂâxügyféloldal
+ügyféloldalak/IóÍžyÂâxügyféloldalügy|fél||oldal
 ügyfelek/IóÍžyÂâxügyfél
 űrtartalmak/IóÍžJyÂâÉxűrtartalom
 űrszemetek/IóÍžyÂâxűrszemét
@@ -63120,20 +63290,20 @@ harmadfelek/)él
 összforgalmak/IóÍžJyÂâÉxösszforgalom
 összbirodalmak/IóÍžJyÂâÉxösszbirodalom
 örömtüzek/IóÍžyÂâxörömtűz
-öröknaptárak/IóÍžyÂâxöröknaptár
+öröknaptárak/IóÍžyÂâxöröknaptárörök||nap|tár
 örménygyökerek/IóÍžyÂâxörménygyökér
 öregurak/IóÍžyÂâxöregúr
 öregujjak/IóÍžyÂâxöregujj
 öregtornyok/IóÍžJyÂâÉxöregtorony
 öreglyukak/IóÍžyÂâxöreglyuk
-ördögharaptafüvek/IóÍžyÂâxördögharaptafű
+ördögharaptafüvek/IóÍžyÂâxördögharaptafűördög|harapta||fű
 önvédelmek/IóÍžJyÂâÉxönvédelem
 önvádak/IóÍžyÂâxönvád
 önuralmak/IóÍžJyÂâÉxönuralom
 öntözőcsövek/IóÍžyÂâxöntözőcső
 öntöttvasak/IóÍžyÂâxöntöttvas
 önszorgalmak/IóÍžJyÂâÉxönszorgalom
-önkényuralmak/IóÍžJyÂâÉxönkényuralom
+önkényuralmak/IóÍžJyÂâÉxönkényuralomön|kény||uralom
 önfegyelmek/IóÍžJyÂâÉxönfegyelem
 önbizalmak/IóÍžJyÂâÉxönbizalom
 ölek/IóÍžöl
@@ -63145,12 +63315,12 @@ harmadfelek/)él
 őzlábak/IóÍžyÂâxőzláb
 őzek/IóÍžĆćşxőz
 ősölek/IóÍžősöl
-őszi-fésűsbaglyok/IóÍžJyÂâÉxőszi-fésűsbagoly
+őszi-fésűsbaglyok/IóÍžJyÂâÉxőszi-fésűsbagolyőszi-fésűs|bagoly
 őstüzek/IóÍžyÂâxőstűz
 őstulkok/IóÍžJyÂâÉxőstulok
 őslovak/IóÍžyÂâxősló
 őskövek/IóÍžyÂâxőskő
-ősegyházak/IóÍžyÂâxősegyház
+ősegyházak/IóÍžyÂâxősegyházős||egy|ház
 őrtüzek/IóÍžyÂâxőrtűz
 őrtornyok/IóÍžJyÂâÉxőrtorony
 őrlőkövek/IóÍžyÂâxőrlőkő
@@ -63193,7 +63363,7 @@ harmadfelek/)él
 élvonalak/IóÍžyÂâxélvonal
 életutak/IóÍžyÂâxéletút
 életművek/IóÍžyÂâxéletmű
-élesmosófüvek/IóÍžyÂâxélesmosófű
+élesmosófüvek/IóÍžyÂâxélesmosófűéles|mosó||fű
 élelmek/IóÍžJĆćş´xélelem
 ékkövek/IóÍžyÂâxékkő
 ékhornyok/IóÍžJyÂâÉxékhorony
@@ -63213,11 +63383,11 @@ harmadfelek/)él
 árvizek/IóÍžyÂâxárvíz
 árvalányhajak/IóÍžyÂâxárvalányhaj
 árvaházak/IóÍžyÂâxárvaház
-áruraktárak/IóÍžyÂâxáruraktár
+áruraktárak/IóÍžyÂâxáruraktáráru||rak|tár
 áruházak/IóÍžyÂâxáruház
 árterek/IóÍžyÂâxártér
 ártalmak/IóÍžJĆćş´xártalom
-árszínvonalak/IóÍžyÂâxárszínvonal
+árszínvonalak/IóÍžyÂâxárszínvonalár||szín|vonal
 árnyak/IóÍžĆćşxárny
 árkok/IóÍžJĆćş´xárok
 árbóckosarak/IóÍžyÂâxárbóckosár
@@ -63231,7 +63401,7 @@ harmadfelek/)él
 álmok/IóÍžJĆćş´xálom
 állóvizek/IóÍžyÂâxállóvíz
 állótükrök/IóÍžJyÂâÉxállótükör
-állónaptárak/IóÍžyÂâxállónaptár
+állónaptárak/IóÍžyÂâxállónaptárálló||nap|tár
 állóhidak/IóÍžyÂâxállóhíd
 állábak/IóÍžyÂâxálláb
 állványhidak/IóÍžyÂâxállványhíd
@@ -63239,7 +63409,7 @@ harmadfelek/)él
 állkapcsok/IóÍžJyÂâÉxállkapocs
 állatkölykök/IóÍžJyÂâÉxállatkölyök
 államtitkárurak/wIóÍžĆćşxállamtitkárúr
-államkincstárak/IóÍžyÂâxállamkincstár
+államkincstárak/IóÍžyÂâxállamkincstárállam||kincs|tár
 államhatalmak/IóÍžJyÂâÉxállamhatalom
 állak/IóÍžĆćşxáll
 álhajak/IóÍžyÂâxálhaj
@@ -63283,7 +63453,7 @@ zeneművek/IóÍžyÂâx)ű
 zabpelyhek/IóÍžJyÂâÉx)
 wertheimzárak/IóÍžyÂâx)ár
 vörösrezek/IóÍžyÂâx)örösréz
-vörösborospoharak/IóÍžyÂâx)örösborospohár
+vörösborospoharak/IóÍžyÂâx)örösborospohárörös|boros||pohár
 völgytorkok/IóÍžJyÂâÉx)ölgytorok
 völgyhidak/IóÍžyÂâx)ölgyhíd
 vödrök/IóÍžJĆćş´x)ödör
@@ -63293,7 +63463,7 @@ vízvonalak/IóÍžyÂâx)ízvonal
 víztornyok/IóÍžJyÂâÉx)íztorony
 vízterek/IóÍžyÂâx)íztér
 vízsugarak/IóÍžyÂâx)ízsugáríz|su-gár
-víznyomócsövek/IóÍžyÂâx)íznyomócső
+víznyomócsövek/IóÍžyÂâx)íznyomócsőíz||nyomó|cső
 vízművek/IóÍžyÂâx)ízmű
 vízkövek/IóÍžyÂâx)ízkő
 vízimalmok/IóÍžJyÂâÉx)ízimalom
@@ -63301,7 +63471,7 @@ vízimadarak/IóÍžyÂâx)ízimadár
 vízilovak/IóÍžyÂâx)íziló
 vízikerekek/IóÍžyÂâx)ízikerék
 vízibogarak/IóÍžyÂâx)ízibogár
-vízgyűjtőgödrök/IóÍžJyÂâÉx)ízgyűjtőgödör
+vízgyűjtőgödrök/IóÍžJyÂâÉx)ízgyűjtőgödöríz|gyűjtő||gödör
 vízerek/IóÍžyÂâx)ízér
 vízdíjak/IóÍžyÂâx)ízdíj
 vízcsövek/IóÍžyÂâx)ízcső
@@ -63310,7 +63480,7 @@ vétkek/IóÍžJĆćş´x)étek
 vételárak/IóÍžyÂâx)ételár
 vészmadarak/IóÍžyÂâx)észmadár
 vértövek/IóÍžyÂâx)értő
-vérontófüvek/IóÍžyÂâx)érontófű
+vérontófüvek/IóÍžyÂâx)érontófűér|ontó||fű
 vérhasak/IóÍžyÂâx)érhas
 vérfüvek/IóÍžyÂâx)érfű
 vérdíjak/IóÍžyÂâx)érdíj
@@ -63383,7 +63553,7 @@ világhatalmak/IóÍžJyÂâÉx)ághatalom
 viharmadarak/IóÍžyÂâx)ár
 vigalmak/IóÍžJĆćş´x)
 vigadalmak/IóÍžJĆćş´x)
-vidrakeserűfüvek/IóÍžyÂâx)űfű
+vidrakeserűfüvek/IóÍžyÂâx)űfűű|fű
 vidrafüvek/IóÍžyÂâx)ű
 viaszosvásznak/IóÍžJyÂâÉx)ászon
 viaszkosvásznak/IóÍžJyÂâÉx)ászon
@@ -63467,7 +63637,7 @@ tűrömfüvek/IóÍžyÂâx)űrömfű
 túloldalak/IóÍžyÂâx)úloldal
 túlhatalmak/IóÍžJyÂâÉx)úlhatalom
 tövek/IóÍžĆćşx)ő
-törökvörösolajak/IóÍžyÂâx)örökvörösolaj
+törökvörösolajak/IóÍžyÂâx)örökvörösolajörök|vörös||olaj
 történelmek/IóÍžJĆćş´x)örténelem
 tört_aranyak/IóÍžĆćşx)ört_arany
 töredelmek/IóÍžJĆćş´x)öredelem
@@ -63483,7 +63653,7 @@ térkövek/IóÍžyÂâx)érkő
 tépőfogak/IóÍžyÂâx)épőfog
 télibaglyok/IóÍžJyÂâÉx)élibagoly
 távcsövek/IóÍžyÂâx)ávcső
-távcsőtükrök/IóÍžJyÂâÉx)ávcsőtükör
+távcsőtükrök/IóÍžJyÂâÉx)ávcsőtüköráv|cső||tükör
 társasházak/IóÍžyÂâx)ársasház
 társak/IóÍžĆćşx)árs
 társadalmak/IóÍžJĆćş´x)ársadalom
@@ -63507,7 +63677,7 @@ tudásvágyak/IóÍžyÂâx)ásvágy
 tudományágak/IóÍžyÂâx)ányág
 trágyalevek/IóÍžyÂâx)ágyalé
 trikarbonsavak/IóÍžyÂâx)
-tridekánsavak/IóÍžyÂâx)ánsav
+tridekánsavak/IóÍžyÂâx)ánsaván||sav
 transz-zsírsavak/IóÍžĆćşx)írsav
 traktorutak/IóÍžyÂâx)út
 tortástálak/IóÍžyÂâx)ástál
@@ -63554,7 +63724,7 @@ tengeritehenek/IóÍžyÂâx)én
 tengerinyulak/IóÍžyÂâx)úl
 tengerifűak/IóÍžyÂâx)ű
 tengericsövek/IóÍžyÂâx)ő
-tengelycsapágyak/IóÍžyÂâx)ágy
+tengelycsapágyak/IóÍžyÂâx)ágyágy
 templomtornyok/IóÍžJyÂâÉx)
 temetőbogarak/IóÍžyÂâx)őbogár
 telt_házak/IóÍžĆćşx)áz
@@ -63574,7 +63744,7 @@ tejesfazekak/IóÍžyÂâx)ék
 tehenek/IóÍžĆćşx)én
 tegzek/IóÍžJĆćş´x)
 teafüvek/IóÍžyÂâx)ű
-tavaszi-fésűsbaglyok/IóÍžJyÂâÉx)ésűsbagoly
+tavaszi-fésűsbaglyok/IóÍžJyÂâÉx)ésűsbagolyésűs|bagoly
 tavak/IóÍžĆćşx)ó
 tartóvázak/IóÍžyÂâx)óváz
 tartószíjak/IóÍžyÂâx)ószíj
@@ -63631,6 +63801,7 @@ sárgalázak/IóÍžyÂâx)árgaláz
 sáncárkok/IóÍžJyÂâÉx)áncárok
 sálak/IóÍžĆćşx)ál
 szüzek/xIóÍžĆćş)űz
+szürkevizek/IóÍžyÂâx)ürkevíz
 szürkeszennyvizek/IóÍžyÂâx)ürkeszennyvízürke||szenny|víz
 szürkeagyak/IóÍžyÂâx)ürkeagy
 szövőmadarak/IóÍžyÂâx)övőmadár
@@ -63653,7 +63824,7 @@ szítóvasak/IóÍžyÂâx)ítóvas
 színvonalak/IóÍžyÂâx)ínvonal
 színterek/IóÍžyÂâx)íntér
 színművek/IóÍžyÂâx)ínmű
-színműirodalmak/IóÍžJyÂâÉx)ínműirodalom
+színműirodalmak/IóÍžJyÂâÉx)ínműirodalomín|mű||irodalom
 színházak/IóÍžyÂâx)ínház
 színfalak/IóÍžyÂâx)ínfal
 szíjak/IóÍžĆćşx)íj
@@ -63665,14 +63836,14 @@ szénalázak/IóÍžyÂâx)énaláz
 szélsőjobboldalak/IóÍžyÂâx)élsőjobboldal
 szélsőbaloldalak/IóÍžyÂâx)élsőbaloldal
 széloldalak/IóÍžyÂâx)éloldal
-szélmalomszárnyak/IóÍžyÂâx)élmalomszárny
-szélmalomkerekek/IóÍžyÂâx)élmalomkerék
+szélmalomszárnyak/IóÍžyÂâx)élmalomszárnyél|malom||szárny
+szélmalomkerekek/IóÍžyÂâx)élmalomkerékél|malom||kerék
 szélmalmok/IóÍžJyÂâÉx)élmalom
 szélkerekek/IóÍžyÂâx)élkerék
 szélfüvek/IóÍžyÂâx)élfű
 székházak/IóÍžyÂâx)ékház
 székfüvek/IóÍžyÂâx)ékfű
-székesegyházak/IóÍžyÂâx)ékesegyház
+székesegyházak/IóÍžyÂâx)ékesegyházékes||egy|ház
 szárnyvonalak/IóÍžyÂâx)árnyvonal
 szárnytollak/IóÍžyÂâx)árnytoll
 szárnyfedelek/IóÍžyÂâx)árnyfedél
@@ -63712,7 +63883,7 @@ szitkok/IóÍžJĆćş´x)
 sziromlevelek/IóÍžyÂâx)él
 szirmok/IóÍžJĆćş´x)
 szintvonalak/IóÍžyÂâx)
-sziksófüvek/IóÍžyÂâx)ófű
+sziksófüvek/IóÍžyÂâx)ófűó||fű
 sziklahátak/IóÍžyÂâx)át
 szikibaglyok/IóÍžJyÂâÉx)
 szifoncsövek/IóÍžyÂâx)ő
@@ -63731,8 +63902,8 @@ szerelmeslevelek/IóÍžyÂâx)él
 szerelmek/IóÍžJĆćş´x)
 szenvedelmek/IóÍžJĆćş´x)
 szentségházak/IóÍžyÂâx)égház
-szentjánoskenyerek/IóÍžyÂâx)ánoskenyér
-szentjánosbogarak/IóÍžyÂâx)ánosbogár
+szentjánoskenyerek/IóÍžyÂâx)ánoskenyérános||kenyér
+szentjánosbogarak/IóÍžyÂâx)ánosbogárános||bogár
 szenteltvizek/IóÍžyÂâx)íz
 szennyvizek/IóÍžyÂâx)íz
 szennyirodalmak/IóÍžJyÂâÉx)
@@ -63816,7 +63987,7 @@ selymek/IóÍžJĆćş´x)
 selyemszálak/IóÍžyÂâx)ál
 selyemmajmok/IóÍžJyÂâÉx)
 sejtelmek/IóÍžJĆćş´x)
-segédhajtóművek/IóÍžyÂâx)édhajtómű
+segédhajtóművek/IóÍžyÂâx)édhajtóműéd||hajtó|mű
 segedelmek/IóÍžJĆćş´x)
 savanyúvizek/IóÍžyÂâx)úvíz
 savanyúkutak/IóÍžyÂâx)úkút
@@ -63841,8 +64012,8 @@ rókakölykök/IóÍžJyÂâÉx)ókakölyök
 rókafarkak/IóÍžJyÂâÉx)ókafarok
 rétegvizek/IóÍžyÂâx)étegvíz
 részestársak/IóÍžyÂâx)észestárs
-részegyházak/IóÍžyÂâx)észegyház
-részegkorpafüvek/IóÍžyÂâx)észegkorpafű
+részegyházak/IóÍžyÂâx)észegyházész||egy|ház
+részegkorpafüvek/IóÍžyÂâx)észegkorpafűészeg||korpa|fű
 répacukrok/IóÍžJyÂâÉx)épacukor
 rémuralmak/IóÍžJyÂâÉx)émuralom
 régmúltak/IóÍž)égmúlt
@@ -63857,7 +64028,7 @@ ruhaderekak/IóÍžyÂâx)ék
 rudak/IóÍžĆćşx)úd
 rubintkövek/IóÍžyÂâx)ő
 rosszházak/IóÍžyÂâx)áz
-rokkantnyugdíjak/IóÍžyÂâx)íj
+rokkantnyugdíjak/IóÍžyÂâx)íjíj
 robbantólyukak/IóÍžyÂâx)ólyuk
 ribonukleinsavak/IóÍžyÂâx)
 ribonsavak/IóÍžyÂâx)
@@ -63879,7 +64050,7 @@ rejtekutak/IóÍžyÂâx)út
 regényirodalmak/IóÍžJyÂâÉx)ényirodalom
 redőnyzárak/IóÍžyÂâx)őnyzár
 recésgyomrok/IóÍžJyÂâÉx)ésgyomor
-raktárházak/IóÍžyÂâx)árház
+raktárházak/IóÍžyÂâx)árházár||ház
 raktárak/IóÍžyÂâx)ár
 rakterek/IóÍžyÂâx)ér
 rakodóterek/IóÍžyÂâx)ótér
@@ -63893,7 +64064,7 @@ pöckök/IóÍžJĆćş´x)öcök
 pöcegödrök/IóÍžJyÂâÉx)öcegödör
 pótágyak/IóÍžyÂâx)ótágy
 pótszabadalmak/IóÍžJyÂâÉx)ótszabadalom
-pótmagánvádak/IóÍžyÂâx)ótmagánvád
+pótmagánvádak/IóÍžyÂâx)ótmagánvádót||magán|vád
 pótkerekek/IóÍžyÂâx)ótkerék
 póthajak/IóÍžyÂâx)óthaj
 pótdíjak/IóÍžyÂâx)ótdíj
@@ -63985,7 +64156,7 @@ osztálytermek/IóÍžJyÂâÉx)ályterem
 ostromzárak/IóÍžyÂâx)ár
 ostorszíjak/IóÍžyÂâx)íj
 ostornyelek/IóÍžyÂâx)él
-ortoperjódsavak/IóÍžyÂâx)ódsav
+ortoperjódsavak/IóÍžyÂâx)ódsavód|sav
 ortofoszforsavak/IóÍžyÂâx)
 ortofoszforossavak/IóÍžyÂâx)
 országutak/IóÍžyÂâx)ágút
@@ -64011,8 +64182,8 @@ olajárak/IóÍžyÂâx)ár
 olajágak/IóÍžyÂâx)ág
 olajkutak/IóÍžyÂâx)út
 olajak/IóÍžĆćşx)
-oktadekánsavak/IóÍžyÂâx)ánsav
-oktadecénsavak/IóÍžyÂâx)énsav
+oktadekánsavak/IóÍžyÂâx)ánsaván|sav
+oktadecénsavak/IóÍžyÂâx)énsavén||sav
 oktadecinsavak/IóÍžyÂâx)
 oklevelek/IóÍžyÂâx)él
 odautak/IóÍžyÂâx)út
@@ -64022,8 +64193,8 @@ nőszirmok/IóÍžJyÂâÉx)őszirom
 nőmozgalmak/IóÍžJyÂâÉx)őmozgalom
 nézőterek/IóÍžyÂâx)ézőtér
 négyzetölek/IóÍžyÂâx)égyzetöl
-négyzetméterárak/IóÍžyÂâx)égyzetméterár
-négyszögölek/IóÍžyÂâx)égyszögöl
+négyzetméterárak/IóÍžyÂâx)égyzetméterárégyzet|méter||ár
+négyszögölek/IóÍžyÂâx)égyszögölégy|szög||öl
 nátronmeszek/IóÍžyÂâx)átronmész
 nászutak/IóÍžyÂâx)ászút
 nádiverebek/IóÍžĆćşx)ádiveréb
@@ -64031,7 +64202,7 @@ nádak/IóÍžĆćşx)ád
 nyüvek/IóÍžĆćşx)ű
 nyúltagyak/IóÍžyÂâx)últagy
 nyúlszájak/IóÍžyÂâx)úlszáj
-nyúlfarkfüvek/IóÍžyÂâx)úlfarkfű
+nyúlfarkfüvek/IóÍžyÂâx)úlfarkfűúl|fark||fű
 nyíltterek/IóÍžyÂâx)ílttér
 nyílfüvek/IóÍžyÂâx)ílfű
 nyársak/IóÍžĆćşx)árs
@@ -64041,8 +64212,8 @@ nyájak/IóÍžĆćşx)áj
 nyulak/IóÍžĆćşx)úl
 nyugágyak/IóÍžyÂâx)ágy
 nyugodalmak/IóÍžJĆćş´x)
-nyugdíjpénztárak/IóÍžyÂâx)íjpénztár
-nyugdíjasházak/IóÍžyÂâx)íjasház
+nyugdíjpénztárak/IóÍžyÂâx)íjpénztáríj||pénz|tár
+nyugdíjasházak/IóÍžyÂâx)íjasházíjas||ház
 nyugdíjak/IóÍžyÂâx)íj
 nyugalmak/IóÍžJĆćş´x)
 nyomócsövek/IóÍžyÂâx)ócső
@@ -64071,7 +64242,7 @@ nevek/xIóÍžĆćş)év
 nemeslevelek/IóÍžyÂâx)él
 nehézvizek/IóÍžyÂâx)ézvíz
 nehézolajak/IóÍžyÂâx)ézolaj
-nehézgépjárművek/IóÍžyÂâx)ézgépjármű
+nehézgépjárművek/IóÍžyÂâx)ézgépjárműéz||gép|jármű
 negyedfelek/IóÍžyÂâx)él
 narancslevek/IóÍžyÂâx)é
 naptárak/IóÍžyÂâx)ár
@@ -64079,7 +64250,7 @@ naptavak/IóÍžyÂâx)ó
 napsugarak/IóÍžyÂâx)ár
 napidíjak/IóÍžyÂâx)íj
 nanocsövek/IóÍžyÂâx)ő
-nagyáruházak/IóÍžyÂâx)áruház
+nagyáruházak/IóÍžyÂâx)áruházáru|ház
 nagyágyak/IóÍžyÂâx)ágy
 nagyvizek/IóÍžyÂâx)íz
 nagyvasutak/IóÍžyÂâx)útút
@@ -64088,9 +64259,9 @@ nagyurak/IóÍžyÂâx)úr
 nagyujjak/IóÍžyÂâx)
 nagytájak/IóÍžyÂâx)áj
 nagytermek/IóÍžJyÂâÉx)
-nagyszótárak/IóÍžyÂâx)ótár
+nagyszótárak/IóÍžyÂâx)ótáró|tár
 nagyszínházak/IóÍžyÂâx)ínházín|ház
-nagylábujjak/IóÍžyÂâx)ábujj
+nagylábujjak/IóÍžyÂâx)ábujjáb|ujj
 nagykörutak/IóÍžyÂâx)örútör|út
 nagykereskedelmek/IóÍžJyÂâÉx)
 nagykanalak/IóÍžyÂâx)ál
@@ -64098,20 +64269,21 @@ nagyhetek/IóÍžyÂâx)ét
 nagyhatalmak/IóÍžJyÂâÉx)
 nagyhalak/IóÍžyÂâx)
 nagyfejedelmek/IóÍžJyÂâÉx)
-nagyezerjófüvek/IóÍžyÂâx)ófű
+nagyezerjófüvek/IóÍžyÂâx)ófűó|fű
 nagydíjak/IóÍžyÂâx)íj
 nagydolgok/IóÍžyÂâx)
 nagyajkak/IóÍžJyÂâÉx)
 nagyagyak/IóÍžyÂâx)
 nadrágszárak/IóÍžyÂâx)ágszár
 művészurak/wIóÍžĆćşx)űvészúr
+művházak/IóÍžyÂâx)űvház
 művek/IóÍžĆćşx)ű
 művajak/IóÍžyÂâx)űvaj
 műutak/IóÍžyÂâx)űút
 műtárgyak/IóÍžyÂâx)űtárgy
 műtermek/IóÍžJyÂâÉx)űterem
 műszálak/IóÍžyÂâx)űszál
-műszerfalak/IóÍžyÂâx)űszerfal
+műszerfalak/IóÍžyÂâx)űszerfalű|szer||fal
 műszavak/IóÍžyÂâx)űszó
 műselymek/IóÍžJyÂâÉx)űselyem
 műlábak/IóÍžyÂâx)űláb
@@ -64145,7 +64317,7 @@ mészkövek/IóÍžyÂâx)észkő
 mérőrudak/IóÍžyÂâx)érőrúd
 mérművek/IóÍžyÂâx)érmű
 mérgek/IóÍžJĆćş´x)éreg
-mérföldkövek/IóÍžyÂâx)érföldkő
+mérföldkövek/IóÍžyÂâx)érföldkőér|föld||kő
 méreggyilkok/IóÍžJyÂâÉx)éreggyilokéreg|gyilok
 méregfogak/IóÍžyÂâx)éregfog
 ménkövek/IóÍžyÂâx)énkő
@@ -64193,7 +64365,7 @@ metakrilsavak/IóÍžyÂâx)
 metakovasavak/IóÍžyÂâx)
 metafoszforsavak/IóÍžyÂâx)
 metafoszforossavak/IóÍžyÂâx)
-metabórsavak/IóÍžyÂâx)órsav
+metabórsavak/IóÍžyÂâx)órsavór|sav
 meszesgödrök/IóÍžJyÂâÉx)ödör
 meszek/IóÍžĆćşx)ész
 mesterművek/IóÍžyÂâx)ű
@@ -64219,7 +64391,7 @@ mellitsavak/IóÍžyÂâx)
 mellcsokrok/IóÍžJyÂâÉx)
 melegágyak/IóÍžyÂâx)ágy
 melegházak/IóÍžyÂâx)áz
-meleghengerművek/IóÍžyÂâx)ű
+meleghengerművek/IóÍžyÂâx)űű
 meleg_vizek/IóÍž)íz
 megbízólevelek/IóÍžyÂâx)ízólevél
 medrek/IóÍžJĆćş´x)
@@ -64232,14 +64404,14 @@ malmok/IóÍžJĆćş´x)
 maleinsavak/IóÍžyÂâx)
 makadámutak/IóÍžyÂâx)ámút
 majmok/IóÍžJĆćş´x)
-magánútlevelek/IóÍžyÂâx)ánútlevél
+magánútlevelek/IóÍžyÂâx)ánútlevélán||út|levél
 magánvádak/IóÍžyÂâx)ánvád
 magánutak/IóÍžyÂâx)ánút
 magántitkok/IóÍžJyÂâÉx)ántitok
 magánnyugdíjak/IóÍžyÂâx)ánnyugdíján||nyug|díj
 magánlevelek/IóÍžyÂâx)ánlevél
-magánkönyvtárak/IóÍžyÂâx)ánkönyvtár
-magánkórházak/IóÍžyÂâx)ánkórház
+magánkönyvtárak/IóÍžyÂâx)ánkönyvtárán||könyv|tár
+magánkórházak/IóÍžyÂâx)ánkórházán||kór|ház
 magánházak/IóÍžyÂâx)ánház
 magánfelek/IóÍžyÂâx)ánfél
 magtárak/IóÍžyÂâx)ár
@@ -64247,7 +64419,7 @@ magházak/IóÍžyÂâx)áz
 magburkok/IóÍžJyÂâÉx)
 magasvasutak/IóÍžyÂâx)útút
 magasságvonalak/IóÍžyÂâx)ágvonal
-madárkeserűfüvek/IóÍžyÂâx)árkeserűfű
+madárkeserűfüvek/IóÍžyÂâx)árkeserűfűár||keserű|fű
 madarak/IóÍžĆćşx)ár
 macskakövek/IóÍžyÂâx)ő
 macskagyökerek/IóÍžyÂâx)ökér
@@ -64260,9 +64432,9 @@ lövészgödrök/IóÍžJyÂâÉx)övészgödör
 lövegzárak/IóÍžyÂâx)övegzár
 lővonalak/IóÍžyÂâx)ővonal
 lőterek/IóÍžyÂâx)őtér
-lőportárak/IóÍžyÂâx)őportár
-lőporraktárak/IóÍžyÂâx)őporraktár
-lőporgyárak/IóÍžyÂâx)őporgyár
+lőportárak/IóÍžyÂâx)őportárő|por||tár
+lőporraktárak/IóÍžyÂâx)őporraktárő|por||rak|tár
+lőporgyárak/IóÍžyÂâx)őporgyárő|por||gyár
 lóvasutak/IóÍžyÂâx)óvasútó||vas|út
 lólábak/IóÍžyÂâx)óláb
 lóhátak/IóÍžyÂâx)óhát
@@ -64277,7 +64449,7 @@ légutak/IóÍžyÂâx)égút
 légterek/IóÍžyÂâx)égtér
 légiterek/IóÍžyÂâx)égitér
 légihidak/IóÍžyÂâx)égihíd
-légifuvardíjak/IóÍžyÂâx)égifuvardíj
+légifuvardíjak/IóÍžyÂâx)égifuvardíjégi||fuvar|díj
 légcsövek/IóÍžyÂâx)égcső
 lázak/IóÍžĆćşx)áz
 lávakövek/IóÍžyÂâx)ávakő
@@ -64290,7 +64462,7 @@ láncfonalak/IóÍžyÂâx)áncfonál
 lámpalázak/IóÍžyÂâx)ámpaláz
 lágyvasak/IóÍžyÂâx)ágyvas
 lágybogarak/IóÍžyÂâx)ágybogár
-lábujjkörmök/IóÍžJyÂâÉx)ábujjköröm
+lábujjkörmök/IóÍžJyÂâÉx)ábujjkörömáb|ujj||köröm
 lábujjak/IóÍžyÂâx)ábujj
 lábtövek/IóÍžyÂâx)ábtő
 lábszárak/IóÍžyÂâx)ábszár
@@ -64355,7 +64527,7 @@ középagyak/IóÍžyÂâx)özépagy
 közutak/IóÍžyÂâx)özút
 közterek/IóÍžyÂâx)öztér
 közszemérmek/IóÍžJyÂâÉx)özszeméremöz|szemérem
-közraktárak/IóÍžyÂâx)özraktár
+közraktárak/IóÍžyÂâx)özraktáröz||rak|tár
 közművek/IóÍžyÂâx)özmű
 közkegyelmek/IóÍžJyÂâÉx)özkegyelem
 közhatalmak/IóÍžJyÂâÉx)özhatalom
@@ -64396,13 +64568,13 @@ köblök/IóÍžJyÂâÉx)öböl
 kőzetburkok/IóÍžJyÂâÉx)őzetburok
 kővárak/IóÍžyÂâx)ővár
 kőutak/IóÍžyÂâx)őút
-kőtörőfüvek/IóÍžyÂâx)őtörőfű
+kőtörőfüvek/IóÍžyÂâx)őtörőfűő|törő||fű
 kőtárak/IóÍžyÂâx)őtár
-kőszínházak/IóÍžyÂâx)őszínház
+kőszínházak/IóÍžyÂâx)őszínháző||szín|ház
 kőszobrok/IóÍžJyÂâÉx)őszobor
 kőszenek/IóÍžyÂâx)őszén
 kőrisbogarak/IóÍžyÂâx)őrisbogár
-kőolajárak/IóÍžyÂâx)őolajár
+kőolajárak/IóÍžyÂâx)őolajárő|olaj||ár
 kőolajak/IóÍžyÂâx)őolaj
 kőkutak/IóÍžyÂâx)őkút
 kőkapcsok/IóÍžJyÂâÉx)őkapocs
@@ -64423,13 +64595,12 @@ kígyófüvek/IóÍžyÂâx)ígyófű
 kézíjak/IóÍžyÂâx)ézíj
 kézközepek/IóÍžyÂâx)ézközép
 kézitükrök/IóÍžJyÂâÉx)ézitükör
-kéziszótárak/IóÍžyÂâx)éziszótár
-kézipénztárak/IóÍžyÂâx)ézipénztár
-kézimunkakosarak/IóÍžyÂâx)ézimunkakosár
+kéziszótárak/IóÍžyÂâx)éziszótárézi||szó|tár
+kézipénztárak/IóÍžyÂâx)ézipénztárézi||pénz|tár
+kézimunkakosarak/IóÍžyÂâx)ézimunkakosárézi|munka||kosár
 kézikosarak/IóÍžyÂâx)ézikosár
 kézikerekek/IóÍžyÂâx)ézikerék
 kézbütykök/IóÍžJyÂâÉx)ézbütyök
-készpénzárak/IóÍžyÂâx)észpénzár
 késedelmek/IóÍžJĆćş´x)ésedelem
 kérgek/IóÍžJĆćş´x)éreg
 kérelmek/IóÍžJĆćş´x)érelem
@@ -64502,7 +64673,7 @@ klubházak/IóÍžyÂâx)áz
 kliensoldalak/IóÍžyÂâx)
 kiutak/IóÍžyÂâx)út
 kisőrlőfogak/IóÍžyÂâx)őrlőfog
-kisáruházak/IóÍžyÂâx)áruház
+kisáruházak/IóÍžyÂâx)áruházáru|ház
 kiságyak/IóÍžyÂâx)ágy
 kiszolgálóoldalak/IóÍžyÂâx)álóoldaláló||oldal
 kisvizek/IóÍžyÂâx)íz
@@ -64512,7 +64683,7 @@ kisujjak/IóÍžyÂâx)
 kistájak/IóÍžyÂâx)áj
 kistermek/IóÍžJyÂâÉx)
 kisszótárak/IóÍžyÂâx)ótáró|tár
-kispárlófüvek/IóÍžyÂâx)árlófű
+kispárlófüvek/IóÍžyÂâx)árlófűárló|fű
 kispoharak/IóÍžyÂâx)ár
 kisnyulak/IóÍžyÂâx)úl
 kismadarak/IóÍžyÂâx)ár
@@ -64521,12 +64692,12 @@ kiskölykök/IóÍžJyÂâÉx)ölyök
 kiskereskedelmek/IóÍžJyÂâÉx)
 kiskanalak/IóÍžyÂâx)ál
 kisholdak/IóÍžyÂâx)
-kishatárforgalmak/IóÍžJyÂâÉx)árforgalom
-kishaszonjárművek/IóÍžyÂâx)ármű
-kishaszongépjárművek/IóÍžyÂâx)épjármű
+kishatárforgalmak/IóÍžJyÂâÉx)árforgalomár||forgalom
+kishaszonjárművek/IóÍžyÂâx)árműármű
+kishaszongépjárművek/IóÍžyÂâx)épjárműép|jármű
 kishalak/IóÍžyÂâx)
 kisfazekak/IóÍžyÂâx)ék
-kisegyházak/IóÍžyÂâx)áz
+kisegyházak/IóÍžyÂâx)ázáz
 kisegerek/IóÍžyÂâx)ér
 kisdolgok/IóÍžyÂâx)
 kisajkak/IóÍžJyÂâÉx)
@@ -64534,7 +64705,7 @@ kisagyak/IóÍžyÂâx)
 kincstárak/IóÍžyÂâx)ár
 kincsestárak/IóÍžyÂâx)ár
 kincsesházak/IóÍžyÂâx)áz
-kilométerkövek/IóÍžyÂâx)éterkő
+kilométerkövek/IóÍžyÂâx)éterkőéter||kő
 kilincsművek/IóÍžyÂâx)ű
 kilincskerekek/IóÍžyÂâx)ék
 kilencedfelek/IóÍžyÂâx)él
@@ -64612,9 +64783,9 @@ kanalak/IóÍžĆćşx)ál
 kamionforgalmak/IóÍžJyÂâÉx)
 kamatlábak/IóÍžyÂâx)áb
 kallómalmok/IóÍžJyÂâÉx)ómalom
-kakukkszegfüvek/IóÍžyÂâx)ű
+kakukkszegfüvek/IóÍžyÂâx)űű
 kakukkfüvek/IóÍžyÂâx)ű
-kakaslábfüvek/IóÍžyÂâx)ábfű
+kakaslábfüvek/IóÍžyÂâx)ábfűáb||fű
 kagylóhéjak/IóÍžyÂâx)óhéj
 kabátlyukak/IóÍžyÂâx)átlyuk
 kabasólymok/IóÍžJyÂâÉx)ólyom
@@ -64632,7 +64803,7 @@ játékterek/IóÍžyÂâx)átéktér
 játszóterek/IóÍžyÂâx)átszótér
 jászlak/IóÍžJĆćş´x)ászol
 jáspiskövek/IóÍžyÂâx)áspiskő
-járványkórházak/IóÍžyÂâx)árványkórház
+járványkórházak/IóÍžyÂâx)árványkórházárvány||kór|ház
 járművek/IóÍžyÂâx)ármű
 jármok/IóÍžJĆćş´x)árom
 járlatlevelek/IóÍžyÂâx)árlatlevél
@@ -64644,11 +64815,12 @@ jogágak/IóÍžyÂâx)ág
 jobbszárnyak/IóÍžyÂâx)árny
 jobboldalak/IóÍžyÂâx)
 jobbközepek/IóÍžyÂâx)özép
+jobbhorgok/IóÍžJyÂâÉx)
 jelzőtüzek/IóÍžyÂâx)őtűz
 jelszavak/IóÍžyÂâx)ó
 jegyárak/IóÍžyÂâx)ár
 jegyzőurak/wIóÍžĆćşx)őúr
-jegypénztárak/IóÍžyÂâx)énztár
+jegypénztárak/IóÍžyÂâx)énztárénz|tár
 jegenyenyárak/IóÍžyÂâx)ár
 jegek/IóÍžĆćşx)ég
 javadalmak/IóÍžJĆćş´x)
@@ -64698,14 +64870,14 @@ idegenforgalmak/IóÍžJyÂâÉx)
 idegen_szavak/IóÍžĆćşx)ó
 hüvelykujjak/IóÍžyÂâx)üvelykujj
 hűtővizek/IóÍžyÂâx)űtővíz
-hűbérurak/IóÍžyÂâx)űbérúr
+hűbérurak/IóÍžyÂâx)űbérúrű|bér||úr
 húsosfazekak/IóÍžyÂâx)úsosfazék
 húslevek/IóÍžyÂâx)úslé
 húslegyek/IóÍžyÂâx)úslégy
 húgycsövek/IóÍžyÂâx)úgycső
 hőárak/IóÍžyÂâx)őár
 hőhidak/IóÍžyÂâx)őhíd
-hőerőművek/IóÍžyÂâx)őerőmű
+hőerőművek/IóÍžyÂâx)őerőműő||erő|mű
 hődíjak/IóÍžyÂâx)ődíj
 hőcsövek/IóÍžyÂâx)őcső
 hótalpak/IóÍžyÂâx)ótalp
@@ -64723,7 +64895,7 @@ héjak/IóÍžĆćşx)éj
 házormok/IóÍžJyÂâÉx)ázorom
 házivásznak/IóÍžJyÂâÉx)ázivászon
 háziurak/IóÍžyÂâx)áziúr
-házipénztárak/IóÍžyÂâx)ázipénztár
+házipénztárak/IóÍžyÂâx)ázipénztárázi||pénz|tár
 házilegyek/IóÍžĆćşx)ázilégy
 házikenyerek/IóÍžyÂâx)ázikenyér
 házi_nyulak/IóÍžyÂâx)ázi_nyúl
@@ -64773,7 +64945,7 @@ hiedelmek/IóÍžJĆćş´x)
 hidegtálak/IóÍžyÂâx)ál
 hideglázak/IóÍžyÂâx)áz
 hidegházak/IóÍžyÂâx)áz
-hideghengerművek/IóÍžyÂâx)ű
+hideghengerművek/IóÍžyÂâx)űű
 hideg_vizek/IóÍž)íz
 hidak/IóÍžĆćşx)íd
 hexándisavak/IóÍžyÂâx)ándisav
@@ -64787,7 +64959,7 @@ hernyóselymek/IóÍžJyÂâÉx)óselyem
 hengerművek/IóÍžyÂâx)ű
 hengeresférgek/IóÍžJyÂâÉx)éreg
 helyárak/IóÍžyÂâx)ár
-helységnévtárak/IóÍžyÂâx)égnévtár
+helységnévtárak/IóÍžyÂâx)égnévtárég|név||tár
 helységnevek/IóÍžyÂâx)égnév
 helynevek/IóÍžyÂâx)év
 hegyoldalak/IóÍžyÂâx)
@@ -64845,26 +65017,26 @@ hagymázak/IóÍžĆćşx)áz
 hadurak/IóÍžyÂâx)úr
 hadiutak/IóÍžyÂâx)út
 hadititkok/IóÍžJyÂâÉx)
-hadipénztárak/IóÍžyÂâx)énztár
-hadilevéltárak/IóÍžyÂâx)éltár
-hadikórházak/IóÍžyÂâx)órház
+hadipénztárak/IóÍžyÂâx)énztárénz|tár
+hadilevéltárak/IóÍžyÂâx)éltárél|tár
+hadikórházak/IóÍžyÂâx)órházór|ház
 hadifoglyok/IóÍžJyÂâÉx)
-hadiemlékművek/IóÍžyÂâx)ékmű
+hadiemlékművek/IóÍžyÂâx)ékműék|mű
 hadak/IóÍžĆćşx)
-habszegfüvek/IóÍžyÂâx)ű
+habszegfüvek/IóÍžyÂâx)űű
 habkövek/IóÍžyÂâx)ő
 güzüegerek/IóÍžyÂâx)üzüegér
 görögtüzek/IóÍžyÂâx)örögtűz
 görvélyfüvek/IóÍžyÂâx)örvélyfű
-görgőscsapágyak/IóÍžyÂâx)örgőscsapágy
+görgőscsapágyak/IóÍžyÂâx)örgőscsapágyörgős||csap|ágyörgős||csap|ágyak
 görgetegkövek/IóÍžyÂâx)örgetegkő
 gödrök/IóÍžJĆćş´x)ödör
 górcsövek/IóÍžyÂâx)órcső
 gólyalábak/IóÍžyÂâx)ólyaláb
 géptermek/IóÍžJyÂâÉx)épterem
 gépszíjak/IóÍžyÂâx)épszíj
-gépkenőolajak/IóÍžyÂâx)épkenőolaj
-gépjárművek/IóÍžyÂâx)épjármű
+gépkenőolajak/IóÍžyÂâx)épkenőolajép||kenő|olaj
+gépjárművek/IóÍžyÂâx)épjárműép||jár|mű
 gépházak/IóÍžyÂâx)épház
 gémeskutak/IóÍžyÂâx)émeskút
 gégetükrök/IóÍžJyÂâÉx)égetükör
@@ -64893,7 +65065,7 @@ gyökerek/xIóÍžĆćş)ökér
 győzelmek/IóÍžJĆćş´x)őzelem
 győzedelmek/IóÍžJĆćş´x)őzedelem
 gyógyvizek/IóÍžyÂâx)ógyvíz
-gyógyszerárak/IóÍžyÂâx)ógyszerár
+gyógyszerárak/IóÍžyÂâx)ógyszerárógy|szer||ár
 gyógyszertárak/IóÍžyÂâx)ógyszertár
 gyógykenyerek/IóÍžyÂâx)ógykenyér
 gyógyfüvek/IóÍžyÂâx)ógyfű
@@ -64917,7 +65089,7 @@ gyilkok/IóÍžJĆćş´x)
 gyertyalábak/IóÍžyÂâx)áb
 gyertyabelek/IóÍžyÂâx)él
 gyermekágyak/IóÍžyÂâx)ágy
-gyermekláncfüvek/IóÍžyÂâx)áncfű
+gyermekláncfüvek/IóÍžyÂâx)áncfűánc||fű
 gyapjúfonalak/IóÍžyÂâx)úfonál
 gyaluvasak/IóÍžyÂâx)
 gyalogutak/IóÍžyÂâx)út
@@ -64930,7 +65102,7 @@ gubacsdarazsak/IóÍžyÂâx)ázs
 gomblyukak/IóÍžyÂâx)
 golyóstollak/IóÍžyÂâx)óstoll
 golyósmalmok/IóÍžJyÂâÉx)ósmalom
-golyóscsapágyak/IóÍžyÂâx)óscsapágy
+golyóscsapágyak/IóÍžyÂâx)óscsapágyós||csap|ágy
 glükonsavak/IóÍžyÂâx)ükonsav
 glutársavak/IóÍžyÂâx)ársav
 ginszenggyökerek/IóÍžyÂâx)ökérökér
@@ -64974,14 +65146,14 @@ főurak/IóÍžyÂâx)őúr
 főtárgyak/IóÍžyÂâx)őtárgy
 főtárak/IóÍžyÂâx)őtár
 főterek/IóÍžyÂâx)őtér
-főszékesegyházak/IóÍžyÂâx)őszékesegyház
+főszékesegyházak/IóÍžyÂâx)őszékesegyháző||székes||egy|ház
 főszerkesztőurak/wIóÍžĆćşx)őszerkesztőúr
-főrendiházak/IóÍžyÂâx)őrendiház
+főrendiházak/IóÍžyÂâx)őrendiháző|rendi||ház
 főorvosurak/wIóÍžĆćşx)őorvosúr
 főoltárak/IóÍžyÂâx)őoltár
 főoldalak/IóÍžyÂâx)őoldal
 főnevek/IóÍžyÂâx)őnév
-főmunkatársak/IóÍžyÂâx)őmunkatárs
+főmunkatársak/IóÍžyÂâx)őmunkatárső||munka|társ
 főkegyurak/IóÍžyÂâx)őkegyúrő||kegy|úr
 főigazgatóurak/wIóÍžĆćşx)őigazgatóúr
 főhatalmak/IóÍžJyÂâÉx)őhatalom
@@ -65000,7 +65172,6 @@ fénymázak/IóÍžyÂâx)énymáz
 fémrudak/IóÍžyÂâx)émrúd
 fémpoharak/IóÍžyÂâx)émpohár
 fémművek/IóÍžyÂâx)émmű
-félárak/IóÍžyÂâx)élár
 félutak/IóÍžyÂâx)élút
 félselymek/IóÍžJyÂâÉx)élselyem
 félmúltak/IóÍžyÂâx)élmúlt
@@ -65069,7 +65240,7 @@ fenyérfüvek/IóÍžyÂâx)érfű
 fenekek/IóÍžĆćşx)ék
 felárak/IóÍžyÂâx)ár
 felvonóhidak/IóÍžyÂâx)óhíd
-felsőkarizmok/IóÍžJyÂâÉx)őkarizom
+felsőkarizmok/IóÍžJyÂâÉx)őkarizomő||kar|izom
 felsőházak/IóÍžyÂâx)őház
 felsálak/IóÍžĆćşx)ál
 felszállóágak/wIóÍžyÂâx)állóág
@@ -65080,7 +65251,7 @@ felek/IóÍžĆćşx)él
 feketeárak/IóÍžyÂâx)ár
 feketeszázak/IóÍžyÂâx)áz
 feketeszenek/IóÍžyÂâx)én
-feketekőszenek/IóÍžyÂâx)őszén
+feketekőszenek/IóÍžyÂâx)őszénő|szén
 feketekereskedelmek/IóÍžJyÂâÉx)
 feketejövedelmek/IóÍžJyÂâÉx)övedelem
 feketegyökerek/IóÍžyÂâx)ökér
@@ -65093,7 +65264,7 @@ fehérmájak/IóÍžyÂâx)érmáj
 fehérgyökerek/IóÍžyÂâx)érgyökér
 fehéraranyak/IóÍžyÂâx)érarany
 fegyvertermek/IóÍžJyÂâÉx)
-fegyverraktárak/IóÍžyÂâx)ár
+fegyverraktárak/IóÍžyÂâx)árár
 fegyvergyárak/IóÍžyÂâx)ár
 fegyházak/IóÍžyÂâx)áz
 fegyelmek/IóÍžJĆćş´x)
@@ -65120,7 +65291,7 @@ falsarkak/IóÍžJyÂâÉx)
 falovak/IóÍžyÂâx)ó
 falkapcsok/IóÍžJyÂâÉx)
 falitükrök/IóÍžJyÂâÉx)ükör
-falinaptárak/IóÍžyÂâx)ár
+falinaptárak/IóÍžyÂâx)árár
 falikutak/IóÍžyÂâx)út
 falevelek/IóÍžyÂâx)él
 falak/IóÍžĆćşx)
@@ -65158,7 +65329,7 @@ elősátrak/IóÍžJyÂâÉx)ősátor
 előszelek/IóÍžyÂâx)őszél
 előszavak/IóÍžyÂâx)őszó
 előoldalak/IóÍžyÂâx)őoldal
-előnyugdíjak/IóÍžyÂâx)őnyugdíj
+előnyugdíjak/IóÍžyÂâx)őnyugdíjő||nyug|díj
 előnevek/IóÍžyÂâx)őnév
 előhadak/IóÍžyÂâx)őhad
 előfenekek/IóÍžyÂâx)őfenék
@@ -65178,15 +65349,14 @@ ekevasak/IóÍžyÂâx)
 ekeszarvak/IóÍžyÂâx)
 egérutak/IóÍžyÂâx)érút
 egérlyukak/IóÍžyÂâx)érlyuk
-egérfarkfüvek/IóÍžyÂâx)érfarkfű
-egárfarkfüvek/IóÍžyÂâx)árfarkfű
+egérfarkfüvek/IóÍžyÂâx)érfarkfűér|fark||fű
 egységárak/IóÍžyÂâx)égár
 egyházak/IóÍžyÂâx)áz
 egyebek/IóÍž)éb
 egerek/IóÍžĆćşx)ér
 egek/IóÍžĆćşxég
 ebszékfüvek/IóÍžyÂâx)ékfű
-ebnyelvfüvek/IóÍžyÂâx)ű
+ebnyelvfüvek/IóÍžyÂâx)űű
 ebihalak/IóÍžyÂâx)
 dúvadak/IóÍžyÂâx)úvad
 dörzsárak/IóÍžyÂâx)örzsár
@@ -65202,9 +65372,10 @@ dárdanyelek/IóÍžyÂâx)árdanyél
 dámvadak/IóÍžyÂâx)ámvad
 duzzasztóművek/IóÍžyÂâx)ómű
 duzzasztógátak/IóÍžyÂâx)ógát
-durvahengerművek/IóÍžyÂâx)ű
+durvahengerművek/IóÍžyÂâx)űű
 durumkenyerek/IóÍžĆćşx)ér
 dunnaludak/IóÍžyÂâx)úd
+dugaljak/IóÍžyÂâx)
 drótkötelek/IóÍžyÂâx)ótkötél
 drótkapcsok/IóÍžJyÂâÉx)ótkapocs
 drótférgek/IóÍžJyÂâÉx)ótféreg
@@ -65221,7 +65392,7 @@ dióhéjak/IóÍžyÂâx)óhéj
 disznóólak/IóÍžyÂâx)óól
 disznóférgek/IóÍžJyÂâÉx)óféreg
 diliházak/IóÍžyÂâx)áz
-dikrómsavak/IóÍžyÂâx)ómsav
+dikrómsavak/IóÍžyÂâx)ómsavóm||sav
 dikarbonsavak/IóÍžyÂâx)
 differenciálművek/IóÍžyÂâx)álmű
 dicsvágyak/IóÍžyÂâx)ágy
@@ -65298,8 +65469,8 @@ csalimadarak/IóÍžyÂâx)ár
 citromlevek/IóÍžyÂâx)é
 citromfüvek/IóÍžyÂâx)ű
 cirkalmak/IóÍžJĆćş´x)
-cipőfénymázak/IóÍžyÂâx)őfénymáz
-cipőegységárak/IóÍžyÂâx)őegységár
+cipőfénymázak/IóÍžyÂâx)őfénymáző||fény|máz
+cipőegységárak/IóÍžyÂâx)őegységárő||egység|ár
 cipészárak/IóÍžyÂâx)észár
 cipészhurkok/IóÍžJyÂâÉx)észhurok
 cipészfonalak/IóÍžyÂâx)észfonál
@@ -65325,13 +65496,14 @@ búzafüvek/IóÍžyÂâx)úzafű
 búvólyukak/IóÍžyÂâx)úvólyuk
 búvármadarak/IóÍžyÂâx)úvármadár
 búvárludak/IóÍžyÂâx)úvárlúd
-bútorraktárak/IóÍžyÂâx)útorraktár
+bútorraktárak/IóÍžyÂâx)útorraktárútor||rak|tár
 búcsúpoharak/IóÍžyÂâx)úcsúpohár
 bölcsességfogak/IóÍžyÂâx)ölcsességfog
 bölcselmek/IóÍžJĆćş´x)ölcselem
 böglyök/IóÍžJĆćş´x)ögöly
 bőrgyárak/IóÍžyÂâx)őrgyár
 bírvágyak/IóÍžyÂâx)írvágy
+bérmanevek/xIóÍžyÂâ)érmanév
 bérjövedelmek/IóÍžJyÂâÉx)érjövedelem
 bérházak/IóÍžyÂâx)érház
 bélsarak/IóÍžyÂâx)élsár
@@ -65345,7 +65517,7 @@ bántalmak/IóÍžJĆćş´x)ántalom
 báltermek/IóÍžJyÂâÉx)álterem
 bálnaolajak/IóÍžyÂâx)álnaolaj
 bájak/IóÍžĆćşx)áj
-bábszínházak/IóÍžyÂâx)ábszínház
+bábszínházak/IóÍžyÂâx)ábszínházáb||szín|ház
 buzgalmak/IóÍžJĆćş´x)
 buvákfüvek/IóÍžyÂâx)ákfű
 butánsavak/IóÍžyÂâx)ánsav
@@ -65410,12 +65582,12 @@ bekötőutak/IóÍžyÂâx)ötőút
 becsületszavak/IóÍžyÂâx)ületszó
 becsvágyak/IóÍžyÂâx)ágy
 becenevek/IóÍžyÂâx)év
-barátszegfüvek/IóÍžyÂâx)átszegfű
+barátszegfüvek/IóÍžyÂâx)átszegfűát||szeg|fű
 barnaszenek/IóÍžyÂâx)én
 barnakövek/IóÍžyÂâx)ő
 barnakőszenek/IóÍžyÂâx)őszén
 barmok/IóÍžJĆćş´x)
-barkácsáruházak/IóÍžyÂâx)ácsáruház
+barkácsáruházak/IóÍžyÂâx)ácsáruházács||áru|ház
 barkácssarkak/IóÍžJyÂâÉx)ácssarok
 baritvizek/IóÍžyÂâx)íz
 barbitursavak/IóÍžyÂâx)
@@ -65428,19 +65600,20 @@ balszárnyak/IóÍžyÂâx)árny
 balsejtelmek/IóÍžJyÂâÉx)
 baloldalak/IóÍžyÂâx)
 balközepek/IóÍžyÂâx)özép
+balhorgok/IóÍžJyÂâÉx)
 balhiedelmek/IóÍžJyÂâÉx)
 bakterházak/IóÍžyÂâx)áz
 bakszakállak/IóÍžyÂâx)áll
 bakhátak/IóÍžyÂâx)át
 bakfüvek/IóÍžyÂâx)ű
-bajuszoskásafüvek/IóÍžyÂâx)ásafű
+bajuszoskásafüvek/IóÍžyÂâx)ásafűása|fű
 bajuszfüvek/IóÍžyÂâx)ű
 bajszok/IóÍžJĆćş´x)
 baglyok/IóÍžJĆćş´x)
 babérfüzek/IóÍžyÂâx)érfűz
 autóutak/IóÍžyÂâx)óút
 aukciósházak/IóÍžyÂâx)ósház
-aszúszegfüvek/IóÍžyÂâx)úszegfű
+aszúszegfüvek/IóÍžyÂâx)úszegfűú||szeg|fű
 aszparaginsavak/IóÍžyÂâx)
 aszkorbinsavak/IóÍžyÂâx)
 aszfaltutak/IóÍžyÂâx)út
@@ -65458,8 +65631,8 @@ apróvadak/IóÍžyÂâx)óvad
 aprószenek/IóÍžyÂâx)ószén
 apróhalak/IóÍžyÂâx)óhal
 anyaölek/IóÍž)öl
-anyagraktárak/IóÍžyÂâx)ár
-anyaegyházak/IóÍžyÂâx)áz
+anyagraktárak/IóÍžyÂâx)árár
+anyaegyházak/IóÍžyÂâx)ázáz
 antennatornyok/IóÍžJyÂâÉx)
 angyalgyökerek/IóÍžyÂâx)ökér
 aminosavak/IóÍžyÂâx)
@@ -65474,7 +65647,7 @@ almok/IóÍžJĆćş´x)
 almedrek/IóÍžJyÂâÉx)
 almalevek/IóÍžyÂâx)é
 allevelek/IóÍžyÂâx)él
-alkönyvtárak/IóÍžyÂâx)önyvtár
+alkönyvtárak/IóÍžyÂâx)önyvtárönyv|tár
 alkuszdíjak/IóÍžyÂâx)íj
 alkancellárurak/wIóÍžĆćşx)árúr
 alkalmak/IóÍžJĆćş´x)
@@ -65494,7 +65667,7 @@ aknatornyok/IóÍžJyÂâÉx)
 aklok/IóÍžJĆćş´x)
 akasztókapcsok/IóÍžJyÂâÉx)ókapocs
 akasztóhorgok/IóÍžJyÂâÉx)óhorog
-akasztófakötelek/IóÍžyÂâx)ófakötél
+akasztófakötelek/IóÍžyÂâx)ófakötéló|fa||kötél
 akantuszlevelek/IóÍžyÂâx)él
 ajánlólevelek/IóÍžyÂâx)ánlólevél
 ajkak/IóÍžJĆćş´x)
@@ -65502,6 +65675,7 @@ agyerek/IóÍžyÂâx)ér
 agyarak/IóÍžĆćşx)
 agyak/IóÍžĆćşx)
 agyagtálak/IóÍžyÂâx)ál
+agyaggátak/IóÍžyÂâx)át
 aggófüvek/IóÍžyÂâx)ófű
 aggodalmak/IóÍžJĆćş´x)
 agarak/IóÍžĆćşx)ár
@@ -66190,16 +66364,16 @@ billiomod/v)ó
 üzleti/ąBÓŐĐGVËR
 üzemmeleg/Ó×GVËnňLRTtląy
 üzemkész/Ó×GVËnňLTtlą
-üzemképtelen/Ó×GVËnňLRlą
+üzemképtelen/Ó×GVËnňLRląy
 üzemi/ąBÓŐĐGVËR
-üzembiztos/ŇŮFUÎmôSsk°
+üzembiztos/ŇŮFUÎmôSsk°y
 üzbéggyűlölő/CÔŐŢHWĚR
 üzbégellenes/Ó×GVËnňLTtl
 üzbégcentrikus/ŇŮFUÎmôKÖSsk
 üzbégbarát/ŇŮFUÎmôKÖQk
 üzbég/Ó×GVËnňLRlą
 üvegzöld/Ô×ÝňGVĚNRlą
-üvegházhatású/°yAŇŐĎFUÎQ
+üvegházhatású/°yAŇŐĎFUÎQüveg|ház||hatású
 üvegezetlen/Ó×GVËnňLRlą
 üveges/Ó×GVËnňLTtlą
 ütőéri/ąBÓŐĐGVËR
@@ -66226,13 +66400,13 @@ billiomod/v)ó
 üldözött/Ô×ÝňGVĚNRlą
 ügyvivő/ąyCÔŐŢHWĚR
 ügyvezető/ąCÔŐŢHWĚRügyvezetőváltás> <*ügyvezetőigazgató>
-ügyfélorientált/ŇŮFUÎmôQk°
-ügyfélkapcsolati/°AŇŐĎFUÎQ
+ügyfélorientált/ŇŮFUÎmôQk°y
+ügyfélkapcsolati/°yAŇŐĎFUÎQ
 ügyféli/ąBÓŐĐGVËR
 ügyetlenke/ąBÓŐĐGVËR
 ügyetlen/Ó×GVËnňLRlą
 ügyes/Ó×GVËnňLTtlą
-ügyefogyott/ŇŮFUÎmôQk°sX
+ügyefogyott/ŇŮFUÎmôQk°ysX
 ügybuzgó/°AŇŐĎFUÎQ
 üdvözült/Ô×ÝňGVĚNRlą
 üdvözlő/ąXCÔŐŢHWĚR
@@ -66255,7 +66429,7 @@ billiomod/v)ó
 úthasználó/°AŇŐĎFUÎQ
 úszólábú/°AŇŐĎFUÎQ
 úszóképes/Ó×GVËnňLTtlą
-úszóhártyás/ŇŮFUÎmôKÖSsk°
+úszóhártyás/ŇŮFUÎmôKÖSsk°y
 úrias/ŇŮFUÎmôKÖSsk°
 újsütetű/ąCÔŐŢHWĚR
 újságírói/°AŇŐĎFUÎQ
@@ -66273,7 +66447,7 @@ billiomod/v)ó
 újlatin/ŇŮFUÎmôKÖQk°
 újkonzervatív/ŇŮFUÎmôKÖSsk°
 újkeresztény/Ó×GVËnňLTtlą
-újjászületett/Ó×GVËnňLRlą
+újjászületett/Ó×GVËnňLRląy
 újhitű/ąCÔŐŢHWĚR
 újgótikus/ŇŮFUÎmôKÖSsk°
 újféle/ąBÓŐĐGVËR
@@ -66345,14 +66519,14 @@ billiomod/v)ó
 összpárti/°yAŇŐĎFUÎQ
 összpiaci/°yAŇŐĎFUÎQ
 összparlamenti/ąyBÓŐĐGVËR
-összoroszországi/°yAŇŐĎFUÎQ
+összoroszországi/°yAŇŐĎFUÎQössz||orosz|országi
 összorosz/ŇŮFUÎmôKÖSsk°y
 összoktatói/°yAŇŐĎFUÎQ
 össznépi/ąyBÓŐĐGVËR
 össznémet/Ó×GVËnňLRląy
 össznemzeti/ąBÓŐĐGVËR
 összmagyar/ŇŮFUÎmôKÖQk°
-összkülföldi/ąyBÓŐĐGVËR
+összkülföldi/ąyBÓŐĐGVËRössz||kül|földi
 összközműves/Ó×GVËnňLTtlą
 összkomfortos/ŇŮFUÎmôKÖSsk°
 összkerék-meghajtású/°AŇŐĎFUÎQ
@@ -66365,56 +66539,56 @@ billiomod/v)ó
 összhangtalan/ŇŮFUÎmôKÖQk°
 összhallgatói/°yAŇŐĎFUÎQ
 összgazdasági/°BÓŐĐGVËR
-összfővárosi/°yAŇŐĎFUÎQ
-összfőiskolai/°yAŇŐĎFUÎQ
+összfővárosi/°yAŇŐĎFUÎQössz||fő|városi
+összfőiskolai/°yAŇŐĎFUÎQössz||fő|iskolai
 összfegyvernemi/ąBÓŐĐGVËR
-összeöltött/Ô×ÝňGVĚNRlą
-összeállított/ŇŮFUÎmôQk°sX
-összezsúfolt/ŇŮFUÎmôQk°
-összezsugorodott/ŇŮFUÎmôQk°sX
-összezavart/ŇŮFUÎmôKÖQk°
+összeöltött/Ô×ÝňGVĚNRląy
+összeállított/ŇŮFUÎmôQk°ysX
+összezsúfolt/ŇŮFUÎmôQk°y
+összezsugorodott/ŇŮFUÎmôQk°ysX
+összezavart/ŇŮFUÎmôKÖQk°y
 összevont/ŇŮFUÎmôKÖQk°
-összevissza/°AŇŐĎFUÎQ	ph:össze-vissza*
+összevissza/°yAŇŐĎFUÎQ	ph:össze-vissza*
 összevert/Ó×GVËnňLRlą
 összevaló/°AŇŐĎFUÎQ
 összeurópai/°AŇŐĎFUÎQ
-összeugrott/ŇŮFUÎmôQk°sX
+összeugrott/ŇŮFUÎmôQk°ysX
 összetett/Ó×GVËnňLRlą
 összes/Ó×GVËnňLTtlą
-összeráncolt/ŇŮFUÎmôQk°
+összeráncolt/ŇŮFUÎmôQk°y
 összerakós/ŇŮFUÎmôKÖSsk°
-összeomlott/ŇŮFUÎmôQk°sX
-összenyomhatatlan/ŇŮFUÎmôKÖQk°
-összemérhetetlen/Ó×GVËnňLRlą
+összeomlott/ŇŮFUÎmôQk°ysX
+összenyomhatatlan/ŇŮFUÎmôKÖQk°y
+összemérhetetlen/Ó×GVËnňLRląy
 összement/Ó×GVËnňLRlą
 összemberi/ąBÓŐĐGVËR
-összekuszált/ŇŮFUÎmôQk°
-összekapkodott/ŇŮFUÎmôQk°sX
-összekapcsolt/ŇŮFUÎmôQk°
+összekuszált/ŇŮFUÎmôQk°y
+összekapkodott/ŇŮFUÎmôQk°ysX
+összekapcsolt/ŇŮFUÎmôQk°y
 összeillő/ąCÔŐŢHWĚR
-összehasonlíthatatlan/ŇŮFUÎmôKÖQk°
+összehasonlíthatatlan/ŇŮFUÎmôKÖQk°y
 összehangolatlan/ŇŮFUÎmôKÖQk°
 összegző/XCÔŐŢHWĚR
 összegzendő/ąCÔŐŢHWĚR
-összegyűjtött/Ô×ÝňGVĚNRlą
+összegyűjtött/Ô×ÝňGVĚNRląy
 összegyetemi/ąyBÓŐĐGVËR
 összegező/ąXCÔŐŢHWĚR
 összefüggéstelen/Ó×GVËnňLRlą
 összeférhető/ąCÔŐŢHWĚR
-összeférhetetlen/Ó×GVËnňLRlą
+összeférhetetlen/Ó×GVËnňLRląy
 összeforrott/ŇŮFUÎmôQk°sX
-összeforratlan/ŇŮFUÎmôKÖQk°
-összeforrasztott/ŇŮFUÎmôQk°sX
+összeforratlan/ŇŮFUÎmôKÖQk°y
+összeforrasztott/ŇŮFUÎmôQk°ysX
 összefont/ŇŮFUÎmôKÖQk°
 összefolyó/°AŇŐĎFUÎQ
-összefogott/ŇŮFUÎmôQk°sX
-összefoglalva/°AŇŐĎFUÎQ
-összefoglalt/ŇŮFUÎmôQk°
-összeegyeztethető/ąCÔŐŢHWĚR
-összeegyeztethetetlen/Ó×GVËnňLRlą
-összecsavart/ŇŮFUÎmôKÖQk°
-összecsapott/ŇŮFUÎmôQk°sX
-összeaszott/ŇŮFUÎmôQk°sX
+összefogott/ŇŮFUÎmôQk°ysX
+összefoglalva/°yAŇŐĎFUÎQ
+összefoglalt/ŇŮFUÎmôQk°y
+összeegyeztethető/ąyCÔŐŢHWĚR
+összeegyeztethetetlen/Ó×GVËnňLRląy
+összecsavart/ŇŮFUÎmôKÖQk°y
+összecsapott/ŇŮFUÎmôQk°ysX
+összeaszott/ŇŮFUÎmôQk°ysX
 összdolgozói/°AŇŐĎFUÎQ
 összcéges/Ó×GVËnňLTtląy
 összbírói/°yAŇŐĎFUÎQ
@@ -66436,8 +66610,8 @@ billiomod/v)ó
 örökletes/Ó×GVËnňLTtlą
 örökkévaló/°AŇŐĎFUÎQ
 örökifjú/°AŇŐĎFUÎQ
-örökbefogadó/°AŇŐĎFUÎQ
-örökbefogadott/ŇŮFUÎmôQk°sX
+örökbefogadó/°yAŇŐĎFUÎQ
+örökbefogadott/ŇŮFUÎmôQk°ysX
 örök_érvényű/ąCÔŐŢHWĚR	örökérvényűbbenörökérvényűbb
 örök/Ô×ÝňGVĚNMRlą
 örvös/Ô×ÝňGVĚNMTtlą
@@ -66450,13 +66624,13 @@ billiomod/v)ó
 öreguras/ŇŮFUÎmôKÖSsk°
 öreges/Ó×GVËnňLTtlą
 öregecske/ąBÓŐĐGVËR
-öregasszonyos/ŇŮFUÎmôKÖSsk°
+öregasszonyos/ŇŮFUÎmôKÖSsk°y
 öreg/Ó×GVËnňLRTtlą
 ördöngös/Ô×ÝňGVĚNMTtlą
 ördögi/ąBÓŐĐGVËR
 önös/Ô×ÝňGVĚNMTtlą
 önérzetes/Ó×GVËnňLTtlą
-önérvényesítő/ąCÔŐŢHWĚR
+önérvényesítő/ąyCÔŐŢHWĚR
 önértékelő/ąCÔŐŢHWĚR
 önéletrajzi/°AŇŐĎFUÎQ
 önállótlan/ŇŮFUÎmôKÖQk°
@@ -66515,7 +66689,7 @@ billiomod/v)ó
 önhitt/Ó×GVËnňLRlą
 önhatalmú/°AŇŐĎFUÎQ
 öngyógyító/°AŇŐĎFUÎQ
-öngyilkos/ŇŮFUÎmôKÖSsk°
+öngyilkos/ŇŮFUÎmôKÖSsk°y
 öngerjesztő/ąCÔŐŢHWĚR
 önfoglalkoztató/°AŇŐĎFUÎQ
 önfinanszírozó/°AŇŐĎFUÎQ
@@ -66533,8 +66707,8 @@ billiomod/v)ó
 önellenőrző/ąCÔŐŢHWĚR
 önelemző/ąCÔŐŢHWĚR
 önduális/ŇŮFUÎmôKÖSsk°
-önbizalom-hiányos/ŇŮFUÎmôKÖSsk°y
-önbeteljesítő/ąCÔŐŢHWĚR
+önbizalom-hiányos/ŇŮFUÎmôKÖSsk°yön|bizalom-hiányos
+önbeteljesítő/ąyCÔŐŢHWĚR
 önbecsülő/ąCÔŐŢHWĚR
 önazonos/ŇŮFUÎmôKÖSsk°y
 önadózó/°AŇŐĎFUÎQ
@@ -66610,8 +66784,8 @@ billiomod/v)ó
 ómagyarcentrikus/ŇŮFUÎmôKÖSsk
 ómagyarbarát/ŇŮFUÎmôKÖQk
 ómagyar/°y
-ólomérzékeny/Ó×GVËnňLTtlą
-ólomszürke/ąBÓŐĐGVËR
+ólomérzékeny/Ó×GVËnňLTtląy
+ólomszürke/ąyBÓŐĐGVËR
 ólomszínű/ąCÔŐŢHWĚR
 ólomfehér/Ó×GVËnňLRlą
 ólmos/ŇŮFUÎmôKÖSsk°
@@ -66651,7 +66825,7 @@ billiomod/v)ó
 írásvédett/Ó×GVËnňLRlą
 írástudói/°AŇŐĎFUÎQ
 írástudó/°AŇŐĎFUÎQ
-írástudatlan/ŇŮFUÎmôKÖQk°
+írástudatlan/ŇŮFUÎmôKÖQk°y
 írásos/ŇŮFUÎmôKÖSsk°
 írásbeli/ąBÓŐĐGVËR
 írott/ŇŮFUÎmôQk°sX
@@ -66673,28 +66847,28 @@ billiomod/v)ó
 évekbeli/ąBÓŐĐGVËR
 év_végi/ąBÓŐĐGVËR
 étvágytalan/ŇŮFUÎmôKÖQk°
-étvágygerjesztő/ąCÔŐŢHWĚR
+étvágygerjesztő/ąyCÔŐŢHWĚRét|vágy||gerjesztő
 éti/ąBÓŐĐGVËR
 éteri/ąBÓŐĐGVËR
-ételérzékeny/Ó×GVËnňLTtlą
+ételérzékeny/Ó×GVËnňLTtląy
 észszerűtlen/Ó×GVËnňLRlą	ph:ésszerűtlen
 észszerű/ąCÔŐŢHWĚR	ph:ésszerű
-észrevétlen/Ó×GVËnňLRlą
+észrevétlen/Ó×GVËnňLRląy
 észrevevő/ąXYCÔŐŢHWĚRészreveszÓ_PRESPART_adj
 észrevevő/ąXYCÔŐŢHWĚR
 észrevett/Ó×GVËnňRlątXészrevesz
 észrevett/Ó×GVËnňRlątX
-észrevehető/ąXCÔŐŢHWĚRészreveszÓ_ABLE_(adj,present_part)
-észrevehető/ąXCÔŐŢHWĚR
-észrevehetetlen/Ó×GVËnňLRląXészrevesz
-észrevehetetlen/Ó×GVËnňLRląX
+észrevehető/ąyXCÔŐŢHWĚRészreveszÓ_ABLE_(adj,present_part)
+észrevehető/ąyXCÔŐŢHWĚR
+észrevehetetlen/Ó×GVËnňLRląyXészrevesz
+észrevehetetlen/Ó×GVËnňLRląyX
 észreveendő/XCÔŐŢHWĚRészreveszÓ_FUTPART_adj
 észbeli/ąBÓŐĐGVËR
 északír/Ó×GVËnňLRlą
-északvidéki/ąBÓŐĐGVËR
+északvidéki/ąyBÓŐĐGVËR
 északsarki/°AŇŐĎFUÎQ
-északnyugati/°AŇŐĎFUÎQ
-északkeleti/ąBÓŐĐGVËR
+északnyugati/°yAŇŐĎFUÎQ
+északkeleti/ąyBÓŐĐGVËR
 északi/°AŇŐĎFUÎQ
 észak-oszétiai/AŇŐĎFUÎQ
 észak-karolinai/AŇŐĎFUÎQ
@@ -66724,9 +66898,9 @@ billiomod/v)ó
 értékvesztett/Ó×GVËnňLRląy
 értéktárgymegőrző/ąCÔŐŢHWĚR
 értéktelen/Ó×GVËnňLRlą
-értéksemleges/Ó×GVËnňLTtlą
-értékorientált/ŇŮFUÎmôQk°
-értéknövelt/Ó×GVËnňLRlą
+értéksemleges/Ó×GVËnňLTtląy
+értékorientált/ŇŮFUÎmôQk°y
+értéknövelt/Ó×GVËnňLRląy
 értékmegőrző/ąCÔŐŢHWĚR
 értékevesztett/Ó×GVËnňLRlą
 értékes/Ó×GVËnňLTtlą
@@ -66771,7 +66945,7 @@ billiomod/v)ó
 ércsomós/ŇŮFUÎmôKÖSsk°
 érces/Ó×GVËnňLTtlą
 ércdús/ŇŮFUÎmôKÖSsk°
-érbeidegző/ąCÔŐŢHWĚR
+érbeidegző/ąyCÔŐŢHWĚR
 épületes/Ó×GVËnňLTtlą
 építésű/ąCÔŐŢHWĚR
 épített/Ó×GVËnňLRlą
@@ -66779,7 +66953,7 @@ billiomod/v)ó
 épelméjű/ąCÔŐŢHWĚR
 ép/Ó×GVËnňLRą
 ény.-i/°AŇŐĎFUÎQ
-énközpontú/°yAŇŐĎFUÎQ
+énközpontú/°yAŇŐĎFUÎQén||köz|pontú
 énhatékony/ŇŮFUÎmôKÖSsk°y
 éneklő/XCÔŐŢHWĚR
 énekkari/°AŇŐĎFUÎQ
@@ -66806,7 +66980,7 @@ billiomod/v)ó
 éltes/Ó×GVËnňLTtlą
 élsimított/ŇŮFUÎmôKÖQk°y
 élményteli/ąyBÓŐĐGVËR
-élménygazdag/ŇŮFUÎmôKÖQk°
+élménygazdag/ŇŮFUÎmôKÖQk°y
 élménydús/ŇŮFUÎmôKÖSsk°
 éljenző/XCÔŐŢHWĚR
 éljenező/ąXCÔŐŢHWĚR
@@ -66822,12 +66996,13 @@ billiomod/v)ó
 életszerűtlen/Ó×GVËnňLRląy
 életrevaló/°AŇŐĎFUÎQ
 életrajzi/°AŇŐĎFUÎQ
-életnagyságú/°AŇŐĎFUÎQ
+életnagyságú/°yAŇŐĎFUÎQ
 életlen/Ó×GVËnňLRlą
+életközeli/ąyBÓŐĐGVËR
 életképtelen/Ó×GVËnňLRlą
 életképes/Ó×GVËnňLTtlą
-életigenlő/ąCÔŐŢHWĚR
-életidegen/Ó×GVËnňLRlą
+életigenlő/ąyCÔŐŢHWĚR
+életidegen/Ó×GVËnňLRląy
 élethű/ąyCÔŐŢHWĚR	élethűebbenélethűebb
 élethossziglani/°BÓŐĐGVËR
 életerős/Ô×ÝňGVĚNMTtlą
@@ -66850,7 +67025,9 @@ billiomod/v)ó
 éjjel-nappali/°AŇŐĎFUÎQ	ph:éjjelnappali
 éji/ąBÓŐĐGVËR
 éjfekete/ąBÓŐĐGVËR
+éhesszájú/°yAŇŐĎFUÎQé=hes|szá-júéhes|szájú
 éhes/Ó×GVËnňLTtlą
+éhenkórász/ŇŮFUÎmôKÖSsk°
 égővörös/Ô×ÝňGVĚNMTtlą
 égőpiros/ŇŮFUÎmôKÖSsk°
 égszínkék/Ó×GVËnňLRlą
@@ -66861,10 +67038,10 @@ billiomod/v)ó
 égetnivaló/°AŇŐĎFUÎQ
 égetlen/Ó×GVËnňLRlą
 égbenyúló/°AŇŐĎFUÎQ
-égbekiáltó/°AŇŐĎFUÎQ
+égbekiáltó/°yAŇŐĎFUÎQ
 édesítetlen/Ó×GVËnňLRlą
 édesvízi/ąBÓŐĐGVËR
-édesszájú/°yAŇŐĎFUÎQé=des|szá-jú
+édesszájú/°yAŇŐĎFUÎQé=des|szá-júédes|szájú
 édeskés/Ó×GVËnňLTtlą
 édeses/Ó×GVËnňLTtlą
 édesded/Ó×GVËnňLRlą
@@ -66874,7 +67051,7 @@ billiomod/v)ó
 édelgő/XCÔŐŢHWĚR
 éber/Ó×GVËnňLRlą
 ébenszínű/ąCÔŐŢHWĚR
-ébenfekete/ąBÓŐĐGVËR
+ébenfekete/ąyBÓŐĐGVËR
 ében/Ó×GVËnňLRlą
 čapeki/BÓŐĐGVËR
 ázott/ŇŮFUÎmôQk°sX
@@ -66924,7 +67101,7 @@ billiomod/v)ó
 ásványi/°AŇŐĎFUÎQ
 ásatag/ŇŮFUÎmôKÖQk°
 árérzékeny/Ó×GVËnňLTtlą
-árvízkárosult/ŇŮFUÎmôKÖQk°
+árvízkárosult/ŇŮFUÎmôKÖQk°yár|víz||károsult
 árva/°AŇŐĎFUÎQ
 áruátvevő/ąCÔŐŢHWĚR
 árukiszolgáltató/°AŇŐĎFUÎQ
@@ -66954,11 +67131,11 @@ billiomod/v)ó
 áremelő/ąCÔŐŢHWĚR
 árcsökkentő/ąCÔŐŢHWĚR
 árapasztó/°AŇŐĎFUÎQ
-áramvonalas/ŇŮFUÎmôKÖSsk°
+áramvonalas/ŇŮFUÎmôKÖSsk°y
 áramvezérelt/Ó×GVËnňLRlą
 áramoló/°XAŇŐĎFUÎQ
 áramló/XAŇŐĎFUÎQ
-áramgerjesztő/ąCÔŐŢHWĚR
+áramgerjesztő/ąyCÔŐŢHWĚR
 áramelosztó/°AŇŐĎFUÎQ
 áradt/ŇŮFUÎmôKÖQk°
 áprilys/ŇŮFUÎmôKÖSsk
@@ -66990,13 +67167,13 @@ billiomod/v)ó
 állítmányi/°AŇŐĎFUÎQ
 állékony/ŇŮFUÎmôKÖSsk°
 állástalan/ŇŮFUÎmôKÖQk°
-állásnélküli/ąBÓŐĐGVËR
+állásnélküli/ąyBÓŐĐGVËR
 állott/ŇŮFUÎmôQk°sX
 állhatatos/ŇŮFUÎmôKÖSsk°
 állhatatlan/ŇŮFUÎmôKÖQk°
 állatövi/ąBÓŐĐGVËR
 állattani/°AŇŐĎFUÎQ
-állatorvosi/°AŇŐĎFUÎQ
+állatorvosi/°yAŇŐĎFUÎQ
 állatias/ŇŮFUÎmôKÖSsk°
 állati/°AŇŐĎFUÎQ
 állathangutánzó/°yAŇŐĎFUÎQ
@@ -67005,10 +67182,10 @@ billiomod/v)ó
 állapotos/ŇŮFUÎmôKÖSsk°
 állandó/°AŇŐĎFUÎQ
 államszocialista/°AŇŐĎFUÎQ
-államokbeli/ąBÓŐĐGVËR
+államokbeli/ąyBÓŐĐGVËR
 államkapitalista/°AŇŐĎFUÎQ
 állami/°AŇŐĎFUÎQ
-államférfiúi/°AŇŐĎFUÎQ
+államférfiúi/°yAŇŐĎFUÎQ
 államfelforgató/°AŇŐĎFUÎQ
 államcentrikus/ŇŮFUÎmôKÖSsk°
 álhumánus/ŇŮFUÎmôKÖSsk°y
@@ -67025,7 +67202,7 @@ billiomod/v)ó
 ájtatos/ŇŮFUÎmôKÖSsk°
 áhítatos/ŇŮFUÎmôKÖSsk°
 ágyéktáji/°AŇŐĎFUÎQ
-ágrólszakadt/ŇŮFUÎmôKÖQk°
+ágrólszakadt/ŇŮFUÎmôKÖQk°y
 ágostai/°AŇŐĎFUÎQ
 ágbogas/ŇŮFUÎmôKÖSsk°
 ágas/ŇŮFUÎmôKÖSsk°
@@ -67049,14 +67226,14 @@ zöngétlen/Ó×GVËnňLRlą
 zömök/Ô×ÝňGVĚNMRlą
 zöldszemű/ąCÔŐŢHWĚR
 zöldmezős/Ô×ÝňGVĚNMTtląy
-zöldkeresztes/Ó×GVËnňLTtlą
+zöldkeresztes/Ó×GVËnňLTtląy
 zöldhasú/°AŇŐĎFUÎQ
 zöldfülű/ąCÔŐŢHWĚR
 zöldessárga/°AŇŐĎFUÎQ
 zöldeskékes/Ó×GVËnňLTtlą
 zöldeskék/Ó×GVËnňLRlą
-zöldesfekete/ąBÓŐĐGVËR
-zöldesbarnás/ŇŮFUÎmôKÖSsk°
+zöldesfekete/ąyBÓŐĐGVËR
+zöldesbarnás/ŇŮFUÎmôKÖSsk°y
 zöldesbarna/°AŇŐĎFUÎQ
 zöldes/Ó×GVËnňLTtlą
 zöldellő/ąCÔŐŢHWĚR
@@ -67081,11 +67258,11 @@ zulu/°AŇŐĎFUÎQ
 zuhanyzó/XAŇŐĎFUÎQ
 zuhanyozó/°XAŇŐĎFUÎQ
 zuborgó/XAŇŐĎFUÎQ
-zsúpfedelű/ąCÔŐŢHWĚR
+zsúpfedelű/ąyCÔŐŢHWĚR
 zsúfolt/ŇŮFUÎmôQk°
 zsírtalan/ŇŮFUÎmôKÖQk°
 zsíros/ŇŮFUÎmôKÖSsk°
-zsíroldékony/ŇŮFUÎmôKÖSsk°
+zsíroldékony/ŇŮFUÎmôKÖSsk°y
 zsírhatlan/ŇŮFUÎmôKÖQk°
 zsírdús/ŇŮFUÎmôKÖSsk°
 zsémbes/Ó×GVËnňLTtlą
@@ -67118,13 +67295,13 @@ zord/ŇŮFUÎmôKÖQ°
 zonális/ŇŮFUÎmôKÖSsk°
 zománckék/Ó×GVËnňLRlą
 zivataros/ŇŮFUÎmôKÖSsk°
-zivatarmentes/Ó×GVËnňLTtlą
+zivatarmentes/Ó×GVËnňLTtląy
 ziher/Ó×GVËnňLRlą
 zigomorf/ŇŮFUÎmôKÖQk°
 zenés/Ó×GVËnňLTtlą
 zenworksös/Ô×ÝňGVĚNMTtl
 zengzetes/Ó×GVËnňLTtlą
-zenekedvelő/ąCÔŐŢHWĚR
+zenekedvelő/ąyCÔŐŢHWĚR
 zenekari/°AŇŐĎFUÎQ
 zeneietlen/Ó×GVËnňLRlą
 zenei/ąBÓŐĐGVËR
@@ -67160,7 +67337,7 @@ wesselényies/Ó×GVËnňLTtl
 wellnessszerű/ąwCÔŐŢHWĚR
 walesi/ąBÓŐĐGVËR
 vöröstarka/°AŇŐĎFUÎQ
-vörösszárnyú/°AŇŐĎFUÎQörös|szárnyú
+vörösszárnyú/°yAŇŐĎFUÎQörös|szárnyú
 vörösnyakú/°AŇŐĎFUÎQ
 vörösmartys/ŇŮFUÎmôKÖSsk
 vörösmartyas/ŇŮFUÎmôKÖSsk
@@ -67168,18 +67345,18 @@ vöröshasú/°AŇŐĎFUÎQ
 vörösfejű/ąCÔŐŢHWĚR
 vörösessárgás/ŇŮFUÎmôKÖSsk°
 vörösessárga/°AŇŐĎFUÎQ
-vörösesszőke/ąyBÓŐĐGVËRö-rö-ses|sző-ke
-vörösesbarnás/ŇŮFUÎmôKÖSsk°
+vörösesszőke/ąyBÓŐĐGVËRö-rö-ses|sző-keöröses|szőke
+vörösesbarnás/ŇŮFUÎmôKÖSsk°y
 vörösesbarna/°AŇŐĎFUÎQ
 vöröses/Ó×GVËnňLTtlą
 vörösbarna/°AŇŐĎFUÎQ
 vörös/Ô×ÝňGVĚNMTtlą
 vörhenyesbarna/°AŇŐĎFUÎQ
 vörhenyes/Ó×GVËnňLTtlą
-vízálló/°AŇŐĎFUÎQ
+vízálló/°yAŇŐĎFUÎQ
 vízzáró/°yAŇŐĎFUÎQ
 vízvájta/°AŇŐĎFUÎQ
-vízumkötelezett/Ó×GVËnňLRlą
+vízumkötelezett/Ó×GVËnňLRląy
 víztiszta/°AŇŐĎFUÎQ
 víztelen/Ó×GVËnňLRlą
 vízszínű/ąCÔŐŢHWĚRíz|színű
@@ -67195,12 +67372,11 @@ vízköves/Ó×GVËnňLTtlą
 vízkóros/ŇŮFUÎmôKÖSsk°
 vízjárta/°AŇŐĎFUÎQ
 vízigényes/Ó×GVËnňLTtlą
-vízierőmű/ąyCÔŐŢHWĚR
 vízi/ąBÓŐĐGVËR
 vízhűtésű/ąCÔŐŢHWĚR
 vízhatlan/ŇŮFUÎmôKÖQk°
 vízfejű/ąCÔŐŢHWĚR
-vízerőművi/ąyBÓŐĐGVËR
+vízerőművi/ąyBÓŐĐGVËRíz||erő|művi
 vízbő/ąyCÔŐŢHWĚR
 vírusos/ŇŮFUÎmôKÖSsk°
 vígjátéki/ąBÓŐĐGVËR
@@ -67211,8 +67387,8 @@ vétkes/Ó×GVËnňLTtlą
 vészjósló/°AŇŐĎFUÎQ
 vésett/Ó×GVËnňLRlą
 vérző/XCÔŐŢHWĚR
-vérzéselállító/°AŇŐĎFUÎQ
-vérzéscsillapító/°AŇŐĎFUÎQ
+vérzéselállító/°yAŇŐĎFUÎQ
+vérzéscsillapító/°yAŇŐĎFUÎQ
 vérzékeny/Ó×GVËnňLTtlą
 vérvörös/Ô×ÝňGVĚNMTtlą
 vértelen/Ó×GVËnňLRlą
@@ -67245,11 +67421,11 @@ véletlen/Ó×GVËnňLRlą
 vélelmezett/Ó×GVËnňLRlą
 vékonytagú/°AŇŐĎFUÎQ
 vékonyka/°AŇŐĎFUÎQ
-vékonydongájú/°AŇŐĎFUÎQ
+vékonydongájú/°yAŇŐĎFUÎQ
 vékonycsőrű/ąCÔŐŢHWĚR
 vékonybélű/ąCÔŐŢHWĚR
 vékony/ŇŮFUÎmôKÖSsk°
-végérvényes/Ó×GVËnňLTtlą
+végérvényes/Ó×GVËnňLTtląy
 végző/XCÔŐŢHWĚR
 végzett/Ó×GVËnňLRlą
 végzetes/Ó×GVËnňLTtlą
@@ -67259,14 +67435,14 @@ végső/ąCÔŐŢHWĚR
 végletes/Ó×GVËnňLTtlą
 végleges/Ó×GVËnňLTtlą
 véghetetlen/Ó×GVËnňLRlą
-végeérhetetlen/Ó×GVËnňLRlą
+végeérhetetlen/Ó×GVËnňLRląy
 végező/ąXCÔŐŢHWĚR
 végezetlen/Ó×GVËnňLRlą
 végetlen/Ó×GVËnňLRlą
-végeszakadatlan/ŇŮFUÎmôKÖQk°
+végeszakadatlan/ŇŮFUÎmôKÖQk°y
 végestelen/Ó×GVËnňLRlą
 véges/Ó×GVËnňLTtlą
-végeláthatatlan/ŇŮFUÎmôKÖQk°
+végeláthatatlan/ŇŮFUÎmôKÖQk°y
 védőgázas/ŇŮFUÎmôKÖSsk°
 védtelen/Ó×GVËnňLRlą
 védnöklő/XCÔŐŢHWĚR
@@ -67281,18 +67457,19 @@ vázlatos/ŇŮFUÎmôKÖSsk°
 vásároló/°XAŇŐĎFUÎQ
 vásárló/XAŇŐĎFUÎQ
 várt/ŇŮFUÎmôKÖQ°
+városközeli/ąyBÓŐĐGVËR
 városias/ŇŮFUÎmôKÖSsk°
 városi/°AŇŐĎFUÎQ
 várományos/ŇŮFUÎmôKÖSsk°
 váratlan/ŇŮFUÎmôKÖQk°
 várandós/ŇŮFUÎmôKÖSsk°
-várakozásteljes/Ó×GVËnňLTtlą
+várakozásteljes/Ó×GVËnňLTtląy
 várakozásteli/ąyBÓŐĐGVËR
 ványadt/ŇŮFUÎmôKÖQk°
 vánszorgó/XAŇŐĎFUÎQ
 vándoroló/°XAŇŐĎFUÎQ
 vándorló/°XAŇŐĎFUÎQ
-vámszabadterületi/ąBÓŐĐGVËR
+vámszabadterületi/ąyBÓŐĐGVËRám|szabad||területi
 vámszabad/ŇŮFUÎmôKÖQk°
 vámolatlan/ŇŮFUÎmôKÖQk°
 vámmentes/Ó×GVËnňLTtlą
@@ -67314,7 +67491,7 @@ választott/ŇŮFUÎmôQk°sX
 válaszolatlan/ŇŮFUÎmôKÖQk°
 válaszképtelen/Ó×GVËnňLRląy
 váladékozó/°AŇŐĎFUÎQ
-vákuumcsomagolt/ŇŮFUÎmôQk°
+vákuumcsomagolt/ŇŮFUÎmôQk°y
 vágásérett/Ó×GVËnňLRlą
 vágánytalan/ŇŮFUÎmôKÖQk°
 vágáns/ŇŮFUÎmôKÖSsk°
@@ -67360,7 +67537,7 @@ vitatott/ŇŮFUÎmôQk°sX
 vitathatatlan/ŇŮFUÎmôKÖQk°
 vitamindús/ŇŮFUÎmôKÖSsk°
 vitakész/Ó×GVËnňLTtląy
-vitakedvelő/ąCÔŐŢHWĚR
+vitakedvelő/ąyCÔŐŢHWĚR
 viszonzott/ŇŮFUÎmôQk°sX
 viszonzatlan/ŇŮFUÎmôKÖQk°
 viszonylagos/ŇŮFUÎmôKÖSsk°
@@ -67379,22 +67556,22 @@ visszterhes/Ó×GVËnňLTtlą
 visszhangzó/XAŇŐĎFUÎQ
 visszhangtalan/ŇŮFUÎmôKÖQk°
 visszhangozó/°XAŇŐĎFUÎQ
-visszaválthatatlan/ŇŮFUÎmôKÖQk°
-visszavonult/ŇŮFUÎmôQk°
-visszavonhatatlan/ŇŮFUÎmôKÖQk°
+visszaválthatatlan/ŇŮFUÎmôKÖQk°y
+visszavonult/ŇŮFUÎmôQk°y
+visszavonhatatlan/ŇŮFUÎmôKÖQk°y
 visszavert/Ó×GVËnňLRlą
-visszautasított/ŇŮFUÎmôQk°sX
-visszautasíthatatlan/ŇŮFUÎmôKÖQk°
+visszautasított/ŇŮFUÎmôQk°ysX
+visszautasíthatatlan/ŇŮFUÎmôKÖQk°y
 visszatért/Ó×GVËnňLRlą
-visszataszító/°AŇŐĎFUÎQ
-visszaszerezhetetlen/Ó×GVËnňLRlą
-visszamenőleges/Ó×GVËnňLTtlą
-visszamaradott/ŇŮFUÎmôQk°sX
-visszaküldött/Ô×ÝňGVĚNRlą
-visszahúzódás/ŇŮFUÎmôKÖSsk°
-visszahozhatatlan/ŇŮFUÎmôKÖQk°
+visszataszító/°yAŇŐĎFUÎQ
+visszaszerezhetetlen/Ó×GVËnňLRląy
+visszamenőleges/Ó×GVËnňLTtląy
+visszamaradott/ŇŮFUÎmôQk°ysX
+visszaküldött/Ô×ÝňGVĚNRląy
+visszahúzódás/ŇŮFUÎmôKÖSsk°y
+visszahozhatatlan/ŇŮFUÎmôKÖQk°y
 visszahajló/°AŇŐĎFUÎQ
-visszafojtott/ŇŮFUÎmôQk°sX
+visszafojtott/ŇŮFUÎmôQk°ysX
 visszaeső/ąCÔŐŢHWĚR
 viselős/Ô×ÝňGVĚNMTtlą
 viseltes/Ó×GVËnňLTtlą
@@ -67402,7 +67579,7 @@ viselt/Ó×GVËnňLRlą
 virágzó/XAŇŐĎFUÎQ
 virágzott/ŇŮFUÎmôQk°sX
 virágtalan/ŇŮFUÎmôKÖQk°
-virágporérzékeny/Ó×GVËnňLTtlą
+virágporérzékeny/Ó×GVËnňLTtląy
 virágozó/°XAŇŐĎFUÎQ
 virágos/ŇŮFUÎmôKÖSsk°
 virág_alakú/°AŇŐĎFUÎQ
@@ -67414,27 +67591,27 @@ virradati/°BÓŐĐGVËR
 virgonc/ŇŮFUÎmôKÖSsk°
 violakék/Ó×GVËnňLRlą
 világítatlan/ŇŮFUÎmôKÖQk°
-világvárosias/ŇŮFUÎmôKÖSsk°
+világvárosias/ŇŮFUÎmôKÖSsk°y
 világtalan/ŇŮFUÎmôKÖQk°
 világszép/Ó×GVËnňLRlą
 világraszóló/°AŇŐĎFUÎQ
-világoszöld/Ô×ÝňGVĚNRląyá-gos|zöld
+világoszöld/Ô×ÝňGVĚNRląyá-gos|zöldágos|zöld
 világossárga/°AŇŐĎFUÎQ
-világosszürke/ąyBÓŐĐGVËRá-gos|szür-ke
+világosszürke/ąyBÓŐĐGVËRá-gos|szür-keágos|szürke
 világosszőke/ąBÓŐĐGVËRá-gos|sző-ke
 világospiros/ŇŮFUÎmôKÖSsk°
 világoslila/°AŇŐĎFUÎQ
 világoskék/Ó×GVËnňLRlą
 világosfejű/ąCÔŐŢHWĚR
-világosbarnás/ŇŮFUÎmôKÖSsk°
+világosbarnás/ŇŮFUÎmôKÖSsk°y
 világosbarna/°AŇŐĎFUÎQ
 világos/ŇŮFUÎmôKÖSsk°
-világlátott/ŇŮFUÎmôQk°sX
+világlátott/ŇŮFUÎmôQk°ysX
 világias/ŇŮFUÎmôKÖSsk°
 világi/°AŇŐĎFUÎQ
 világhírű/ąCÔŐŢHWĚR
 világhíres/Ó×GVËnňLTtlą
-világfájdalmas/ŇŮFUÎmôKÖSsk°
+világfájdalmas/ŇŮFUÎmôKÖSsk°y
 világfias/ŇŮFUÎmôKÖSsk°
 világelső/ąCÔŐŢHWĚR
 villás/ŇŮFUÎmôKÖSsk°
@@ -67447,12 +67624,13 @@ vihetetlen/Ó×GVËnňLRlX)
 viharálló/°AŇŐĎFUÎQ
 viharvert/Ó×GVËnňLRlą
 viharos/ŇŮFUÎmôKÖSsk°
-viharmentes/Ó×GVËnňLTtlą
-viharedzett/Ó×GVËnňLRlą
+viharmentes/Ó×GVËnňLTtląy
+viharedzett/Ó×GVËnňLRląy
 vigyázatlan/ŇŮFUÎmôKÖQk°
 vigyorgó/°XAŇŐĎFUÎQ
 vigasztalhatatlan/ŇŮFUÎmôKÖQk°
 vigasztalan/ŇŮFUÎmôKÖQk°
+viendő/XCÔŐŢHWĚR)Ó_FUTPART_adj
 vidékies/Ó×GVËnňLTtlą
 vidéki/ąBÓŐĐGVËR
 vidám/ŇŮFUÎmôKÖSsk°
@@ -67471,7 +67649,7 @@ vezérelő/ąXCÔŐŢHWĚR
 vezénylő/XCÔŐŢHWĚR
 vezényelő/ąXCÔŐŢHWĚR
 vezető/ąCÔŐŢHWĚR
-vezetésképtelen/Ó×GVËnňLRlą
+vezetésképtelen/Ó×GVËnňLRląy
 vezeklő/ąXCÔŐŢHWĚR
 vezekelő/ąXCÔŐŢHWĚR
 vevőorientált/ŇŮFUÎmôQk°
@@ -67505,25 +67683,25 @@ vespuccis/ŇŮFUÎmôKÖSsk
 veseköves/Ó×GVËnňLTtlą
 veseelégtelen/Ó×GVËnňLRląy
 vesebajos/ŇŮFUÎmôKÖSsk°
-verőfényes/Ó×GVËnňLTtlą
+verőfényes/Ó×GVËnňLTtląy
 verzátus/ŇŮFUÎmôKÖSsk°
 verzális/ŇŮFUÎmôKÖSsk°
 vertikális/ŇŮFUÎmôKÖSsk°
-versmértékes/Ó×GVËnňLTtlą
+versmértékes/Ó×GVËnňLTtląy
 verses/Ó×GVËnňLTtlą
 versenyző/XCÔŐŢHWĚR
-versenysemleges/Ó×GVËnňLTtlą
-versenyképtelen/Ó×GVËnňLRlą
+versenysemleges/Ó×GVËnňLTtląy
+versenyképtelen/Ó×GVËnňLRląy
 versenyképes/Ó×GVËnňLTtlą
 versenyező/ąXCÔŐŢHWĚR
 verhetetlen/Ó×GVËnňLRlą
 veretlen/Ó×GVËnňLRlą
-veresszárnyú/°AŇŐĎFUÎQárnyú
+veresszárnyú/°yAŇŐĎFUÎQárnyú
 veres/Ó×GVËnňLTtlą
 verbális/ŇŮFUÎmôKÖSsk°
 ventrikuláris/ŇŮFUÎmôKÖSsk°
 venereás/ŇŮFUÎmôKÖSsk°
-vendégszerető/ąCÔŐŢHWĚR
+vendégszerető/ąyCÔŐŢHWĚR
 vendéglátó-ipari/°wAŇŐĎFUÎQ
 vendég/Ó×GVËnňLRTtlą
 vendgyűlölő/CÔŐŢHWĚR
@@ -67536,7 +67714,7 @@ velőtrázó/°AŇŐĎFUÎQ
 velőtlen/Ó×GVËnňLRlą
 velős/Ô×ÝňGVĚNMTtlą
 veláris/ŇŮFUÎmôKÖSsk°
-veleszületett/Ó×GVËnňLRlą
+veleszületett/Ó×GVËnňLRląy
 velencei/ąBÓŐĐGVËR
 vektoriális/ŇŮFUÎmôKÖSsk°
 vehető/XCÔŐŢHWĚR)Ó_ABLE_(adj,present_part)
@@ -67559,7 +67737,7 @@ vastartalmú/°AŇŐĎFUÎQ
 vastagnyakú/°AŇŐĎFUÎQ
 vastagfejű/ąCÔŐŢHWĚR
 vastagbőrű/ąCÔŐŢHWĚR
-vastag_betűs/Ô×ÝňGVĚNMTtląy
+vastag_betűs/Ô×ÝňGVĚNMTtląyűs
 vastag/ŇŮFUÎmôKÖQk°
 vaskos/ŇŮFUÎmôKÖSsk°
 vaskezű/ąCÔŐŢHWĚR
@@ -67610,7 +67788,7 @@ valami/°AŇŐĎFUÎQ
 valamelyes/Ó×GVËnňLTtlą
 valahai/°AŇŐĎFUÎQ
 vakító/°AŇŐĎFUÎQ
-vakításmentes/Ó×GVËnňLTtlą
+vakításmentes/Ó×GVËnňLTtląy
 vaksötét/Ó×GVËnňLRlą
 vaksi/°AŇŐĎFUÎQ
 vakolatlan/ŇŮFUÎmôKÖQk°
@@ -67625,12 +67803,13 @@ vajas/ŇŮFUÎmôKÖSsk°
 vagány/ŇŮFUÎmôKÖSsk°
 vagyontalan/ŇŮFUÎmôKÖQk°
 vagyonos/ŇŮFUÎmôKÖSsk°
-vagyonbukott/ŇŮFUÎmôQk°sX
+vagyonbukott/ŇŮFUÎmôQk°ysX
 vagylagos/ŇŮFUÎmôKÖSsk°
 vaginális/ŇŮFUÎmôKÖSsk°
 vadózus/ŇŮFUÎmôKÖSsk°
 vadízű/ąCÔŐŢHWĚR
 vadállatias/ŇŮFUÎmôKÖSsk°
+vadregényes/Ó×GVËnňLTtląy
 vadonatúj/ŇŮFUÎmôKÖSsk°
 vadnyugati/°AŇŐĎFUÎQ
 vadkapitalista/°AŇŐĎFUÎQ
@@ -67654,9 +67833,9 @@ utánzó/°AŇŐĎFUÎQ
 utánzott/ŇŮFUÎmôQk°sX
 utánozhatatlan/ŇŮFUÎmôKÖQk°
 utánjátszó/°AŇŐĎFUÎQ
-utángyártott/ŇŮFUÎmôQk°sX
+utángyártott/ŇŮFUÎmôQk°ysX
 utálatos/ŇŮFUÎmôKÖSsk°
-utolérhetetlen/Ó×GVËnňLRlą
+utolérhetetlen/Ó×GVËnňLRląy
 utilitarista/°AŇŐĎFUÎQ
 utcai/°AŇŐĎFUÎQ
 utazott/ŇŮFUÎmôQk°sX
@@ -67690,20 +67869,21 @@ underground/ŇŮFUÎmôKÖQk°
 uncsi/°AŇŐĎFUÎQ
 unalmas/ŇŮFUÎmôKÖSsk°
 umbilikus/ŇŮFUÎmôKÖSsk°
-ultravékony/ŇŮFUÎmôKÖSsk°
+ultravékony/ŇŮFUÎmôKÖSsk°y
 ultraszonikus/ŇŮFUÎmôKÖSsk°
-ultrarövid/Ó×GVËnňLRlą
-ultraortodox/ŇŮFUÎmôKÖSsk°
-ultranacionalista/°AŇŐĎFUÎQ
+ultrarövid/Ó×GVËnňLRląy
+ultraortodox/ŇŮFUÎmôKÖSsk°y
+ultranacionalista/°yAŇŐĎFUÎQ
 ultramontán/ŇŮFUÎmôKÖQk°
-ultramodern/Ó×GVËnňLRlą
+ultramodern/Ó×GVËnňLRląy
 ultramarinkék/Ó×GVËnňLRlą
-ultraliberális/ŇŮFUÎmôKÖSsk°
-ultrakonzervatív/ŇŮFUÎmôKÖSsk°
-ultrakompakt/ŇŮFUÎmôKÖQk°
-ultraibolya/°AŇŐĎFUÎQ
+ultraliberális/ŇŮFUÎmôKÖSsk°y
+ultrakonzervatív/ŇŮFUÎmôKÖSsk°y
+ultrakompakt/ŇŮFUÎmôKÖQk°y
+ultraibolya/°yAŇŐĎFUÎQ
 ultragyors/ŇŮFUÎmôKÖSsk
 ultrabalos/ŇŮFUÎmôKÖSsk°
+ukránpárti/°yAŇŐĎFUÎQ
 ukrángyűlölő/CÔŐŢHWĚR
 ukránellenes/Ó×GVËnňLTtl
 ukráncentrikus/ŇŮFUÎmôKÖSsk
@@ -67765,14 +67945,14 @@ tündéri/ąBÓŐĐGVËR
 tülekvő/ąXYCÔŐŢHWĚR)ülekszikÓ_PRESPART_adj
 tülekvő/ąXYCÔŐŢHWĚR
 tükörsima/°AŇŐĎFUÎQ
-tüdővészes/Ó×GVËnňLTtlą
-tüdőtágulásos/ŇŮFUÎmôKÖSsk°
+tüdővészes/Ó×GVËnňLTtląy
+tüdőtágulásos/ŇŮFUÎmôKÖSsk°y
 tüdőbeteg/Ó×GVËnňLRTtlą
 tüchtig/Ó×GVËnňLRlą	ph:tühtig
 tűzálló/°AŇŐĎFUÎQ
 tűzvörös/Ô×ÝňGVĚNMTtlą
 tűzveszélyes/Ó×GVËnňLTtlą
-tűzrőlpattant/ŇŮFUÎmôKÖQk°
+tűzrőlpattant/ŇŮFUÎmôKÖQk°y
 tűzkárosult/ŇŮFUÎmôQk°
 tűzforró/°AŇŐĎFUÎQ
 tűrt/Ô×ÝňGVĚNRą	űrtet
@@ -67813,9 +67993,9 @@ törökcentrikus/ŇŮFUÎmôKÖSsk
 törökbarát/ŇŮFUÎmôKÖQk
 török/ą
 törékeny/Ó×GVËnňLTtlą
-törzskönyvezett/Ó×GVËnňLRlą
+törzskönyvezett/Ó×GVËnňLRląy
 törzsi/ąBÓŐĐGVËR
-törvénytisztelő/ąCÔŐŢHWĚR
+törvénytisztelő/ąyCÔŐŢHWĚR
 törvénytelen/Ó×GVËnňLRlą
 törvényszéki/ąBÓŐĐGVËR
 törvényszerű/ąCÔŐŢHWĚR
@@ -67828,7 +68008,7 @@ történelmietlen/Ó×GVËnňLRlą
 történelmi/ąBÓŐĐGVËR
 törtkitevős/Ô×ÝňGVĚNMTtlą
 törtkitevő/ąCÔŐŢHWĚR
-törtfekete/ąBÓŐĐGVËR
+törtfekete/ąyBÓŐĐGVËR
 törtfehér/Ó×GVËnňLRTtląy
 törtes/Ó×GVËnňLTtlą
 tört/Ô×ÝňGVĚNRą
@@ -67887,34 +68067,34 @@ többévi/ąBÓŐĐGVËR
 többévenkénti/ąBÓŐĐGVËR
 többtagú/°AŇŐĎFUÎQ
 többszörös/Ô×ÝňGVĚNMTtlą
-többszólamú/°AŇŐĎFUÎQ
+többszólamú/°yAŇŐĎFUÎQ
 többszínű/ąCÔŐŢHWĚR
-többszázszoros/ŇŮFUÎmôKÖSsk°öbb|száz-szo-ros
+többszázszoros/ŇŮFUÎmôKÖSsk°yöbb|száz-szo-ros
 többszempontú/°AŇŐĎFUÎQ
-többrendbeli/ąBÓŐĐGVËR
+többrendbeli/ąyBÓŐĐGVËR
 többpercenkénti/ąBÓŐĐGVËR
-többoldalú/°AŇŐĎFUÎQ
-többoldali/°AŇŐĎFUÎQ
-többnyelvű/ąCÔŐŢHWĚR
+többoldalú/°yAŇŐĎFUÎQ
+többoldali/°yAŇŐĎFUÎQ
+többnyelvű/ąyCÔŐŢHWĚR
 többnejű/ąCÔŐŢHWĚR
 többnaponkénti/ąBÓŐĐGVËR
-többmotoros/ŇŮFUÎmôKÖSsk°
-többmilliószoros/ŇŮFUÎmôKÖSsk°
-többmilliárdszoros/ŇŮFUÎmôKÖSsk°
-többlépcsős/Ô×ÝňGVĚNMTtlą
-többjelentésű/ąCÔŐŢHWĚR
-többistenhívő/ąyCÔŐŢHWĚR
+többmotoros/ŇŮFUÎmôKÖSsk°y
+többmilliószoros/ŇŮFUÎmôKÖSsk°y
+többmilliárdszoros/ŇŮFUÎmôKÖSsk°y
+többlépcsős/Ô×ÝňGVĚNMTtląy
+többjelentésű/ąyCÔŐŢHWĚR
+többistenhívő/ąyCÔŐŢHWĚRöbb|isten||hívő
 többismeretlenes/Ó×GVËnňLTtlą
 többheti/ąBÓŐĐGVËR
 többhetenkénti/ąBÓŐĐGVËR
 többhavonkénti/ąBÓŐĐGVËR
 többhavi/°BÓŐĐGVËR
-többhatású/°AŇŐĎFUÎQ
+többhatású/°yAŇŐĎFUÎQ
 többhangú/°AŇŐĎFUÎQ
 többférjű/ąCÔŐŢHWĚR
 többféle/ąBÓŐĐGVËR
-többfázisú/°AŇŐĎFUÎQ
-többezerszeres/Ó×GVËnňLTtlą
+többfázisú/°yAŇŐĎFUÎQ
+többezerszeres/Ó×GVËnňLTtląy
 többesztendei/ąBÓŐĐGVËR
 többalakú/°AŇŐĎFUÎQ
 több_száz_éves/Ó×GVËnňLTtlą	ph:többsz	ph:többsázéves
@@ -67922,10 +68102,10 @@ több_száz/ŇŮFUÎmôKÖSsk°
 több_ezer_éves/Ó×GVËnňLTtlą	ph:többezeréves
 több_ezer/Ó×GVËnňLRlą
 tősgyökeres/Ó×GVËnňLTtlą	ph:törzsgy	ph:törzsgökeres
-tőrőlmetszett/Ó×GVËnňLRlą
+tőrőlmetszett/Ó×GVËnňLRląy
 tőrbeesett/Ó×GVËnňLRlą
 tőkés/Ó×GVËnňLTtlą
-tőkeigényes/Ó×GVËnňLTtlą
+tőkeigényes/Ó×GVËnňLTtląy
 tőkeerős/Ô×ÝňGVĚNMTtlą
 tőgymeleg/Ó×GVËnňLRlą
 tízóránkénti/ąBÓŐĐGVËR
@@ -67959,13 +68139,13 @@ térmértani/°AŇŐĎFUÎQ
 térláttató/°AŇŐĎFUÎQ
 térképezetlen/Ó×GVËnňLRlą
 térhatású/°AŇŐĎFUÎQ
-térhanghatású/°AŇŐĎFUÎQ
+térhanghatású/°yAŇŐĎFUÎQ
 téres/Ó×GVËnňLTtlą
 tércentrált/ŇŮFUÎmôKÖQk°
 térbeni/ąBÓŐĐGVËR
 térbeli/ąBÓŐĐGVËR
 tényleges/Ó×GVËnňLTtlą
-tényközpontú/°yAŇŐĎFUÎQ
+tényközpontú/°yAŇŐĎFUÎQény||köz|pontú
 ténfergő/XCÔŐŢHWĚR
 télutói/°BÓŐĐGVËR
 télirevaló/°AŇŐĎFUÎQ
@@ -67988,10 +68168,10 @@ távfelügyelt/Ó×GVËnňLRlą
 tárt/ŇŮFUÎmôKÖQ°
 társtalan/ŇŮFUÎmôKÖQk°
 társfinanszírozott/ŇŮFUÎmôQk°ysX
-társaságkedvelő/ąCÔŐŢHWĚR
+társaságkedvelő/ąyCÔŐŢHWĚR
 társas/ŇŮFUÎmôKÖSsk°
 társalgó/XAŇŐĎFUÎQ
-társadalomellenes/Ó×GVËnňLTtlą
+társadalomellenes/Ó×GVËnňLTtląy
 társadalmi/°AŇŐĎFUÎQ
 tárgytalan/ŇŮFUÎmôKÖQk°
 tárgyilagos/ŇŮFUÎmôKÖSsk°
@@ -68024,7 +68204,7 @@ tádzsik/°
 tábori/°AŇŐĎFUÎQ
 táblázatos/ŇŮFUÎmôKÖSsk°
 táblás/ŇŮFUÎmôKÖSsk°
-tyúkszemes/Ó×GVËnňLTtlą
+tyúkszemes/Ó×GVËnňLTtląy
 tutyimutyi/°AŇŐĎFUÎQ
 tuti/°AŇŐĎFUÎQ
 tuskólábú/°AŇŐĎFUÎQ
@@ -68077,7 +68257,7 @@ tromboplasztikus/ŇŮFUÎmôKÖSsk°
 trolibuszmegálló/°AŇŐĎFUÎQ
 trockista/°AŇŐĎFUÎQ
 trochaikus/ŇŮFUÎmôKÖSsk°
-triászkorabeli/ąBÓŐĐGVËR
+triászkorabeli/ąyBÓŐĐGVËR
 triviális/ŇŮFUÎmôKÖSsk°
 triploid/ŇŮFUÎmôKÖQk°
 trinomiális/ŇŮFUÎmôKÖSsk°
@@ -68104,20 +68284,23 @@ traumatikus/ŇŮFUÎmôKÖSsk°
 trapéz_alakú/°AŇŐĎFUÎQ
 trappista/°AŇŐĎFUÎQ
 tranzitív/Ó×GVËnňLTtlą
-transzverzális/ŇŮFUÎmôKÖSsk°
-transzszibériai/°AŇŐĎFUÎQ
-transzszexuális/ŇŮFUÎmôKÖSsk°
+transzverzális/ŇŮFUÎmôKÖSsk°y
+transzszibériai/°yAŇŐĎFUÎQ
+transzszexuális/ŇŮFUÎmôKÖSsk°y
 transzponált/ŇŮFUÎmôKÖQk°
+transzparens/Ó×GVËnňLTtlą
+transznemű/ąCÔŐŢHWĚR
 transznacionális/ŇŮFUÎmôKÖSsk°
-transzkontinentális/ŇŮFUÎmôKÖSsk°
+transzkontinentális/ŇŮFUÎmôKÖSsk°y
 transzgenikus/ŇŮFUÎmôKÖSsk°
+transzfób/ŇŮFUÎmôKÖQk°
 transzformált/ŇŮFUÎmôKÖQk°
 transzferábilis/ŇŮFUÎmôKÖSsk°
 transzeurópai/°AŇŐĎFUÎQ
-transzdiszciplináris/ŇŮFUÎmôKÖSsk°
+transzdiszciplináris/ŇŮFUÎmôKÖSsk°y
 transzcendentális/ŇŮFUÎmôKÖSsk°
 transzcendens/Ó×GVËnňLTtlą
-transzatlanti/°AŇŐĎFUÎQ
+transzatlanti/°yAŇŐĎFUÎQ
 trajektoriális/ŇŮFUÎmôKÖSsk°
 tragikus/ŇŮFUÎmôKÖSsk°
 tragikomikus/ŇŮFUÎmôKÖSsk°
@@ -68202,7 +68385,7 @@ tisztességtelen/Ó×GVËnňLRlą
 tisztességes/Ó×GVËnňLTtlą
 tisztes/Ó×GVËnňLTtlą
 tisztelgő/XCÔŐŢHWĚR
-tiszteletteljes/Ó×GVËnňLTtlą
+tiszteletteljes/Ó×GVËnňLTtląy
 tiszteletteli/ąyBÓŐĐGVËR
 tiszteletreméltó/°AŇŐĎFUÎQ
 tiszteletlen/Ó×GVËnňLRlą
@@ -68251,7 +68434,7 @@ tetemes/Ó×GVËnňLTtlą
 teszetosza/°AŇŐĎFUÎQ
 testületi/ąBÓŐĐGVËR
 testű/ąCÔŐŢHWĚR
-testvértelen/Ó×GVËnňLRlą
+testvértelen/Ó×GVËnňLRląy
 testvérietlen/Ó×GVËnňLRlą
 testvéries/Ó×GVËnňLTtlą
 testvéri/ąBÓŐĐGVËR
@@ -68266,7 +68449,7 @@ testhezálló/°AŇŐĎFUÎQ
 testetlen/Ó×GVËnňLRlą
 testes/Ó×GVËnňLTtlą
 tespedt/Ó×GVËnňLRlą
-területmértékű/ąCÔŐŢHWĚR
+területmértékű/ąyCÔŐŢHWĚR
 területi/ąBÓŐĐGVËR
 terítetlen/Ó×GVËnňLRlą
 tervszerűtlen/Ó×GVËnňLRlą
@@ -68279,12 +68462,12 @@ termő/ąXCÔŐŢHWĚR
 természetszerű/ąCÔŐŢHWĚR
 természetközeli/ąBÓŐĐGVËR
 természethű/ąyCÔŐŢHWĚR
-természetfölötti/ąBÓŐĐGVËR
-természetfeletti/ąBÓŐĐGVËR
+természetfölötti/ąyBÓŐĐGVËR
+természetfeletti/ąyBÓŐĐGVËR
 természetes/Ó×GVËnňLTtlą
 természetellenes/Ó×GVËnňLTtląy
 természetbeni/ąBÓŐĐGVËR
-természetazonos/ŇŮFUÎmôKÖSsk°
+természetazonos/ŇŮFUÎmôKÖSsk°y
 terméketlen/Ó×GVËnňLRlą
 termékeny/Ó×GVËnňLTtlą
 termál/ŇŮFUÎmôKÖQk°
@@ -68310,7 +68493,7 @@ teoretikus/ŇŮFUÎmôKÖSsk°
 teokratikus/ŇŮFUÎmôKÖSsk°
 tenyészérett/Ó×GVËnňLRlą
 tenyésztett/Ó×GVËnňLRlą
-tenyérbemászó/°AŇŐĎFUÎQ
+tenyérbemászó/°yAŇŐĎFUÎQ
 tengerészkék/Ó×GVËnňLRlą
 tengerzöld/Ô×ÝňGVĚNRlą
 tengervízi/ąBÓŐĐGVËR
@@ -68354,7 +68537,7 @@ telepatikus/ŇŮFUÎmôKÖSsk°
 teleológiai/°AŇŐĎFUÎQ
 teleologikus/ŇŮFUÎmôKÖSsk°
 telemetrikus/ŇŮFUÎmôKÖSsk°
-telekkönyvi/ąBÓŐĐGVËR
+telekkönyvi/ąyBÓŐĐGVËR
 telegrafikus/ŇŮFUÎmôKÖSsk°
 tel-avivi/AŇŐĎFUÎQ
 tel-aviv-jaffai/AŇŐĎFUÎQ
@@ -68371,7 +68554,7 @@ tejfelhajú/°AŇŐĎFUÎQ
 tejfelesszájú/°AŇŐĎFUÎQ
 tejfehér/Ó×GVËnňLRlą
 tejes/Ó×GVËnňLTtlą
-tehéntejérzékeny/Ó×GVËnňLTtlą
+tehéntejérzékeny/Ó×GVËnňLTtląyén|tej||érzékeny
 tehénbőgés/Ó×GVËnňLTtlą
 tehetős/Ô×ÝňGVĚNMTtlą
 tehető/XCÔŐŢHWĚR)Ó_ABLE_(adj,present_part)
@@ -68379,10 +68562,10 @@ tehetségtelen/Ó×GVËnňLRlą
 tehetséges/Ó×GVËnňLTtlą
 tehetetlen/Ó×GVËnňLRląX)
 tehetetlen/Ó×GVËnňLRląX
-tehermentesített/Ó×GVËnňLRlą
-tehermentes/Ó×GVËnňLTtlą
+tehermentesített/Ó×GVËnňLRląy
+tehermentes/Ó×GVËnňLTtląy
 tegnapi/°AŇŐĎFUÎQ
-tegnapelőtti/ąBÓŐĐGVËR
+tegnapelőtti/ąyBÓŐĐGVËR
 teendő/XCÔŐŢHWĚR)Ó_FUTPART_adj
 technológiai/°AŇŐĎFUÎQ
 technikai/°AŇŐĎFUÎQ
@@ -68436,7 +68619,7 @@ tanulságos/ŇŮFUÎmôKÖSsk°
 tanulmányi/ą
 tanulatlan/ŇŮFUÎmôKÖQk°
 tantaluszi/°AŇŐĎFUÎQ
-tankelhárító/°AŇŐĎFUÎQ
+tankelhárító/°yAŇŐĎFUÎQ
 tangenciális/ŇŮFUÎmôKÖSsk°
 tanganyika-tói/°wAŇŐĎFUÎQ
 tanerős/Ô×ÝňGVĚNMTtlą
@@ -68455,7 +68638,7 @@ talpatlan/ŇŮFUÎmôKÖQk°
 talmi/°AŇŐĎFUÎQ
 talajvesztett/Ó×GVËnňLRląy
 talajtalan/ŇŮFUÎmôKÖQk°
-talajközeli/ąBÓŐĐGVËR
+talajközeli/ąyBÓŐĐGVËR
 talajavesztett/Ó×GVËnňLRlą
 taktilis/Ó×GVËnňLTtlą
 taktikus/ŇŮFUÎmôKÖSsk°
@@ -68473,8 +68656,8 @@ tahó/°AŇŐĎFUÎQ
 tagozott/ŇŮFUÎmôKÖQk°
 tagolt/ŇŮFUÎmôQk°
 tagolatlan/ŇŮFUÎmôKÖQk°
-tagdíjfizető/ąCÔŐŢHWĚR
-tagbaszakadt/ŇŮFUÎmôKÖQk°
+tagdíjfizető/ąyCÔŐŢHWĚRíj||fizető
+tagbaszakadt/ŇŮFUÎmôKÖQk°y
 tagadhatatlan/ŇŮFUÎmôKÖQk°
 sütött/Ô×ÝňGVĚNRlą
 süsü/ąCÔŐŢHWĚR
@@ -68502,7 +68685,7 @@ sötétvörös/Ô×ÝňGVĚNMTtlą
 sötétsárgás/ŇŮFUÎmôKÖSsk°
 sötétsárga/°AŇŐĎFUÎQ
 sötétszürkés/Ó×GVËnňLTtlą
-sötétszürke/ąBÓŐĐGVËR
+sötétszürke/ąyBÓŐĐGVËR
 sötétszőke/ąBÓŐĐGVËR
 sötétpirosas/ŇŮFUÎmôKÖSsk°
 sötétpiros/ŇŮFUÎmôKÖSsk°
@@ -68514,7 +68697,7 @@ sötétkék/Ó×GVËnňLRlą
 sötétes/Ó×GVËnňLTtlą
 sötétbőrű/ąwCÔŐŢHWĚR
 sötétbordó/°AŇŐĎFUÎQ
-sötétbeborult/ŇŮFUÎmôQk°
+sötétbeborult/ŇŮFUÎmôQk°y
 sötétbarnás/ŇŮFUÎmôKÖSsk°
 sötétbarna/°AŇŐĎFUÎQ
 sötét_bőrű/ąCÔŐŢHWĚR
@@ -68545,7 +68728,7 @@ sémi/ąBÓŐĐGVËR
 sátoros/ŇŮFUÎmôKÖSsk°
 sásos/ŇŮFUÎmôKÖSsk°
 sáros/ŇŮFUÎmôKÖSsk°
-sárgászöldes/Ó×GVËnňLTtląár-gás|zöl-des
+sárgászöldes/Ó×GVËnňLTtląyár-gás|zöl-desárgás|zöldes
 sárgászöld/Ô×ÝňGVĚNMRląár-gás|zöld
 sárgásvöröses/Ó×GVËnňLTtlą
 sárgásvörös/Ô×ÝňGVĚNMTtlą
@@ -68553,7 +68736,7 @@ sárgásszürkés/Ó×GVËnňLTtląár-gás|szür-kés
 sárgásszürke/ąBÓŐĐGVËRár-gás|szür-ke
 sárgásfehéres/Ó×GVËnňLTtlą
 sárgásfehér/Ó×GVËnňLRlą
-sárgásbarnás/ŇŮFUÎmôKÖSsk°
+sárgásbarnás/ŇŮFUÎmôKÖSsk°y
 sárgásbarna/°AŇŐĎFUÎQ
 sárgás/ŇŮFUÎmôKÖSsk°
 sárgálló/°AŇŐĎFUÎQ
@@ -68572,19 +68755,19 @@ sáfránysárga/°AŇŐĎFUÎQ
 szürreális/ŇŮFUÎmôKÖSsk°
 szürrealisztikus/ŇŮFUÎmôKÖSsk°
 szürkületi/ąBÓŐĐGVËR
-szürkészöldes/Ó×GVËnňLTtląür-kés|zöl-des
+szürkészöldes/Ó×GVËnňLTtląyür-kés|zöl-desürkés|zöldes
 szürkészöld/Ô×ÝňGVĚNRląür-kés|zöld
 szürkéssárga/°AŇŐĎFUÎQ
 szürkéslila/°AŇŐĎFUÎQ
 szürkéskékes/Ó×GVËnňLTtlą
 szürkéskék/Ó×GVËnňLRlą
-szürkésfekete/ąBÓŐĐGVËR
+szürkésfekete/ąyBÓŐĐGVËR
 szürkésfehéres/Ó×GVËnňLTtlą
 szürkésfehér/Ó×GVËnňLRlą
-szürkésbarnás/ŇŮFUÎmôKÖSsk°
+szürkésbarnás/ŇŮFUÎmôKÖSsk°y
 szürkésbarna/°AŇŐĎFUÎQ
 szürkés/Ó×GVËnňLTtlą
-szürkeárnyalatos/ŇŮFUÎmôKÖSsk°
+szürkeárnyalatos/ŇŮFUÎmôKÖSsk°y
 szürkederes/Ó×GVËnňLTtlą
 szürke/ąBÓŐĐGVËR
 szürjektív/Ó×GVËnňLTtlą
@@ -68622,7 +68805,7 @@ szöveghű/ąyCÔŐŢHWĚR
 szöszke/ąBÓŐĐGVËR
 szörnyűséges/Ó×GVËnňLTtlą
 szörnyű/ąCÔŐŢHWĚR	örnyenörnyebbikörnyebbenörnyebb
-szörnyszülött/Ô×ÝňGVĚNRlą
+szörnyszülött/Ô×ÝňGVĚNRląy
 szökőévi/ąBÓŐĐGVËR
 szökőnap/ŇŮFUÎmôKÖQk°
 szögletes/Ó×GVËnňLTtlą
@@ -68633,9 +68816,9 @@ szőröstalpú/°AŇŐĎFUÎQ
 szőröskarú/°AŇŐĎFUÎQ
 szőrös/Ô×ÝňGVĚNMTtlą
 szőrtelen/Ó×GVËnňLRlą
-szőrszálhasogató/°AŇŐĎFUÎQ
+szőrszálhasogató/°yAŇŐĎFUÎQőr|szál||hasogató
 szőlőtermő/ąCÔŐŢHWĚR
-szőlőtermelő/ąCÔŐŢHWĚR
+szőlőtermelő/ąyCÔŐŢHWĚR
 szőkésbarna/°AŇŐĎFUÎQ
 szőkés/Ó×GVËnňLTtlą
 szőke/ąBÓŐĐGVËR
@@ -68644,13 +68827,13 @@ szótlan/ŇŮFUÎmôKÖQk°
 szótalan/ŇŮFUÎmôKÖQk°
 szószátyár/ŇŮFUÎmôKÖQk°
 szószegő/ąCÔŐŢHWĚR
-szószaporító/°AŇŐĎFUÎQ
+szószaporító/°yAŇŐĎFUÎQ
 szórványos/ŇŮFUÎmôKÖSsk°
 szórványmagyargyűlölő/CÔŐŢHWĚR
 szórványmagyarellenes/Ó×GVËnňLTtl
 szórványmagyarcentrikus/ŇŮFUÎmôKÖSsk
 szórványmagyarbarát/ŇŮFUÎmôKÖQk
-szórványmagyar/ŇŮFUÎmôKÖQk°
+szórványmagyar/ŇŮFUÎmôKÖQk°y
 szórakoztató/°AŇŐĎFUÎQ
 szórakozott/ŇŮFUÎmôQk°sX
 szónokoló/°XAŇŐĎFUÎQ
@@ -68671,7 +68854,7 @@ szó_végi/ąBÓŐĐGVËR
 szívókaros/ŇŮFUÎmôKÖSsk°
 szívélyes/Ó×GVËnňLTtlą
 szívtelen/Ó×GVËnňLRlą
-szívszaggató/°AŇŐĎFUÎQ
+szívszaggató/°yAŇŐĎFUÎQ
 szívmelengető/ąyCÔŐŢHWĚR
 szívhez_szóló/°AŇŐĎFUÎQ	ívhezszólóbbikívhezszólóbbanívhezszólóbb
 szíveslevelű/ąCÔŐŢHWĚR
@@ -68683,13 +68866,13 @@ színű/ąCÔŐŢHWĚR
 színészies/Ó×GVËnňLTtlą
 színészi/ąBÓŐĐGVËR
 színérzékeny/Ó×GVËnňLTtlą
-színárnyalatú/°AŇŐĎFUÎQ
+színárnyalatú/°yAŇŐĎFUÎQ
 színvonaltalan/ŇŮFUÎmôKÖQk°
 színvonalas/ŇŮFUÎmôKÖSsk°
-színtiszta/°AŇŐĎFUÎQ
+színtiszta/°yAŇŐĎFUÎQ
 színtelen/Ó×GVËnňLRlą
 színtartó/°AŇŐĎFUÎQ
-színpompás/ŇŮFUÎmôKÖSsk°
+színpompás/ŇŮFUÎmôKÖSsk°y
 színpadias/ŇŮFUÎmôKÖSsk°
 színpadi/°AŇŐĎFUÎQ
 színmagyargyűlölő/CÔŐŢHWĚR
@@ -68713,36 +68896,36 @@ szétszórt/ŇŮFUÎmôKÖQk°
 szétmállott/ŇŮFUÎmôQk°sX
 széthajló/°AŇŐĎFUÎQ
 szépítetlen/Ó×GVËnňLRlą
-széptermetű/ąCÔŐŢHWĚR
+széptermetű/ąyCÔŐŢHWĚR
 szépséges/Ó×GVËnňLTtlą
 szépszámú/°AŇŐĎFUÎQ
-szépreményű/ąCÔŐŢHWĚR
+szépreményű/ąyCÔŐŢHWĚR
 szépkiejtési/ąyBÓŐĐGVËR
 szépfekvésű/ąCÔŐŢHWĚR
 szépelgő/XCÔŐŢHWĚR
-széntartalmú/°AŇŐĎFUÎQ
+széntartalmú/°yAŇŐĎFUÎQ
 szénsemleges/Ó×GVËnňLTtląy
 szénsavas/ŇŮFUÎmôKÖSsk°
-szénfekete/ąBÓŐĐGVËR
-szénerőművi/ąyBÓŐĐGVËR
+szénfekete/ąyBÓŐĐGVËR
+szénerőművi/ąyBÓŐĐGVËRén||erő|művi
 szélütött/Ô×ÝňGVĚNRlą
-szélütéses/Ó×GVËnňLTtlą
+szélütéses/Ó×GVËnňLTtląy
 szélvédett/Ó×GVËnňLRlą
 szélvájta/°AŇŐĎFUÎQ
 szélsőséges/Ó×GVËnňLTtlą
-szélsőbaloldali/°BÓŐĐGVËR
+szélsőbaloldali/°yBÓŐĐGVËR
 szélsőbal/ŇŮFUÎmôKÖQk°
 szélsebes/Ó×GVËnňLTtlą
 szélporozta/°yAŇŐĎFUÎQ
-szélmentes/Ó×GVËnňLTtlą
+szélmentes/Ó×GVËnňLTtląy
 szélmarta/°AŇŐĎFUÎQ
-széllelbélelt/Ó×GVËnňLRlą
+széllelbélelt/Ó×GVËnňLRląy
 széljárta/°AŇŐĎFUÎQ
 szélházi/°BÓŐĐGVËR
 szélhajtó/°AŇŐĎFUÎQ
 szélfútta/°AŇŐĎFUÎQ
-szélesvásznú/°AŇŐĎFUÎQ
-szélesvágányú/°AŇŐĎFUÎQ
+szélesvásznú/°yAŇŐĎFUÎQ
+szélesvágányú/°yAŇŐĎFUÎQ
 szélesszájú/°AŇŐĎFUÎQé-les|szá-jú
 szélesorrú/°AŇŐĎFUÎQ
 széleslevelű/ąCÔŐŢHWĚR
@@ -68750,11 +68933,11 @@ szélesfarkú/°AŇŐĎFUÎQ
 széles_sávú/°AŇŐĎFUÎQ
 széles_körű/ąCÔŐŢHWĚR	éleskörűbbenéleskörűbb
 széles/Ó×GVËnňLTtlą
-szélerőművi/ąyBÓŐĐGVËR
-székrekedéses/Ó×GVËnňLTtlą
-székfoglaló/°AŇŐĎFUÎQ
+szélerőművi/ąyBÓŐĐGVËRél||erő|művi
+székrekedéses/Ó×GVËnňLTtląy
+székfoglaló/°yAŇŐĎFUÎQ
 székesfővárosi/°BÓŐĐGVËR
-szégyenteljes/Ó×GVËnňLTtlą
+szégyenteljes/Ó×GVËnňLTtląy
 szégyenteli/ąBÓŐĐGVËR
 szégyentelen/Ó×GVËnňLRlą
 szégyenlős/Ô×ÝňGVĚNMTtlą
@@ -68771,7 +68954,7 @@ százórai/°BÓŐĐGVËR
 százévi/ąBÓŐĐGVËR
 százéves/Ó×GVËnňLTtlą
 százévenkénti/ąBÓŐĐGVËR
-százszázalékos/ŇŮFUÎmôKÖSsk°áz|szá-za-lé-kos
+százszázalékos/ŇŮFUÎmôKÖSsk°yáz|szá-za-lé-kosáz|százalékos
 százszoros/ŇŮFUÎmôKÖSsk°áz-szo-ros
 százrétű/ąCÔŐŢHWĚR
 százrendbeli/ąBÓŐĐGVËR
@@ -68823,7 +69006,7 @@ számiellenes/Ó×GVËnňLTtl
 számicentrikus/ŇŮFUÎmôKÖSsk
 számibarát/ŇŮFUÎmôKÖQk
 számi/°AŇŐĎFUÎQ
-számfeletti/ąBÓŐĐGVËR
+számfeletti/ąyBÓŐĐGVËR
 szállított/ŇŮFUÎmôQk°sX
 szálkás/ŇŮFUÎmôKÖSsk°
 szálas/ŇŮFUÎmôKÖSsk°
@@ -68838,30 +69021,30 @@ szutykos/ŇŮFUÎmôKÖSsk°
 szuszimuszi/°BÓŐĐGVËR
 szurtos/ŇŮFUÎmôKÖSsk°
 szuroksötét/Ó×GVËnňLRlą
-szurokfekete/ąBÓŐĐGVËR
+szurokfekete/ąyBÓŐĐGVËR
 szurkálódó/°AŇŐĎFUÎQ
 szurkos/ŇŮFUÎmôKÖSsk°
 szupraszegmentális/ŇŮFUÎmôKÖSsk°
 szupranacionális/ŇŮFUÎmôKÖSsk°
 szupraindividuális/ŇŮFUÎmôKÖSsk°y
-szuperérzékeny/Ó×GVËnňLTtlą
-szupertitkos/ŇŮFUÎmôKÖSsk°
+szuperérzékeny/Ó×GVËnňLTtląy
+szupertitkos/ŇŮFUÎmôKÖSsk°y
 szuperszonikus/ŇŮFUÎmôKÖSsk°
 szuperszimmetrikus/ŇŮFUÎmôKÖSsk°y
-szupernormális/ŇŮFUÎmôKÖSsk°
-szupermodern/Ó×GVËnňLRlą
+szupernormális/ŇŮFUÎmôKÖSsk°y
+szupermodern/Ó×GVËnňLRląy
 szupermenő/ąCÔŐŢHWĚR
 szuperkritikus/ŇŮFUÎmôKÖSsk°
 szuperklasszis/ŇŮFUÎmôKÖSsk°
-szuperintenzív/Ó×GVËnňLTtlą
-szuperintelligens/Ó×GVËnňLTtlą
-szuperhatékony/ŇŮFUÎmôKÖSsk°
+szuperintenzív/Ó×GVËnňLTtląy
+szuperintelligens/Ó×GVËnňLTtląy
+szuperhatékony/ŇŮFUÎmôKÖSsk°y
 szupergyors/ŇŮFUÎmôKÖSsk
-szupergazdag/ŇŮFUÎmôKÖQk°
-szuperfolyékony/ŇŮFUÎmôKÖSsk°
+szupergazdag/ŇŮFUÎmôKÖQk°y
+szuperfolyékony/ŇŮFUÎmôKÖSsk°y
 szuperexponenciális/ŇŮFUÎmôKÖSsk°
 szupererős/Ô×ÝňGVĚNMTtlą
-szuperbiztos/ŇŮFUÎmôSsk°
+szuperbiztos/ŇŮFUÎmôSsk°y
 szuper/Ó×GVËnňLRlą
 szukcesszív/ŇŮFUÎmôKÖSsÓ×GVËnňLTtklą
 szuicid/ŇŮFUÎmôKÖQk°
@@ -68950,7 +69133,7 @@ szociografikus/ŇŮFUÎmôKÖSsk°
 szocialisztikus/ŇŮFUÎmôKÖSsk°
 szocialista/°AŇŐĎFUÎQ
 szobrászati/°AŇŐĎFUÎQ
-szobatiszta/°AŇŐĎFUÎQ
+szobatiszta/°yAŇŐĎFUÎQ
 szobakonyhás/ŇŮFUÎmôKÖSsk°w
 szobai/°AŇŐĎFUÎQ
 szoba-konyhás/ŇŮFUÎmôKÖSsk°	ph:szobakonyhás
@@ -69061,7 +69244,7 @@ szerény/Ó×GVËnňLTtlą
 szeráfi/°AŇŐĎFUÎQ
 szerző/XCÔŐŢHWĚR
 szerzetesi/ąBÓŐĐGVËR
-szervátültetett/Ó×GVËnňRTtląXát|ültetett
+szervátültetett/Ó×GVËnňRTtląyXát|ültetett
 szervita/°AŇŐĎFUÎQ
 szervilis/Ó×GVËnňLTtlą
 szervi/ąBÓŐĐGVËR
@@ -69071,7 +69254,7 @@ szervezeti/ąBÓŐĐGVËR
 szervetlen/Ó×GVËnňLRlą
 szerves/Ó×GVËnňLTtlą
 szertelen/Ó×GVËnňLRlą
-szertartásos/ŇŮFUÎmôKÖSsk°
+szertartásos/ŇŮFUÎmôKÖSsk°y
 szerpentin/Ó×GVËnňLRlą
 szerkezetkész/Ó×GVËnňLTtlą
 szerkezeti/ąBÓŐĐGVËR
@@ -69094,7 +69277,7 @@ szerbhorvátgyűlölő/CÔŐŢHWĚR
 szerbhorvátellenes/Ó×GVËnňLTtl
 szerbhorvátcentrikus/ŇŮFUÎmôKÖSsk
 szerbhorvátbarát/ŇŮFUÎmôKÖQk
-szerbhorvát/ŇŮFUÎmôKÖQk°
+szerbhorvát/ŇŮFUÎmôKÖQk°y
 szerbgyűlölő/CÔŐŢHWĚR
 szerbellenes/Ó×GVËnňLTtl
 szerbcentrikus/ŇŮFUÎmôKÖSsk
@@ -69116,7 +69299,7 @@ szenvtelen/Ó×GVËnňLRlą
 szenvelgő/ąXCÔŐŢHWĚR
 szenvedésteli/ąyBÓŐĐGVËR
 szenvedélytelen/Ó×GVËnňLRlą
-szenvedélymentes/Ó×GVËnňLTtlą
+szenvedélymentes/Ó×GVËnňLTtląy
 szenvedélyes/Ó×GVËnňLTtlą
 szentélybeli/ąBÓŐĐGVËR
 szentségáruló/°AŇŐĎFUÎQ
@@ -69135,14 +69318,14 @@ szenilis/Ó×GVËnňLTtlą
 szendergő/XCÔŐŢHWĚR
 szenderegő/ąXCÔŐŢHWĚR
 szende/ąBÓŐĐGVËR
-szemüveges/Ó×GVËnňLTtlą
+szemüveges/Ó×GVËnňLTtląy
 szemüregi/ąBÓŐĐGVËR
 szemétlerakó/°AŇŐĎFUÎQ
 szemétledobó/°AŇŐĎFUÎQ
 szemérmetlen/Ó×GVËnňLRlą
 szemérmetes/Ó×GVËnňLTtlą
 szemérmes/Ó×GVËnňLTtlą
-szeméremsértő/ąCÔŐŢHWĚR
+szeméremsértő/ąyCÔŐŢHWĚR
 személytelen/Ó×GVËnňLRlą
 személyi/ąBÓŐĐGVËR
 személyes/Ó×GVËnňLTtlą
@@ -69153,7 +69336,7 @@ szemrehányó/°AŇŐĎFUÎQ
 szemléletes/Ó×GVËnňLTtlą
 szemközti/ąBÓŐĐGVËR
 szemita/°AŇŐĎFUÎQ
-szemipermeábilis/ŇŮFUÎmôKÖSsk°
+szemipermeábilis/ŇŮFUÎmôKÖSsk°y
 szemilineáris/ŇŮFUÎmôKÖSsk°
 szemiinfinit/Ó×GVËnňLRlą
 szemidefinit/Ó×GVËnňLRlą
@@ -69168,8 +69351,8 @@ szemergett/Ó×GVËnňLRlą
 szemelt/Ó×GVËnňLRlą
 szemcsézett/Ó×GVËnňLRlą
 szemcsés/Ó×GVËnňLTtlą
-szembeállított/ŇŮFUÎmôQk°sX
-szembetűnő/ąCÔŐŢHWĚR
+szembeállított/ŇŮFUÎmôQk°ysX
+szembetűnő/ąyCÔŐŢHWĚR
 szemben_álló/°AŇŐĎFUÎQ	állóbbikállóbbanállóbb
 szembeli/ąBÓŐĐGVËR
 szemantikus/ŇŮFUÎmôKÖSsk°
@@ -69189,14 +69372,14 @@ szelepes/Ó×GVËnňLTtlą
 szelepelt/Ó×GVËnňLRlą
 szelektív/Ó×GVËnňLTtlą
 szeleburdi/°AŇŐĎFUÎQ
-szekérnyomos/ŇŮFUÎmôKÖSsk°
+szekérnyomos/ŇŮFUÎmôKÖSsk°y
 szekánt/ŇŮFUÎmôKÖQk°
 szekáns/ŇŮFUÎmôKÖSsk°
 szekvenciális/ŇŮFUÎmôKÖSsk°
 szekunder/Ó×GVËnňLRlą
 szekuláris/ŇŮFUÎmôKÖSsk°
 szektorális/ŇŮFUÎmôKÖSsk°
-szektorsemleges/Ó×GVËnňLTtlą
+szektorsemleges/Ó×GVËnňLTtląy
 szektoriális/ŇŮFUÎmôKÖSsk°
 szektariánus/ŇŮFUÎmôKÖSsk°
 szekréciós/ŇŮFUÎmôKÖSsk°
@@ -69217,12 +69400,13 @@ szaúd-arábiai/AŇŐĎFUÎQ
 szavazóképes/Ó×GVËnňLTtlą
 szavatolt/ŇŮFUÎmôQk°
 szavatartó/°AŇŐĎFUÎQ
-szavajátszó/°AŇŐĎFUÎQ
-szavahihető/ąCÔŐŢHWĚR
+szavajátszó/°yAŇŐĎFUÎQ
+szavahihető/ąyCÔŐŢHWĚR
+szavahihetetlen/Ó×GVËnňLRląy
 szatirikus/ŇŮFUÎmôKÖSsk°
 szarvatlan/ŇŮFUÎmôKÖQk°
 szarus/ŇŮFUÎmôKÖSsk°
-szarukeretes/Ó×GVËnňLTtlą
+szarukeretes/Ó×GVËnňLTtląy
 szarmata/°AŇŐĎFUÎQ
 szarkasztikus/ŇŮFUÎmôKÖSsk°
 szarjankó/°AŇŐĎFUÎQ=
@@ -69235,12 +69419,12 @@ szanszkritgyűlölő/CÔŐŢHWĚR
 szanszkritellenes/Ó×GVËnňLTtl
 szanszkritcentrikus/ŇŮFUÎmôKÖSsk
 szanszkritbarát/ŇŮFUÎmôKÖQk
-szanszkrit/ŇŮFUÎmôKÖQk°
+szanszkrit/ŇŮFUÎnňKÖQÓ×GVËmôLRkl°
 szangvinikus/ŇŮFUÎmôKÖSsk°
 szamár/ŇŮFUÎmôKÖQk°
 szamojéd/ŇŮFUÎmôKÖQÓ×GVËnňLRklą
 szamizdat/ŇŮFUÎmôKÖQk°
-szalonképtelen/Ó×GVËnňLRlą
+szalonképtelen/Ó×GVËnňLRląy
 szalmás/ŇŮFUÎmôKÖSsk°
 szalmasárga/°AŇŐĎFUÎQ
 szalmaszőke/ąBÓŐĐGVËR
@@ -69252,28 +69436,28 @@ szakértő/ąCÔŐŢHWĚR
 szakállú/°AŇŐĎFUÎQ
 szakálltalan/ŇŮFUÎmôKÖQk°
 szakállas/ŇŮFUÎmôKÖSsk°
-szaktanácsadó/°AŇŐĎFUÎQ
+szaktanácsadó/°yAŇŐĎFUÎQ
 szakszerűtlen/Ó×GVËnňLRlą
 szakszerű/ąCÔŐŢHWĚR
-szakszervezeti/ąBÓŐĐGVËR
+szakszervezeti/ąyBÓŐĐGVËR
 szakrális/ŇŮFUÎmôKÖSsk°
 szakos/ŇŮFUÎmôKÖSsk°
 szakmaiatlan/ŇŮFUÎmôKÖQk°
 szakmai/°AŇŐĎFUÎQ
-szakmabeli/ąBÓŐĐGVËR
-szakközépiskolai/°AŇŐĎFUÎQ
-szakképzett/Ó×GVËnňLRlą
-szakképzetlen/Ó×GVËnňLRlą
+szakmabeli/ąyBÓŐĐGVËR
+szakközépiskolai/°yAŇŐĎFUÎQ
+szakképzett/Ó×GVËnňLRląy
+szakképzetlen/Ó×GVËnňLRląy
 szakbeli/ąBÓŐĐGVËR
 szakbarbár/ŇŮFUÎmôKÖQk°
-szakavatott/ŇŮFUÎmôQk°sX
+szakavatott/ŇŮFUÎmôQk°ysX
 szakaszos/ŇŮFUÎmôKÖSsk°
 szakaszoló/°AŇŐĎFUÎQ
 szakadékony/ŇŮFUÎmôKÖSsk°
 szakadatlan/ŇŮFUÎmôKÖQk°
 szagtalan/ŇŮFUÎmôKÖQk°
 szagos/ŇŮFUÎmôKÖSsk°
-szaglószervi/ąBÓŐĐGVËR
+szaglószervi/ąyBÓŐĐGVËR
 szaggatott/ŇŮFUÎmôQk°sX
 szagelszívó/°AŇŐĎFUÎQ
 szadisztikus/ŇŮFUÎmôKÖSsk°
@@ -69296,12 +69480,12 @@ szabadszájú/°AŇŐĎFUÎQ
 szabadszirmú/°AŇŐĎFUÎQ
 szabadstílusú/°AŇŐĎFUÎQ
 szabados/ŇŮFUÎmôKÖSsk°
-szabadkőműves/Ó×GVËnňLTtląő|műves
+szabadkőműves/Ó×GVËnňLTtląyő|műves
 szabadkézi/ąBÓŐĐGVËR
 szabadgondolkozó/°AŇŐĎFUÎQ
-szabadgondolkodó/°AŇŐĎFUÎQ
+szabadgondolkodó/°yAŇŐĎFUÎQ
 szabadföldi/ąBÓŐĐGVËR
-szabadfogású/°AŇŐĎFUÎQ
+szabadfogású/°yAŇŐĎFUÎQ
 szabadelvű/ąCÔŐŢHWĚR
 szabadalmaztatott/ŇŮFUÎmôQk°sX
 szabadalmazatlan/ŇŮFUÎmôKÖQk°
@@ -69319,6 +69503,7 @@ svábbarát/ŇŮFUÎmôKÖQk
 sváb/°
 svindlis/Ó×GVËnňLTtlą
 sutyorgó/XAŇŐĎFUÎQ
+suttyó/°AŇŐĎFUÎQ
 suta/°AŇŐĎFUÎQ
 sustorgó/XAŇŐĎFUÎQ
 sunyorgó/XAŇŐĎFUÎQ
@@ -69331,10 +69516,10 @@ sumer/Ó×GVËnňLRlą
 sulykolt/ŇŮFUÎmôQk°
 sugárzó/XAŇŐĎFUÎQ
 sugártörő/ąCÔŐŢHWĚR
-sugárszennyezett/Ó×GVËnňLRlą
+sugárszennyezett/Ó×GVËnňLRląy
 sugározó/°XAŇŐĎFUÎQ
-sugárirányú/°AŇŐĎFUÎQ
-sugárfertőzött/Ô×ÝňGVĚNRTtlą
+sugárirányú/°yAŇŐĎFUÎQ
+sugárfertőzött/Ô×ÝňGVĚNRTtląy
 sugaras/ŇŮFUÎmôKÖSsk°
 sudár/ŇŮFUÎmôKÖQk°
 subás/ŇŮFUÎmôKÖSsk°
@@ -69374,7 +69559,7 @@ spéci/ąBÓŐĐGVËR
 spártai/°AŇŐĎFUÎQ
 sprőd/Ô×ÝňGVĚNMRą
 sprayes/Ó×GVËnňLTtlą
-sportválogatott/ŇŮFUÎmôQk°sX
+sportválogatott/ŇŮFUÎmôQk°ysX
 sportszerűtlen/Ó×GVËnňLRlą
 sportszerű/ąCÔŐŢHWĚR
 sportos/ŇŮFUÎmôKÖSsk°
@@ -69437,7 +69622,7 @@ sokmilliószoros/ŇŮFUÎmôKÖSsk°
 sokmilliárdszoros/ŇŮFUÎmôKÖSsk°
 soklapú/°AŇŐĎFUÎQ
 sokkötetes/Ó×GVËnňLTtlą
-sokistenhívő/ąyCÔŐŢHWĚR
+sokistenhívő/ąyCÔŐŢHWĚRívő
 sokheti/ąBÓŐĐGVËR
 sokhetenkénti/ąBÓŐĐGVËR
 sokhavonkénti/ąBÓŐĐGVËR
@@ -69492,7 +69677,7 @@ siket/Ó×GVËnňLRlą
 sikerült/Ô×ÝňGVĚNRlą
 sikerületlen/Ó×GVËnňLRlą
 sikertelen/Ó×GVËnňLRlą
-sikerorientált/ŇŮFUÎmôQk°
+sikerorientált/ŇŮFUÎmôQk°y
 sikeretlen/Ó×GVËnňLRlą
 sikeres/Ó×GVËnňLTtlą
 sikamlós/ŇŮFUÎmôKÖSsk°
@@ -69590,10 +69775,11 @@ rühes/Ó×GVËnňLTtlą
 rücskös/Ô×ÝňGVĚNMTtlą
 rút/ŇŮFUÎmôKÖQ°
 rúd_alakú/°AŇŐĎFUÎQ
+rövidpályás/ŇŮFUÎmôKÖSsk°y
 rövidlátó/°AŇŐĎFUÎQ
-rövidlejáratú/°AŇŐĎFUÎQ
+rövidlejáratú/°yAŇŐĎFUÎQ
 rövidkarmú/°AŇŐĎFUÎQ
-rövidhullámú/°AŇŐĎFUÎQ
+rövidhullámú/°yAŇŐĎFUÎQ
 rövideszű/ąCÔŐŢHWĚR
 rövidcsőrű/ąCÔŐŢHWĚR
 rövid_szőrű/ąCÔŐŢHWĚR
@@ -69612,7 +69798,7 @@ rózsás/ŇŮFUÎmôKÖSsk°
 rózsaszínű/ąCÔŐŢHWĚR
 rózsaszín/Ó×GVËnňLRląy
 rózsapiros/ŇŮFUÎmôKÖSsk°
-rózsakeresztes/Ó×GVËnňLTtlą
+rózsakeresztes/Ó×GVËnňLTtląy
 rótt/ŇŮFUÎmôQ°)ó
 rótt/ŇŮFUÎmôQ°
 római/°AŇŐĎFUÎQ
@@ -69637,12 +69823,12 @@ rétegező/ąXCÔŐŢHWĚR
 részvétteljes/Ó×GVËnňLTtlą
 részvétteli/ąyBÓŐĐGVËR
 részvéttelen/Ó×GVËnňLRlą
-részvétlen/Ó×GVËnňLRlą
+részvétlen/Ó×GVËnňLRląy
 részvevő/ąCÔŐŢHWĚR
 részt_vett/Ó×GVËnňLRlą
 részrehajló/°AŇŐĎFUÎQ
 részrehajlatlan/ŇŮFUÎmôKÖQk°
-részletgazdag/ŇŮFUÎmôKÖQk°
+részletgazdag/ŇŮFUÎmôKÖQk°y
 részletezett/Ó×GVËnňLRlą
 részletes/Ó×GVËnňLTtlą
 részletdús/ŇŮFUÎmôKÖSsk°y
@@ -69656,7 +69842,7 @@ részeg/Ó×GVËnňLRTtlą
 részbenrendezett/Ó×GVËnňLRlą
 részbeni/ąBÓŐĐGVËR
 részbeli/ąBÓŐĐGVËR
-részarányos/ŇŮFUÎmôKÖSsk°
+részarányos/ŇŮFUÎmôKÖSsk°y
 rémült/Ô×ÝňGVĚNRlą
 rémületes/Ó×GVËnňLTtlą
 rémes/Ó×GVËnňLTtlą
@@ -69717,9 +69903,9 @@ rozsdástorkú/°AŇŐĎFUÎQ
 rozsdás/ŇŮFUÎmôKÖSsk°
 rozsdavörös/Ô×ÝňGVĚNMTtlą
 rozsdaszínű/ąCÔŐŢHWĚR
-rozsdamentes/Ó×GVËnňLTtlą
+rozsdamentes/Ó×GVËnňLTtląy
 rozsdaette/ąBÓŐĐGVËR
-rozsdabarnás/ŇŮFUÎmôKÖSsk°
+rozsdabarnás/ŇŮFUÎmôKÖSsk°y
 rozsdabarna/°AŇŐĎFUÎQ
 rozoga/°AŇŐĎFUÎQ
 royalista/°AŇŐĎFUÎQ
@@ -69735,14 +69921,14 @@ rostálatlan/ŇŮFUÎmôKÖQk°
 rostos/ŇŮFUÎmôKÖSsk°
 rostokoló/°XAŇŐĎFUÎQ
 rostokló/XAŇŐĎFUÎQ
-rostgazdag/ŇŮFUÎmôKÖQk°
+rostgazdag/ŇŮFUÎmôKÖQk°y
 rostdús/ŇŮFUÎmôKÖSsk°
 rosszízű/ąCÔŐŢHWĚR
 rossznyelvű/ąCÔŐŢHWĚR
 rosszmájú/°AŇŐĎFUÎQ
 rosszképű/ąCÔŐŢHWĚR
 rosszkedvű/ąCÔŐŢHWĚR
-rosszindulatú/°AŇŐĎFUÎQ
+rosszindulatú/°yAŇŐĎFUÎQ
 rosszhiszemű/ąCÔŐŢHWĚR
 rossz-szívű/ąCÔŐŢHWĚR
 rossz/ŇŮFUÎmôSs°	éié
@@ -69791,7 +69977,7 @@ rohadt/ŇŮFUÎmôKÖQk°
 robusztus/ŇŮFUÎmôKÖSsk°	ph:robosztus
 robinsonos/ŇŮFUÎmôKÖSsk
 robbanékony/ŇŮFUÎmôKÖSsk°
-robbanásvédett/Ó×GVËnňLRlą
+robbanásvédett/Ó×GVËnňLRląy
 riói/AŇŐĎFUÎQ
 rizlingszilváni/°BÓŐĐGVËR
 rivális/ŇŮFUÎmôKÖSsk°
@@ -69860,12 +70046,13 @@ rendületlen/Ó×GVËnňLRlą
 rendű/ąCÔŐŢHWĚR
 rendíthetetlen/Ó×GVËnňLRlą
 rendszerű/ąCÔŐŢHWĚR
-rendszertelen/Ó×GVËnňLRlą
-rendszerjellegű/ąyCÔŐŢHWĚR
+rendszertelen/Ó×GVËnňLRląy
+rendszerközeli/ąyBÓŐĐGVËR
+rendszerjellegű/ąyCÔŐŢHWĚRű
 rendszerhű/ąCÔŐŢHWĚR
-rendszerető/ąCÔŐŢHWĚR
-rendszeres/Ó×GVËnňLTtlą
-rendkívüli/ąBÓŐĐGVËR
+rendszerető/ąyCÔŐŢHWĚR
+rendszeres/Ó×GVËnňLTtląy
+rendkívüli/ąyBÓŐĐGVËR
 rendhagyó/°AŇŐĎFUÎQ
 rendezett/Ó×GVËnňLRlą
 rendezetlen/Ó×GVËnňLRlą
@@ -69874,8 +70061,8 @@ rendes/Ó×GVËnňLTtlą
 rendelt/Ó×GVËnňLRlą
 rendellenes/Ó×GVËnňLTtląy
 rendbeli/ąBÓŐĐGVËR
-reményvesztett/Ó×GVËnňLRlą
-reményteljes/Ó×GVËnňLTtlą
+reményvesztett/Ó×GVËnňLRląy
+reményteljes/Ó×GVËnňLTtląy
 reményteli/ąBÓŐĐGVËR
 reménytelen/Ó×GVËnňLRlą
 reménydús/ŇŮFUÎmôKÖSsk°y
@@ -69890,9 +70077,10 @@ relativisztikus/ŇŮFUÎmôKÖSsk°
 relativista/°AŇŐĎFUÎQ
 rekurzív/ŇŮFUÎmôKÖSsk°
 rekuperált/ŇŮFUÎmôQk°
-rekordnagyságú/°AŇŐĎFUÎQ
+rekordnagyságú/°yAŇŐĎFUÎQ
 rekordmagas/ŇŮFUÎmôKÖSsk°y
 rekordgyors/ŇŮFUÎmôKÖSsk
+rekordalacsony/ŇŮFUÎmôKÖSsk°y
 rekedtes/Ó×GVËnňLTtlą
 rekedt/Ó×GVËnňLRlą
 rejtélyes/Ó×GVËnňLTtlą
@@ -69916,7 +70104,7 @@ redős/Ô×ÝňGVĚNMTtlą
 redves/Ó×GVËnňLTtlą
 redundáns/ŇŮFUÎmôKÖSsk°
 reduktív/ŇŮFUÎmôKÖSsÓ×GVËnňLTtklą
-recésszárnyú/°AŇŐĎFUÎQés|szár-nyúés|szárnyú
+recésszárnyú/°yAŇŐĎFUÎQés|szár-nyúés|szárnyú
 recés/Ó×GVËnňLTtlą
 reciprok/ŇŮFUÎmôKÖQSsk°
 reciprocitási/°BÓŐĐGVËR
@@ -69937,7 +70125,7 @@ raplis/ŇŮFUÎmôKÖSsk°
 rapid/ŇŮFUÎmôKÖQk°
 rangú/°AŇŐĎFUÎQ
 rangos/ŇŮFUÎmôKÖSsk°
-ranglistaelső/ąCÔŐŢHWĚR
+ranglistaelső/ąyCÔŐŢHWĚRő
 rangjavesztett/Ó×GVËnňLRlą
 rangidős/Ô×ÝňGVĚNMTtlą
 rangelső/ąCÔŐŢHWĚR
@@ -69946,7 +70134,7 @@ ramaty/ŇŮFUÎmôKÖSsk°
 rakó/°XYAŇŐĎFUÎQ)Ó_PRESPART_adj
 rakó/°XYAŇŐĎFUÎQ
 rakétakilövő/ąCÔŐŢHWĚR
-rakétahajtású/°AŇŐĎFUÎQ
+rakétahajtású/°yAŇŐĎFUÎQ
 raktáros/ŇŮFUÎmôKÖSsk°
 rakott/ŇŮFUÎmôQk°sX)
 rakott/ŇŮFUÎmôQk°sX
@@ -69980,6 +70168,7 @@ rabiátus/ŇŮFUÎmôKÖSsk°
 rabbinusi/°AŇŐĎFUÎQ
 rabbinikus/ŇŮFUÎmôKÖSsk°
 quimbys/ŇŮFUÎmôKÖSsk
+queer/Ó×GVËnňLRlą	ph:kvír
 püthagoraszi/AŇŐĎFUÎQ
 püspöklila/°AŇŐĎFUÎQ
 púpos/ŇŮFUÎmôKÖSsk°
@@ -70016,8 +70205,8 @@ péter-páli/AŇŐĎFUÎQ
 pépes/Ó×GVËnňLTtlą
 pénzügyi/ąBÓŐĐGVËR
 pénztelen/Ó×GVËnňLRlą
-pénzsóvár/ŇŮFUÎmôKÖQk°yénz|só-vár
-pénzigényes/Ó×GVËnňLTtlą
+pénzsóvár/ŇŮFUÎmôKÖQk°yénz|só-várénz|sóvár
+pénzigényes/Ó×GVËnňLTtląy
 pénzes/Ó×GVËnňLTtlą
 pénzbeni/ąBÓŐĐGVËR
 pénzbeli/ąBÓŐĐGVËR
@@ -70026,9 +70215,11 @@ példás/ŇŮFUÎmôKÖSsk°
 példaértékű/ąCÔŐŢHWĚR
 pázsitos/ŇŮFUÎmôKÖSsk°
 párzó/XAŇŐĎFUÎQ
+pártus/ŇŮFUÎmôKÖSsk°
 pártszerűtlen/Ó×GVËnňLRlą
-pártsemleges/Ó×GVËnňLTtlą
-pártonkívüli/ąBÓŐĐGVËR
+pártsemleges/Ó×GVËnňLTtląy
+pártonkívüli/ąyBÓŐĐGVËR
+pártközeli/ąyBÓŐĐGVËR
 párthű/ąyCÔŐŢHWĚR
 pártatlan/ŇŮFUÎmôKÖQk°
 párszigyűlölő/CÔŐŢHWĚR
@@ -70055,7 +70246,7 @@ páradús/ŇŮFUÎmôKÖSsk°
 pár_havi/°BÓŐĐGVËR
 pápua/°AŇŐĎFUÎQ
 pápista/°AŇŐĎFUÎQ
-pápaszemes/Ó×GVËnňLTtlą
+pápaszemes/Ó×GVËnňLTtląy
 pápapárti/°yAŇŐĎFUÎQ
 pángermán/ŇŮFUÎmôKÖQk°
 páneurópai/°AŇŐĎFUÎQ
@@ -70116,7 +70307,7 @@ próbálatlan/ŇŮFUÎmôKÖQk°
 próbaidős/Ô×ÝňGVĚNMTtlą
 príma/°AŇŐĎFUÎQ
 préselt/Ó×GVËnňLRlą
-prémbélésű/ąCÔŐŢHWĚR
+prémbélésű/ąyCÔŐŢHWĚR
 prudens/Ó×GVËnňLTtlą
 prudenciális/ŇŮFUÎmôKÖSsk°
 proximális/ŇŮFUÎmôKÖSsk°
@@ -70147,7 +70338,7 @@ progresszív/ŇŮFUÎmôKÖSsÓ×GVËnňLTtklą
 programozott/sX
 prognosztikus/ŇŮFUÎmôKÖSsk°
 profán/ŇŮFUÎmôKÖQk°
-profitérdekelt/Ó×GVËnňLRlą
+profitérdekelt/Ó×GVËnňLRląy
 profitábilis/ŇŮFUÎmôKÖSsÓ×GVËnňLTtklą
 profitorientált/ŇŮFUÎmôQk°
 profi/°AŇŐĎFUÎQ
@@ -70156,8 +70347,8 @@ professzionális/ŇŮFUÎmôKÖSsk°
 produktív/ŇŮFUÎmôKÖSsÓ×GVËnňLTtklą
 procedurális/ŇŮFUÎmôKÖSsk°
 procc/ŇŮFUÎmôKÖSs°
-problémaérzékeny/Ó×GVËnňLTtlą
-problémamegoldó/°AŇŐĎFUÎQ
+problémaérzékeny/Ó×GVËnňLTtląy
+problémamegoldó/°AŇŐĎFUÎQéma||meg|oldó
 problematikus/ŇŮFUÎmôKÖSsk°
 proaktív/ŇŮFUÎmôKÖQk°	ph:pro-aktív
 privát/ŇŮFUÎmôKÖQk°
@@ -70181,7 +70372,7 @@ preferenciális/ŇŮFUÎmôKÖSsk°
 preemptív/Ó×GVËnňLTtlą
 prediktív/Ó×GVËnňLTtlą
 precíziós/ŇŮFUÎmôKÖSsk°
-precíz/Ó×GVËnňLTtlą
+precíz/Ó×GVËnňLTtlą	ph:percíz
 pravoszláv/ŇŮFUÎmôKÖQk°
 praktikus/ŇŮFUÎmôKÖSsk°
 pragmatista/°AŇŐĎFUÎQ
@@ -70196,13 +70387,13 @@ potrohos/ŇŮFUÎmôKÖSsk°
 potens/Ó×GVËnňLTtlą
 potenciális/ŇŮFUÎmôKÖSsk°
 posztumusz/ŇŮFUÎmôKÖSsk°	ph:poszthumusz	ph:poszthumus	ph:posthumous
-posztszocialista/°AŇŐĎFUÎQ
-posztmodern/Ó×GVËnňLRlą
-posztindusztriális/ŇŮFUÎmôKÖSsk°
+posztszocialista/°yAŇŐĎFUÎQ
+posztmodern/Ó×GVËnňLRląy
+posztindusztriális/ŇŮFUÎmôKÖSsk°y
 posztgraduális/ŇŮFUÎmôKÖSsk°
 posztfeudális/ŇŮFUÎmôKÖSsk°
-posztembrionális/ŇŮFUÎmôKÖSsk°
-posztbiblikus/ŇŮFUÎmôKÖSsk°
+posztembrionális/ŇŮFUÎmôKÖSsk°y
+posztbiblikus/ŇŮFUÎmôKÖSsk°y
 posványos/ŇŮFUÎmôKÖSsk°
 postai/°AŇŐĎFUÎQ
 posszibilis/ŇŮFUÎmôKÖSsÓ×GVËnňLTtklą
@@ -70234,6 +70425,7 @@ porhanyó/°AŇŐĎFUÎQ
 por_alakú/°AŇŐĎFUÎQ
 populáris/ŇŮFUÎmôKÖSsk°
 populista/°AŇŐĎFUÎQ
+popkulturális/ŇŮFUÎmôKÖSsk°y
 pontszimmetrikus/ŇŮFUÎmôKÖSsk°
 pontoskodó/°AŇŐĎFUÎQ
 pontos/ŇŮFUÎmôKÖSsk°
@@ -70245,7 +70437,7 @@ poláros/ŇŮFUÎmôKÖSsk°
 poláris/ŇŮFUÎmôKÖSsk°
 polyvás/ŇŮFUÎmôKÖSsk°
 poloskás/ŇŮFUÎmôKÖSsk°
-pollenérzékeny/Ó×GVËnňLTtlą
+pollenérzékeny/Ó×GVËnňLTtląy
 politúrozatlan/ŇŮFUÎmôKÖQk°
 politropikus/ŇŮFUÎmôKÖSsk°
 politikus/ŇŮFUÎmôKÖSsk°
@@ -70277,8 +70469,8 @@ pohos/ŇŮFUÎmôKÖSsk°
 pogányos/ŇŮFUÎmôKÖSsk°
 pogány/ŇŮFUÎmôKÖSsk°
 pofátlan/ŇŮFUÎmôKÖQk°
-pofonegyszerű/ąCÔŐŢHWĚR
-pofaszakállas/ŇŮFUÎmôKÖSsk°
+pofonegyszerű/ąyCÔŐŢHWĚR
+pofaszakállas/ŇŮFUÎmôKÖSsk°y
 pocsékló/°AŇŐĎFUÎQ
 pocsék/ŇŮFUÎmôKÖQk°
 pocakos/ŇŮFUÎmôKÖSsk°
@@ -70314,7 +70506,7 @@ pitiáner/Ó×GVËnňLRlą
 piti/ąBÓŐĐGVËR
 piszlicsáré/°AŇŐĎFUÎQ
 piszlicsár/ŇŮFUÎmôKÖQk°
-piszkosszürke/ąBÓŐĐGVËRür-ke
+piszkosszürke/ąyBÓŐĐGVËRür-keürke
 piszkosfehér/Ó×GVËnňLRlą
 piszkos/ŇŮFUÎmôKÖSsk°
 pisze/ąBÓŐĐGVËR
@@ -70330,7 +70522,7 @@ pisilhatatlan/ŇŮFUÎmôKÖQkX)
 pirruszi/°AŇŐĎFUÎQ
 pirotechnikai/°AŇŐĎFUÎQ
 pirostarka/°AŇŐĎFUÎQ
-pirospozsgás/ŇŮFUÎmôKÖSsk°
+pirospozsgás/ŇŮFUÎmôKÖSsk°y
 pirosló/°AŇŐĎFUÎQ
 piroslábú/°AŇŐĎFUÎQ
 pirosfejű/ąCÔŐŢHWĚR
@@ -70383,7 +70575,7 @@ pici/ąBÓŐĐGVËR
 piacsenzai/°BÓŐĐGVËR
 piacorientált/ŇŮFUÎmôQk°
 piacképes/Ó×GVËnňLTtlą
-piackonform/ŇŮFUÎmôKÖSsk°
+piackonform/ŇŮFUÎmôKÖSsk°y
 piaci/°AŇŐĎFUÎQ
 philipses/Ó×GVËnňLTtl
 pezsgő/ąXCÔŐŢHWĚR
@@ -70439,8 +70631,8 @@ penészzöld/Ô×ÝňGVĚNRlą
 penészes/Ó×GVËnňLTtlą
 pentatonikus/ŇŮFUÎmôKÖSsk°
 pentagonális/ŇŮFUÎmôKÖSsk°
-penicillinérzékeny/Ó×GVËnňLTtlą
-pengevékony/ŇŮFUÎmôKÖSsk°
+penicillinérzékeny/Ó×GVËnňLTtląy
+pengevékony/ŇŮFUÎmôKÖSsk°y
 penetráns/ŇŮFUÎmôKÖSsk°
 pendelyházi/°BÓŐĐGVËR
 pendelyes/Ó×GVËnňLTtlą
@@ -70460,7 +70652,7 @@ pedzett/Ó×GVËnňRlątX
 pedzetlen/Ó×GVËnňLRlX)
 pedzendő/XCÔŐŢHWĚR)Ó_FUTPART_adj
 pedrő/XCÔŐŢHWĚR
-pedofil/ŇŮFUÎmôKÖQk°
+pedofil/ŇŮFUÎnňKÖQÓ×GVËmôLRkl°
 pedagógiai/°AŇŐĎFUÎQ
 pedagogikus/ŇŮFUÎmôKÖSsk°
 pecsétes/Ó×GVËnňLTtlą
@@ -70470,7 +70662,7 @@ peches/Ó×GVËnňLTtlą
 pazarló/°XAŇŐĎFUÎQ
 pazar/ŇŮFUÎmôKÖQk°
 pavarottis/ŇŮFUÎmôKÖSsk
-patyolattiszta/°AŇŐĎFUÎQ
+patyolattiszta/°yAŇŐĎFUÎQ
 patyolatfehér/Ó×GVËnňLRlą
 pattogzott/sX
 pattogatott/ŇŮFUÎmôQk°sX
@@ -70499,7 +70691,7 @@ parázna/°AŇŐĎFUÎQ
 parás/ŇŮFUÎmôKÖSsk°
 parányi/°AŇŐĎFUÎQ
 parttalan/ŇŮFUÎmôKÖQk°
-partraszálló/°AŇŐĎFUÎQ
+partraszálló/°yAŇŐĎFUÎQ
 partiképes/Ó×GVËnňLTtlą
 partikuláris/ŇŮFUÎmôKÖSsk°
 parti/°AŇŐĎFUÎQ	ph:party	ph:part	ph:part
@@ -70518,7 +70710,7 @@ parapszichológikus/ŇŮFUÎmôKÖSsk°
 parapet/Ó×GVËnňLRlą
 paranormális/ŇŮFUÎmôKÖSsk°
 paranoid/ŇŮFUÎmôKÖQk°
-parancsuralmi/°AŇŐĎFUÎQ
+parancsuralmi/°yAŇŐĎFUÎQ
 parancsnokoló/°XAŇŐĎFUÎQ
 parancsnokló/XAŇŐĎFUÎQ
 paramilitáris/ŇŮFUÎmôKÖSsk°
@@ -70531,7 +70723,7 @@ paradox/ŇŮFUÎmôKÖSsk°
 paradigmatikus/ŇŮFUÎmôKÖSsk°
 paradicsomi/°AŇŐĎFUÎQ
 parabolikus/ŇŮFUÎmôKÖSsk°
-papírvékony/ŇŮFUÎmôKÖSsk°
+papírvékony/ŇŮFUÎmôKÖSsk°y
 papságellenes/Ó×GVËnňLTtląy
 paprikavörös/Ô×ÝňGVĚNMTtlą
 paprikapiros/ŇŮFUÎmôKÖSsk°
@@ -70554,7 +70746,7 @@ pallérozatlan/ŇŮFUÎmôKÖQk°
 paleolitikus/ŇŮFUÎmôKÖSsk°
 paleolit/ŇŮFUÎmôKÖQk°
 palatális/ŇŮFUÎmôKÖSsk°
-palaszürke/ąBÓŐĐGVËR
+palaszürke/ąyBÓŐĐGVËR
 palakék/Ó×GVËnňLRlą
 palackzöld/Ô×ÝňGVĚNRlą
 palackkirakó/°AŇŐĎFUÎQ
@@ -70568,7 +70760,7 @@ padlizsánlila/°AŇŐĎFUÎQ
 pacifista/°AŇŐĎFUÎQ
 paccer/Ó×GVËnňLRlą
 ozmotikus/ŇŮFUÎmôKÖSsk°
-oxigénigényes/Ó×GVËnňLTtlą
+oxigénigényes/Ó×GVËnňLTtląy
 oxigéndús/ŇŮFUÎmôKÖSsk°
 oxidatív/ŇŮFUÎmôKÖQk°
 ovális/ŇŮFUÎmôKÖSsk°
@@ -70614,9 +70806,9 @@ ortokromatikus/ŇŮFUÎmôKÖSsk°
 ortogonális/ŇŮFUÎmôKÖSsk°
 ortodox/ŇŮFUÎmôKÖSsk°
 ortocentrikus/ŇŮFUÎmôKÖSsk°
-orsócsonti/°AŇŐĎFUÎQ
+orsócsonti/°yAŇŐĎFUÎQ
 országos/ŇŮFUÎmôKÖSsk°
-országokbeli/ąBÓŐĐGVËR
+országokbeli/ąyBÓŐĐGVËR
 országnévi/ąBÓŐĐGVËR
 országházi/°AŇŐĎFUÎQ
 orsolyita/°AŇŐĎFUÎQ
@@ -70655,6 +70847,7 @@ optikai/°AŇŐĎFUÎQ
 operábilis/ŇŮFUÎmôKÖSsk°
 operatív/ŇŮFUÎmôKÖQk°
 operai/°AŇŐĎFUÎQ
+openstreetmapes/Ó×GVËnňLTtl	ph:OpenStreetMap-es
 opendocumentes/Ó×GVËnňLTtl
 opcionális/ŇŮFUÎmôKÖSsk°
 onyega-tói/°wAŇŐĎFUÎQ
@@ -70688,7 +70881,7 @@ olvashatatlan/ŇŮFUÎmôKÖQk°
 olvasatlan/ŇŮFUÎmôKÖQk°
 olvadékony/ŇŮFUÎmôKÖSsk°
 olvadt/ŇŮFUÎmôKÖQk°
-oltásszkeptikus/ŇŮFUÎmôKÖSsk°
+oltásszkeptikus/ŇŮFUÎmôKÖSsk°yás|szkeptikus
 olthatatlan/ŇŮFUÎmôKÖQk°
 oltatlan/ŇŮFUÎmôKÖQk°
 olimpiai/°AŇŐĎFUÎQ
@@ -70708,7 +70901,7 @@ olaszcentrikus/ŇŮFUÎmôKÖSsk
 olaszbarát/ŇŮFUÎmôKÖQk
 olasz/ŇŮFUÎmôKÖSsk°
 olajzöld/Ô×ÝňGVĚNRlą
-olajtartalmú/°AŇŐĎFUÎQ
+olajtartalmú/°yAŇŐĎFUÎQ
 olajszínű/ąCÔŐŢHWĚR
 olajozatlan/ŇŮFUÎmôKÖQk°
 olajos/ŇŮFUÎmôKÖSsk°
@@ -70798,26 +70991,26 @@ négyütemű/ąCÔŐŢHWĚR
 négyóránkénti/ąBÓŐĐGVËR
 négyórai/°BÓŐĐGVËR
 négyévi/ąBÓŐĐGVËR
-négyévenkénti/ąBÓŐĐGVËR
+négyévenkénti/ąyBÓŐĐGVËR
 négyzetes/Ó×GVËnňLTtlą
 négyzet_alakú/°AŇŐĎFUÎQ
 négyszögű/ąCÔŐŢHWĚR
-négyszögletes/Ó×GVËnňLTtlą
-négyszemközti/ąBÓŐĐGVËR
+négyszögletes/Ó×GVËnňLTtląy
+négyszemközti/ąyBÓŐĐGVËR
 négyrétű/ąCÔŐŢHWĚR
 négyrendbeli/ąBÓŐĐGVËR
-négypárevezős/Ô×ÝňGVĚNMTtlą
+négypárevezős/Ô×ÝňGVĚNMTtląy
 négypercenkénti/ąBÓŐĐGVËR
 négyosztályos/ŇŮFUÎmôKÖSsk°
 négynaponkénti/ąBÓŐĐGVËR
 négylovas/ŇŮFUÎmôKÖSsk°
-négykerekű/ąCÔŐŢHWĚR
+négykerekű/ąyCÔŐŢHWĚR
 négyismeretlenes/Ó×GVËnňLTtlą
 négyheti/ąBÓŐĐGVËR
 négyhetenkénti/ąBÓŐĐGVËR
 négyhavonkénti/ąBÓŐĐGVËR
 négyhavi/°BÓŐĐGVËR
-négyhatalmi/°BÓŐĐGVËR
+négyhatalmi/°yBÓŐĐGVËR
 négyféle/ąBÓŐĐGVËR
 négyesztendei/ąBÓŐĐGVËR
 négerbarna/°AŇŐĎFUÎQ
@@ -70847,7 +71040,7 @@ nyúlszívű/ąCÔŐŢHWĚR
 nyúlott/ŇŮFUÎmôQk°sX
 nyújtott/ŇŮFUÎmôQk°sX
 nyöszörgő/XCÔŐŢHWĚR
-nyögvenyelős/Ô×ÝňGVĚNMTtlą
+nyögvenyelős/Ô×ÝňGVĚNMTtląy
 nyírségi/BÓŐĐGVËR
 nyírott/ŇŮFUÎmôQk°sX
 nyíratlan/ŇŮFUÎmôKÖQk°
@@ -70855,7 +71048,7 @@ nyíltszívű/ąCÔŐŢHWĚR
 nyílt/ŇŮFUÎmôKÖQ°
 nyílott/ŇŮFUÎmôQk°sX
 nyíl_alakú/°AŇŐĎFUÎQ
-nyárspolgári/°AŇŐĎFUÎQ
+nyárspolgári/°yAŇŐĎFUÎQ
 nyárias/ŇŮFUÎmôKÖSsk°
 nyári/°AŇŐĎFUÎQ
 nyár_végi/ąBÓŐĐGVËR
@@ -70875,7 +71068,7 @@ nyugodt/ŇŮFUÎmôKÖQk°
 nyugodalmas/ŇŮFUÎmôKÖSsk°
 nyugis/ŇŮFUÎmôKÖSsk°
 nyughatatlan/ŇŮFUÎmôKÖQk°
-nyugdíjjogosult/ŇŮFUÎmôQk°
+nyugdíjjogosult/ŇŮFUÎmôQk°íj||jogosult
 nyugdíjas/ŇŮFUÎmôKÖSsk°
 nyugatrómai/°BÓŐĐGVËR
 nyugatnémet/Ó×GVËnňLRlą
@@ -70885,7 +71078,7 @@ nyugat-virginiai/AŇŐĎFUÎQ
 nyugat-európai/AŇŐĎFUÎQ
 nyugalmazott/ŇŮFUÎmôQk°sX
 nyugalmas/ŇŮFUÎmôKÖSsk°
-nyomásérzékeny/Ó×GVËnňLTtlą
+nyomásérzékeny/Ó×GVËnňLTtląy
 nyomtatásvezérlő/ąCÔŐŢHWĚR
 nyomtalan/ŇŮFUÎmôKÖQk°
 nyomorúságos/ŇŮFUÎmôKÖSsk°
@@ -70936,7 +71129,7 @@ nyiszlett/Ó×GVËnňLRlą
 nyirkos/ŇŮFUÎmôKÖSsk°
 nyimnyám/ŇŮFUÎmôKÖSsk°
 nyilvánvaló/°AŇŐĎFUÎQ
-nyilvántartott/ŇŮFUÎmôQk°sX
+nyilvántartott/ŇŮFUÎmôQk°ysX
 nyilvános/ŇŮFUÎmôKÖSsk°
 nyikorogó/°XAŇŐĎFUÎQ
 nyikorgós/ŇŮFUÎmôKÖSsk°
@@ -70946,14 +71139,14 @@ nyesett/Ó×GVËnňLRlą
 nyesetlen/Ó×GVËnňLRlą
 nyertes/Ó×GVËnňLTtlą
 nyersszínű/ąwCÔŐŢHWĚR
-nyersmodorú/°AŇŐĎFUÎQ
+nyersmodorú/°yAŇŐĎFUÎQ
 nyersgyapjúszínű/ąCÔŐŢHWĚR
 nyersarany/ŇŮFUÎmôKÖSsk°
 nyers/Ó×GVËnňLTt
 nyergeletlen/Ó×GVËnňLRlą
 nyeretlen/Ó×GVËnňLRlą
-nyereségérdekelt/Ó×GVËnňLRlą
-nyereségorientált/ŇŮFUÎmôQk°
+nyereségérdekelt/Ó×GVËnňLRląy
+nyereségorientált/ŇŮFUÎmôQk°y
 nyelvtani/°AŇŐĎFUÎQ
 nyelvi/ąBÓŐĐGVËR
 nyelvhibás/ŇŮFUÎmôKÖSsk°
@@ -70973,7 +71166,7 @@ nyakú/°AŇŐĎFUÎQ
 nyaktörő/ąCÔŐŢHWĚR
 nyakigláb/ŇŮFUÎmôKÖQk°
 nyaki/°AŇŐĎFUÎQ
-nyakatekert/Ó×GVËnňLRlą
+nyakatekert/Ó×GVËnňLRląy
 nyakas/ŇŮFUÎmôKÖSsk°
 nyafka/°AŇŐĎFUÎQ
 numerikus/ŇŮFUÎmôKÖSsk°
@@ -71054,7 +71247,7 @@ nemzeties/Ó×GVËnňLTtlą
 nemzeti_színű/ąCÔŐŢHWĚR
 nemzeti/ąBÓŐĐGVËR
 nemzethű/ąyCÔŐŢHWĚR
-nemzedékrendi/ąBÓŐĐGVËR
+nemzedékrendi/ąyBÓŐĐGVËR
 nemvizes/Ó×GVËnňLTtlą
 nemvezető/ąCÔŐŢHWĚR
 nemulassszerű/ąwCÔŐŢHWĚR
@@ -71091,8 +71284,8 @@ nem_peres/Ó×GVËnňLTtlą
 nem_létező/ąCÔŐŢHWĚR
 nem_kívánt/ŇŮFUÎmôKÖQk°
 nem_hivatalos/ŇŮFUÎmôKÖSsk°
-nekivadult/ŇŮFUÎmôQk°
-nekibőszült/Ô×ÝňGVĚNRlą
+nekivadult/ŇŮFUÎmôQk°y
+nekibőszült/Ô×ÝňGVĚNRląy
 nehézszagú/°AŇŐĎFUÎQéz|szagú
 nehézkes/Ó×GVËnňLTtlą
 nehézfejű/ąCÔŐŢHWĚR
@@ -71142,7 +71335,7 @@ narkotikus/ŇŮFUÎmôKÖSsk°
 narkomániás/ŇŮFUÎmôKÖSsk°
 narcisztikus/ŇŮFUÎmôKÖSsk°
 narancsvörös/Ô×ÝňGVĚNMTtlą
-narancssárgás/ŇŮFUÎmôKÖSsk°
+narancssárgás/ŇŮFUÎmôKÖSsk°y
 narancssárga/°AŇŐĎFUÎQ
 napálló/°AŇŐĎFUÎQ
 napsütötte/ąBÓŐĐGVËR
@@ -71161,7 +71354,7 @@ napközbeni/ąBÓŐĐGVËR
 napi/°AŇŐĎFUÎQ
 napfénytelen/Ó×GVËnňLRlą
 napfényes/Ó×GVËnňLTtlą
-naperőművi/ąyBÓŐĐGVËR
+naperőművi/ąyBÓŐĐGVËRő|művi
 napbarnított/ŇŮFUÎmôQk°sX
 nanoméretű/ąCÔŐŢHWĚR
 nanokompozit/ŇŮFUÎmôKÖQk°
@@ -71169,11 +71362,11 @@ naiv/ŇŮFUÎmôKÖSsk°
 nagyöbű/ąCÔŐŢHWĚR
 nagyívű/ąCÔŐŢHWĚR
 nagyétkű/ąCÔŐŢHWĚR
-nagyérdemű/ąCÔŐŢHWĚR
+nagyérdemű/ąyCÔŐŢHWĚR
 nagyvérű/ąCÔŐŢHWĚR
 nagyvárosias/ŇŮFUÎmôKÖSsk°y
 nagyvállalkozó/°AŇŐĎFUÎQ
-nagyvonalú/°AŇŐĎFUÎQ
+nagyvonalú/°yAŇŐĎFUÎQ
 nagyvirágú/°AŇŐĎFUÎQ
 nagytiszteletű/ąCÔŐŢHWĚR
 nagytestű/ąCÔŐŢHWĚR
@@ -71185,9 +71378,9 @@ nagyszámú/°AŇŐĎFUÎQ
 nagyszálló/°AŇŐĎFUÎQ
 nagyszájú/°AŇŐĎFUÎQ
 nagyszerű/ąCÔŐŢHWĚR
-nagyszabású/°AŇŐĎFUÎQ
+nagyszabású/°yAŇŐĎFUÎQ
 nagystílű/ąCÔŐŢHWĚR
-nagyreményű/ąCÔŐŢHWĚR
+nagyreményű/ąyCÔŐŢHWĚR
 nagyravágyó/°AŇŐĎFUÎQ
 nagyratörő/ąCÔŐŢHWĚR
 nagyralátó/°AŇŐĎFUÎQ
@@ -71205,26 +71398,26 @@ nagynémet/Ó×GVËnňLRlą
 nagynyomású/°AŇŐĎFUÎQ
 nagynevű/ąCÔŐŢHWĚR
 nagymérvű/ąCÔŐŢHWĚR
-nagymértékű/ąCÔŐŢHWĚR
+nagymértékű/ąyCÔŐŢHWĚR
 nagymértékben/Ó×GVËnňLRlą
-nagyméretarányú/°AŇŐĎFUÎQ
+nagyméretarányú/°yAŇŐĎFUÎQ
 nagyméltóságú/°AŇŐĎFUÎQ
 nagymellű/ąCÔŐŢHWĚR
 nagylélegzetű/ąCÔŐŢHWĚR
-nagylátószögű/ąCÔŐŢHWĚR
+nagylátószögű/ąyCÔŐŢHWĚRátó|szögű
 nagylelkű/ąCÔŐŢHWĚR
 nagyképű/ąCÔŐŢHWĚR
 nagykorú/°AŇŐĎFUÎQ
 nagyivó/°AŇŐĎFUÎQ
 nagyipari/°BÓŐĐGVËR
-nagyigényű/ąCÔŐŢHWĚR
+nagyigényű/ąyCÔŐŢHWĚR
 nagyhatalmú/°wAŇŐĎFUÎQ
 nagyhangú/°AŇŐĎFUÎQ
 nagygépes/Ó×GVËnňLTtląy
 nagyfülű/ąCÔŐŢHWĚR
-nagyfrekvenciás/ŇŮFUÎmôKÖSsk°
+nagyfrekvenciás/ŇŮFUÎmôKÖSsk°y
 nagyfoltú/°AŇŐĎFUÎQ
-nagyfeszültségű/ąCÔŐŢHWĚR
+nagyfeszültségű/ąyCÔŐŢHWĚR
 nagyfejű/ąCÔŐŢHWĚR
 nagyevő/ąCÔŐŢHWĚR
 nagyeszű/ąCÔŐŢHWĚR
@@ -71237,7 +71430,7 @@ nagybetűérzékeny/Ó×GVËnňLTtląy
 nagybeteg/Ó×GVËnňLRlą
 nagybecsű/ąCÔŐŢHWĚR
 nagybani/°AŇŐĎFUÎQ
-nagyarányú/°AŇŐĎFUÎQ
+nagyarányú/°yAŇŐĎFUÎQ
 nagyalakú/°AŇŐĎFUÎQ
 nagyadó/°AŇŐĎFUÎQ
 nagy_értékű/ąCÔŐŢHWĚR
@@ -71328,24 +71521,24 @@ méretű/ąCÔŐŢHWĚR
 mérethű/ąCÔŐŢHWĚR
 mérethatékony/ŇŮFUÎmôKÖSsk°y
 méregzöld/Ô×ÝňGVĚNRlą
-méregközömbösítő/ąCÔŐŢHWĚR
+méregközömbösítő/ąyCÔŐŢHWĚR
 méregerős/Ô×ÝňGVĚNMTtlą
 méregdrága/°AŇŐĎFUÎQ
 mélyült/Ô×ÝňGVĚNRlą
 mélyített/Ó×GVËnňLRlą
 mélyépítő/ąCÔŐŢHWĚR
-mélyáteresztő/ąCÔŐŢHWĚR
+mélyáteresztő/ąyCÔŐŢHWĚR
 mélyzöld/Ô×ÝňGVĚNRlą
 mélyvörös/Ô×ÝňGVĚNMTtlą
 mélyvízi/ąBÓŐĐGVËR
 mélyvénás/ŇŮFUÎmôKÖSsk°
-mélytengeri/ąBÓŐĐGVËR
+mélytengeri/ąyBÓŐĐGVËR
 mélységes/Ó×GVËnňLTtlą
 mélysárga/°AŇŐĎFUÎQ
-mélyszürke/ąBÓŐĐGVËR
+mélyszürke/ąyBÓŐĐGVËR
 mélyszántás/ŇŮFUÎmôKÖSsk°
-mélyszegény/Ó×GVËnňLTtlą
-mélyretekintő/ąCÔŐŢHWĚR
+mélyszegény/Ó×GVËnňLTtląy
+mélyretekintő/ąyCÔŐŢHWĚR
 mélyreható/°AŇŐĎFUÎQ
 mélypiros/ŇŮFUÎmôKÖSsk°
 mélynyomó/°AŇŐĎFUÎQ
@@ -71359,7 +71552,7 @@ mélyenjáró/°AŇŐĎFUÎQ
 mélybordó/°AŇŐĎFUÎQ
 mélybarna/°AŇŐĎFUÎQ
 mély/Ó×GVËnňLTtą
-méltóságteljes/Ó×GVËnňLTtlą
+méltóságteljes/Ó×GVËnňLTtląy
 méltó/°AŇŐĎFUÎQ
 méltánytalan/ŇŮFUÎmôKÖQk°
 méltányos/ŇŮFUÎmôKÖSsk°
@@ -71375,13 +71568,13 @@ mázos/ŇŮFUÎmôKÖSsk°
 mázlis/ŇŮFUÎmôKÖSsk°
 mázatlan/ŇŮFUÎmôKÖQk°
 másvéleményű/ąCÔŐŢHWĚR
-másolásvédett/Ó×GVËnňLRlą
+másolásvédett/Ó×GVËnňLRląy
 másodéves/Ó×GVËnňLTtlą
 másodévenkénti/ąBÓŐĐGVËR
 másodrendű/ąCÔŐŢHWĚR
 másodrangú/°AŇŐĎFUÎQ
 másodpercenkénti/ąBÓŐĐGVËR
-másodosztályú/°AŇŐĎFUÎQ
+másodosztályú/°yAŇŐĎFUÎQ
 másodlagos/ŇŮFUÎmôKÖSsk°
 másodközölt/Ô×ÝňGVĚNRląy
 másodidőszakos/ŇŮFUÎmôKÖSsk°
@@ -71392,7 +71585,7 @@ másoddiplomás/ŇŮFUÎmôKÖSsk°
 másnemű/ąCÔŐŢHWĚR
 másnapos/ŇŮFUÎmôKÖSsk°
 másképpeni/ąBÓŐĐGVËR
-másfélszázados/ŇŮFUÎmôKÖSsk°
+másfélszázados/ŇŮFUÎmôKÖSsk°yás|fél||százados
 másféle/ąBÓŐĐGVËR
 másforma/°AŇŐĎFUÎQ
 másfajta/°AŇŐĎFUÎQ
@@ -71428,25 +71621,25 @@ munkátlan/ŇŮFUÎmôKÖQk°
 munkált/ŇŮFUÎmôQk°
 munkácsys/ŇŮFUÎmôKÖSsk
 munkácsyas/ŇŮFUÎmôKÖSsk
-munkanélküli/ąBÓŐĐGVËR
-munkaképtelen/Ó×GVËnňLRlą
-munkaigényes/Ó×GVËnňLTtlą
-munkaerő-igényes/Ó×GVËnňLTtląy
+munkanélküli/ąyBÓŐĐGVËR
+munkaképtelen/Ó×GVËnňLRląy
+munkaigényes/Ó×GVËnňLTtląy
+munkaerő-igényes/Ó×GVËnňLTtląyő-igényes
 multipoláris/ŇŮFUÎmôKÖSsk°
 multiplikatív/Ó×GVËnňLTtlą
 multiplex/Ó×GVËnňLTtlą
 multinacionális/ŇŮFUÎmôKÖSsk°
 multimodális/ŇŮFUÎmôKÖSsk°
-multimediális/ŇŮFUÎmôKÖSsk°
-multilaterális/ŇŮFUÎmôKÖSsk°
+multimediális/ŇŮFUÎmôKÖSsk°y
+multilaterális/ŇŮFUÎmôKÖSsk°y
 multikulturális/ŇŮFUÎmôKÖSsk°
 multikulti/°AŇŐĎFUÎQ
 multifunkcionális/ŇŮFUÎmôKÖSsk°
 multifokális/ŇŮFUÎmôKÖSsk°
-multifaktoriális/ŇŮFUÎmôKÖSsk°
+multifaktoriális/ŇŮFUÎmôKÖSsk°y
 multidiszciplináris/ŇŮFUÎmôKÖSsk°
 mulatságos/ŇŮFUÎmôKÖSsk°
-mulatságkedvelő/ąCÔŐŢHWĚR
+mulatságkedvelő/ąyCÔŐŢHWĚR
 mulandó/°AŇŐĎFUÎQ
 mucsai/°AŇŐĎFUÎQ
 mozogó/°XAŇŐĎFUÎQ
@@ -71454,14 +71647,14 @@ mozgó/°XAŇŐĎFUÎQ
 mozgékony/ŇŮFUÎmôKÖSsk°
 mozgástani/°AŇŐĎFUÎQ
 mozgássérült/Ô×ÝňGVĚNRlą
-mozgásszegény/Ó×GVËnňLTtląás|sze-gény
+mozgásszegény/Ó×GVËnňLTtląyás|sze-gényás|szegény
 mozgásképtelen/Ó×GVËnňLRlą
 mozgáskorlátozott/ŇŮFUÎmôQk°sX
 mozgalmas/ŇŮFUÎmôKÖSsk°
 mozdíthatatlan/ŇŮFUÎmôKÖQk°
 mozdulatlan/ŇŮFUÎmôKÖQk°
 motyorgó/XAŇŐĎFUÎQ
-motormeghajtású/°AŇŐĎFUÎQ
+motormeghajtású/°yAŇŐĎFUÎQ
 motorikus/ŇŮFUÎmôKÖSsk°
 motiválatlan/ŇŮFUÎmôKÖQk°
 motivikus/ŇŮFUÎmôKÖSsk°
@@ -71523,7 +71716,7 @@ monarchista/°AŇŐĎFUÎQ
 monarchikus/ŇŮFUÎmôKÖSsk°
 moláris/ŇŮFUÎmôKÖSsk°
 molyrágta/°AŇŐĎFUÎQ
-molyrágott/ŇŮFUÎmôQk°sX
+molyrágott/ŇŮFUÎmôQk°ysX
 molyos/ŇŮFUÎmôKÖSsk°
 molylepte/ąBÓŐĐGVËR
 molyhos/ŇŮFUÎmôKÖSsk°
@@ -71548,7 +71741,7 @@ mohás/ŇŮFUÎmôKÖSsk°
 mohlepte/ąBÓŐĐGVËR
 mohazöld/Ô×ÝňGVĚNMRlą
 mohamedán/ŇŮFUÎmôKÖQk°
-mogyoróbarna/°AŇŐĎFUÎQ
+mogyoróbarna/°yAŇŐĎFUÎQ
 mogorva/°AŇŐĎFUÎQ
 modális/ŇŮFUÎmôKÖSsk°
 moduláris/ŇŮFUÎmôKÖSsk°
@@ -71596,7 +71789,7 @@ mindkétféle/ąBÓŐĐGVËR
 mindháromféle/ąBÓŐĐGVËR
 mindenórás/ŇŮFUÎmôKÖSsk°
 mindentudó/°AŇŐĎFUÎQ
-mindenoldalú/°AŇŐĎFUÎQ
+mindenoldalú/°yAŇŐĎFUÎQ
 mindennapos/ŇŮFUÎmôKÖSsk°
 mindennapi/°AŇŐĎFUÎQ
 mindenható/°AŇŐĎFUÎQ
@@ -71643,7 +71836,7 @@ mihaszna/°AŇŐĎFUÎQ
 mihamar/ŇŮFUÎmôKÖQk°
 microsoftos/ŇŮFUÎmôKÖSsk
 miazmás/ŇŮFUÎmôKÖSsk°
-mezővárosias/ŇŮFUÎmôKÖSsk°
+mezővárosias/ŇŮFUÎmôKÖSsk°y
 mezítlábas/ŇŮFUÎmôKÖSsk°
 mezítelen/Ó×GVËnňLRlą
 mezzoszoprán/ŇŮFUÎmôKÖQk°
@@ -71654,11 +71847,11 @@ mezofil/ŇŮFUÎmôKÖQk°
 mezei/ąBÓŐĐGVËR
 metálzöld/Ô×ÝňGVĚNRlą
 metálsárga/°AŇŐĎFUÎQ
-metálszürke/ąBÓŐĐGVËR
+metálszürke/ąyBÓŐĐGVËR
 metálpiros/ŇŮFUÎmôKÖSsk°
 metállila/°AŇŐĎFUÎQ
 metálkék/Ó×GVËnňLRlą
-metálfekete/ąBÓŐĐGVËR
+metálfekete/ąyBÓŐĐGVËR
 metálbordó/°AŇŐĎFUÎQ
 metál/ŇŮFUÎmôKÖQk°
 mettlachi/°AŇŐĎFUÎQ
@@ -71731,16 +71924,16 @@ melodramatikus/ŇŮFUÎmôKÖSsk°
 melodikus/ŇŮFUÎmôKÖSsk°
 mellüregi/ąBÓŐĐGVËR
 mellőzött/Ô×ÝňGVĚNRlą
-melléknévi/ąBÓŐĐGVËR
+melléknévi/ąyBÓŐĐGVËR
 mellékes/Ó×GVËnňLTtlą
 mellkasi/°AŇŐĎFUÎQ
-melldöngető/ąCÔŐŢHWĚR
+melldöngető/ąyCÔŐŢHWĚR
 mellbevágó/°AŇŐĎFUÎQ
 melegítetlen/Ó×GVËnňLRlą
 melegvérű/ąCÔŐŢHWĚR
 melegszívű/ąCÔŐŢHWĚR
 melegkedvelő/ąCÔŐŢHWĚR
-melegigényes/Ó×GVËnňLTtlą
+melegigényes/Ó×GVËnňLTtląy
 melegellenes/Ó×GVËnňLTtląy
 melegbarát/ŇŮFUÎmôKÖQk°y
 meleg_vizes/Ó×GVËnňLTtlą
@@ -72054,7 +72247,7 @@ magánkereskedő/ąCÔŐŢHWĚR
 magánkapitalista/°AŇŐĎFUÎQ
 magánjáró/°AŇŐĎFUÎQ
 magánjellegű/ąyCÔŐŢHWĚR
-magánhangzói/°AŇŐĎFUÎQ
+magánhangzói/°yAŇŐĎFUÎQ
 magánfuvarozó/°AŇŐĎFUÎQ
 magánfogyasztó/°AŇŐĎFUÎQ
 magánerős/Ô×ÝňGVĚNMTtlą
@@ -72091,7 +72284,7 @@ magaszőrű/ąCÔŐŢHWĚR	őrűek
 magasztos/ŇŮFUÎmôKÖSsk°
 magasszintű/ąwCÔŐŢHWĚR
 magasröptű/ąCÔŐŢHWĚR
-magasművelésű/ąCÔŐŢHWĚR
+magasművelésű/ąyCÔŐŢHWĚR
 magashegyi/ąBÓŐĐGVËR
 magasfényű/ąCÔŐŢHWĚR
 magasfeszültségű/ąCÔŐŢHWĚR
@@ -72100,7 +72293,7 @@ magas_szintű/ąCÔŐŢHWĚR
 magas_sarkú/°AŇŐĎFUÎQ
 magas_rendű/ąCÔŐŢHWĚR
 magas/ŇŮFUÎmôKÖSsk°
-magamutogatós/ŇŮFUÎmôKÖSsk°
+magamutogatós/ŇŮFUÎmôKÖSsk°y
 magamutogató/°AŇŐĎFUÎQ
 magamfajta/°AŇŐĎFUÎQ	ák
 magakorú/°AŇŐĎFUÎQ
@@ -72110,7 +72303,7 @@ magajáró/°AŇŐĎFUÎQ
 magafajta/°AŇŐĎFUÎQ	ák
 magabízó/°AŇŐĎFUÎQ
 magabíró/°AŇŐĎFUÎQ
-magabiztos/ŇŮFUÎmôSsk°
+magabiztos/ŇŮFUÎmôSsk°y
 mafla/°AŇŐĎFUÎQ
 madártani/°AŇŐĎFUÎQ
 madárlátta/°AŇŐĎFUÎQ
@@ -72183,7 +72376,7 @@ lényegbeni/ąBÓŐĐGVËR
 lélektelen/Ó×GVËnňLRlą
 lélektani/°AŇŐĎFUÎQ
 lélegző/XCÔŐŢHWĚR
-lélegzetelállító/°AŇŐĎFUÎQ
+lélegzetelállító/°yAŇŐĎFUÎQ
 lélegező/ąXCÔŐŢHWĚR
 léha/°AŇŐĎFUÎQ
 légüres/Ó×GVËnňLTtlą
@@ -72193,8 +72386,8 @@ légzáró/°AŇŐĎFUÎQ
 légzett/Ó×GVËnňRlątX)élegez
 légzett/Ó×GVËnňRlątX
 légzendő/XCÔŐŢHWĚR)élegezÓ_FUTPART_adj
-légypiszkos/ŇŮFUÎmôKÖSsk°
-légybeköpte/ąBÓŐĐGVËR
+légypiszkos/ŇŮFUÎmôKÖSsk°y
+légybeköpte/ąyBÓŐĐGVËR
 légvédelmi/ąBÓŐĐGVËR
 légvonatos/ŇŮFUÎmôKÖSsk°
 légszigetelt/Ó×GVËnňLRlą
@@ -72246,7 +72439,7 @@ lándzsás/ŇŮFUÎmôKÖSsk°
 láncolt/ŇŮFUÎmôQk°
 láncolatos/ŇŮFUÎmôKÖSsk°
 lámpátlan/ŇŮFUÎmôKÖQk°
-lágyéktáji/°AŇŐĎFUÎQ
+lágyéktáji/°yAŇŐĎFUÎQ
 lágyszívű/ąCÔŐŢHWĚR
 lágyszárú/°AŇŐĎFUÎQ
 lágyrajzú/°AŇŐĎFUÎQ
@@ -72286,7 +72479,7 @@ lovagiatlan/ŇŮFUÎmôKÖQk°
 lovagias/ŇŮFUÎmôKÖSsk°
 louvre-beli/ąBÓŐĐGVËR
 lottyadt/ŇŮFUÎmôKÖQk°
-lopásbiztos/ŇŮFUÎmôSsk°
+lopásbiztos/ŇŮFUÎmôSsk°y
 lopott/ŇŮFUÎmôQk°sX
 longitudinális/ŇŮFUÎmôKÖSsk°
 loncsos/ŇŮFUÎmôKÖSsk°
@@ -72294,7 +72487,7 @@ lompos/ŇŮFUÎmôKÖSsk°
 lomha/°AŇŐĎFUÎQ
 lombtalan/ŇŮFUÎmôKÖQk°
 lombos/ŇŮFUÎmôKÖSsk°
-lombhullató/°AŇŐĎFUÎQ
+lombhullató/°yAŇŐĎFUÎQ
 lokális/ŇŮFUÎmôKÖSsk°
 lojális/ŇŮFUÎmôKÖSsk°
 lognormális/ŇŮFUÎmôKÖSsk°
@@ -72310,7 +72503,7 @@ lobbanékony/ŇŮFUÎmôKÖSsk°
 liturgikus/ŇŮFUÎmôKÖSsk°
 litotróf/ŇŮFUÎmôKÖQk°
 literális/ŇŮFUÎmôKÖSsk°
-lisztérzékeny/Ó×GVËnňLTtlą
+lisztérzékeny/Ó×GVËnňLTtląy
 lisztes/Ó×GVËnňLTtlą
 listaelső/ąCÔŐŢHWĚR
 liptói/°AŇŐĎFUÎQ
@@ -72327,7 +72520,7 @@ lilásvörös/Ô×ÝňGVĚNMTtlą
 liláspiros/ŇŮFUÎmôKÖSsk°
 liláskékes/Ó×GVËnňLTtlą
 liláskék/Ó×GVËnňLRlą
-lilásfekete/ąBÓŐĐGVËR
+lilásfekete/ąyBÓŐĐGVËR
 lilásbarna/°AŇŐĎFUÎQ
 lilás/ŇŮFUÎmôKÖSsk°
 liliputi/°BÓŐĐGVËR
@@ -72347,6 +72540,7 @@ leírhatatlan/ŇŮFUÎmôKÖQk°
 leányos/ŇŮFUÎmôKÖSsk°
 leánykori/°AŇŐĎFUÎQ
 lezáratlan/ŇŮFUÎmôKÖQk°
+lezser/Ó×GVËnňLRlą
 lexikális/ŇŮFUÎmôKÖSsk°
 lexikografikus/ŇŮFUÎmôKÖSsk°
 levő/ąXYCÔŐŢHWĚR)Ó_PRESPART_adj
@@ -72416,10 +72610,10 @@ lemaradt/ŇŮFUÎmôKÖQk°
 leltári/°BÓŐĐGVËR
 lelombozódott/ŇŮFUÎmôQk°sX
 lelkészi/ąBÓŐĐGVËR
-lelkipásztori/°AŇŐĎFUÎQ
-lelkiismeretlen/Ó×GVËnňLRlą
-lelkiismeretfurdalásos/ŇŮFUÎmôKÖSsk°
-lelkiismeretes/Ó×GVËnňLTtlą
+lelkipásztori/°yAŇŐĎFUÎQ
+lelkiismeretlen/Ó×GVËnňLRląy
+lelkiismeretfurdalásos/ŇŮFUÎmôKÖSsk°yásos
+lelkiismeretes/Ó×GVËnňLTtląy
 lelki_beteg/Ó×GVËnňLRlą
 lelki/ąBÓŐĐGVËR
 lelketlen/Ó×GVËnňLRlą
@@ -72514,7 +72708,7 @@ langy/ŇŮFUÎmôKÖSs°
 lamináris/ŇŮFUÎmôKÖSsk°
 laminált/ŇŮFUÎmôKÖQk°
 lamelláris/ŇŮFUÎmôKÖSsk°
-lakónegyedbeli/ąBÓŐĐGVËR
+lakónegyedbeli/ąyBÓŐĐGVËR
 lakástalan/ŇŮFUÎmôKÖQk°
 lakályos/ŇŮFUÎmôKÖSsk°
 laktató/°AŇŐĎFUÎQ
@@ -72523,7 +72717,7 @@ lakonikus/ŇŮFUÎmôKÖSsk°
 lakodalmi/°AŇŐĎFUÎQ
 lakkozott/ŇŮFUÎmôQk°sX
 lakkozatlan/ŇŮFUÎmôKÖQk°
-lakkfekete/ąBÓŐĐGVËR
+lakkfekete/ąyBÓŐĐGVËR
 lakhatatlan/ŇŮFUÎmôKÖQk°
 lakberendező/ąCÔŐŢHWĚR
 lakatlan/ŇŮFUÎmôKÖQk°
@@ -72534,7 +72728,7 @@ ladoga-tói/°wAŇŐĎFUÎQ
 labiális/ŇŮFUÎmôKÖSsk°
 labilis/ŇŮFUÎmôKÖSsk°
 küzdelmes/Ó×GVËnňLTtlą
-küszöbönálló/°AŇŐĎFUÎQ
+küszöbönálló/°yAŇŐĎFUÎQ
 különös/Ô×ÝňGVĚNMTtlą
 különélő/ąCÔŐŢHWĚR
 különálló/°AŇŐĎFUÎQ
@@ -72548,9 +72742,11 @@ külvárosias/ŇŮFUÎmôKÖSsk°
 külvárosi/°AŇŐĎFUÎQ
 külterjes/Ó×GVËnňLTtlą
 külsőleges/Ó×GVËnňLTtlą
+külsődleges/Ó×GVËnňLTtlą
 külső/ąCÔŐŢHWĚR
 külpontos/ŇŮFUÎmôKÖSsk°
 külországi/°BÓŐĐGVËR
+külhonos/ŇŮFUÎmôKÖSsk°y
 külgazdaság-érzékeny/Ó×GVËnňLTtlą
 külföldies/Ó×GVËnňLTtlą
 külföldi/ąBÓŐĐGVËR
@@ -72560,7 +72756,7 @@ közúti/°AŇŐĎFUÎQ
 közötti/ąBÓŐĐGVËR	özöttiek
 közös/Ô×ÝňGVĚNMTtlą
 közönyös/Ô×ÝňGVĚNMTtlą
-közönségkedvenc/Ó×GVËnňLTtlą
+közönségkedvenc/Ó×GVËnňLTtląy
 közönséges/Ó×GVËnňLTtlą
 közömbös/Ô×ÝňGVĚNMTtlą
 közölő/ąXCÔŐŢHWĚR
@@ -72569,10 +72765,10 @@ közérthető/ąCÔŐŢHWĚR
 közértes/Ó×GVËnňLTtlą
 középzöld/Ô×ÝňGVĚNRlą
 középsős/Ô×ÝňGVĚNMTtlą
-középszürke/ąBÓŐĐGVËR
+középszürke/ąyBÓŐĐGVËR
 középszerű/ąCÔŐŢHWĚR
-középosztálybeli/ąBÓŐĐGVËR
-középnagyságú/°AŇŐĎFUÎQ
+középosztálybeli/ąyBÓŐĐGVËR
+középnagyságú/°yAŇŐĎFUÎQ
 középmeleg/Ó×GVËnňLRląy
 középmagas/ŇŮFUÎmôKÖSsk°
 középkülsős/Ô×ÝňGVĚNMTtląy
@@ -72581,7 +72777,7 @@ középkorias/ŇŮFUÎmôKÖSsk°
 középkori/°AŇŐĎFUÎQ
 középfelnémet/Ó×GVËnňLRlą
 középbarna/°AŇŐĎFUÎQ
-középarányos/ŇŮFUÎmôKÖSsk°
+középarányos/ŇŮFUÎmôKÖSsk°y
 közép-európai/AŇŐĎFUÎQ
 közzétevő/ąXYCÔŐŢHWĚR)özzéteszÓ_PRESPART_adj
 közzétevő/ąXYCÔŐŢHWĚR
@@ -72594,15 +72790,14 @@ közvitéz/Ó×GVËnňLTtlą
 közvetlen/Ó×GVËnňLRlą
 közvetett/Ó×GVËnňLRlą
 köztörök/Ô×ÝňGVĚNMRlą
-köztársaságpárti/°yAŇŐĎFUÎQ
+köztársaságpárti/°yAŇŐĎFUÎQöz|társaság||párti
 köztudott/ŇŮFUÎmôQk°sX
 köztes/Ó×GVËnňLTtlą
-közszolgálatis/ŇŮFUÎmôKÖSsk°y
-központkereső/ąCÔŐŢHWĚR
+közszolgálatis/ŇŮFUÎmôKÖSsk°yöz|szolgálatis
+központkereső/ąyCÔŐŢHWĚR
 központi/°AŇŐĎFUÎQ
 köznapias/ŇŮFUÎmôKÖSsk°
 köznapi/°AŇŐĎFUÎQ
-közművelődésügyi/ąBÓŐĐGVËR
 közmondásos/ŇŮFUÎmôKÖSsk°
 közlő/XCÔŐŢHWĚR
 közlékeny/Ó×GVËnňLTtlą
@@ -72620,7 +72815,7 @@ közelgő/ąXCÔŐŢHWĚR
 közelegő/ąXCÔŐŢHWĚR
 közbülső/ąCÔŐŢHWĚR
 közbeékelt/Ó×GVËnňLRlą
-közbevetett/Ó×GVËnňLRlą
+közbevetett/Ó×GVËnňLRląy
 közbenső/ąCÔŐŢHWĚR
 közbeni/ąBÓŐĐGVËR
 közbejött/Ô×ÝňGVĚNRlą
@@ -72639,28 +72834,28 @@ követelt/Ó×GVËnňLRlą
 köves/Ó×GVËnňLTtlą
 kövecses/Ó×GVËnňLTtlą
 kötöznivaló/°AŇŐĎFUÎQ
-kötöttpályás/ŇŮFUÎmôKÖSsk°
-kötöttfogású/°AŇŐĎFUÎQ
+kötöttpályás/ŇŮFUÎmôKÖSsk°y
+kötöttfogású/°yAŇŐĎFUÎQ
 kötödés/Ó×GVËnňLTtlą
 kötélrevaló/°AŇŐĎFUÎQ
 kötetlen/Ó×GVËnňLRlą
 kötelező/ąCÔŐŢHWĚR
 kötelezett/Ó×GVËnňLRlą
 kötelességtudó/°AŇŐĎFUÎQ
-kötelességmulasztó/°AŇŐĎFUÎQ
+kötelességmulasztó/°yAŇŐĎFUÎQ
 köteles/Ó×GVËnňLTtlą
 kötekvő/ąXYCÔŐŢHWĚR)ötekszikÓ_PRESPART_adj
 kötekvő/ąXYCÔŐŢHWĚR
 köszörületlen/Ó×GVËnňLRlą
 köszvényes/Ó×GVËnňLTtlą
-körülárkolt/ŇŮFUÎmôQk°
+körülárkolt/ŇŮFUÎmôQk°y
 körülvevő/ąCÔŐŢHWĚR
 körülvett/Ó×GVËnňLRlą
 körülményes/Ó×GVËnňLTtlą
 körülmetélt/Ó×GVËnňLRlą
-körülmetéletlen/Ó×GVËnňLRlą
-körülhatárolt/ŇŮFUÎmôQk°
-körülbelüli/ąBÓŐĐGVËR
+körülmetéletlen/Ó×GVËnňLRląy
+körülhatárolt/ŇŮFUÎmôQk°y
+körülbelüli/ąyBÓŐĐGVËR
 körözöttes/Ó×GVËnňLTtlą
 köröző/ąXCÔŐŢHWĚR
 körző/XCÔŐŢHWĚR
@@ -72670,8 +72865,8 @@ körutazó/°AŇŐĎFUÎQ
 körte_alakú/°AŇŐĎFUÎQ
 körszimmetrikus/ŇŮFUÎmôKÖSsk°
 környező/ąCÔŐŢHWĚR
-környezetérzékeny/Ó×GVËnňLTtlą
-környezetkímélő/ąCÔŐŢHWĚR
+környezetérzékeny/Ó×GVËnňLTtląy
+környezetkímélő/ąyCÔŐŢHWĚR
 környezeti/ąBÓŐĐGVËR
 környezetbarát/ŇŮFUÎmôKÖQk°y
 körmös/Ô×ÝňGVĚNMTtlą
@@ -72689,15 +72884,15 @@ könyörtelen/Ó×GVËnňLRlą
 könyörgő/ąXCÔŐŢHWĚR
 könyökölő/ąXCÔŐŢHWĚR
 könyöklő/XCÔŐŢHWĚR
-könyvkedvelő/ąCÔŐŢHWĚR
+könyvkedvelő/ąyCÔŐŢHWĚR
 könyv_alakú/°AŇŐĎFUÎQ
 könnyűvérű/ąCÔŐŢHWĚR
 könnyűszerkezetes/Ó×GVËnňLTtlą
 könnyűcirkáló/°AŇŐĎFUÎQ
 könnyű/ąCÔŐŢHWĚR	önnyenönnyebbikönnyebbenönnyebb
 könnytelen/Ó×GVËnňLRlą
-könnyfoltos/ŇŮFUÎmôKÖSsk°
-könnyfakasztó/°AŇŐĎFUÎQ
+könnyfoltos/ŇŮFUÎmôKÖSsk°y
+könnyfakasztó/°yAŇŐĎFUÎQ
 könnyetlen/Ó×GVËnňLRlą
 könnyes/Ó×GVËnňLTtlą
 könnyelmű/ąCÔŐŢHWĚR
@@ -72706,9 +72901,9 @@ kölykes/Ó×GVËnňLTtlą
 költött/Ô×ÝňGVĚNRlą
 költőietlen/Ó×GVËnňLRlą
 költőies/Ó×GVËnňLTtlą
-költségtakarékos/ŇŮFUÎmôKÖSsk°
+költségtakarékos/ŇŮFUÎmôKÖSsk°y
 költségkímélő/ąyCÔŐŢHWĚR
-költségigényes/Ó×GVËnňLTtlą
+költségigényes/Ó×GVËnňLTtląy
 költséghatékony/ŇŮFUÎmôKÖSsk°
 költséges/Ó×GVËnňLTtlą
 kölcsönöző/ąXCÔŐŢHWĚR
@@ -72723,11 +72918,11 @@ kőzettani/°AŇŐĎFUÎQ
 kőszívű/ąCÔŐŢHWĚR
 kőszáli/°AŇŐĎFUÎQ
 kőkorszaki/°AŇŐĎFUÎQ
-kőkorszakbeli/ąBÓŐĐGVËR
+kőkorszakbeli/ąyBÓŐĐGVËR
 kőkeménységű/ąCÔŐŢHWĚR
 kőkemény/Ó×GVËnňLTtlą
 kőerezetű/ąCÔŐŢHWĚR
-kőbevésett/Ó×GVËnňLRlą
+kőbevésett/Ó×GVËnňLRląy
 kóválygó/XAŇŐĎFUÎQ
 kótyagos/ŇŮFUÎmôKÖSsk°
 kósza/°AŇŐĎFUÎQ
@@ -72741,6 +72936,7 @@ kócos/ŇŮFUÎmôKÖSsk°
 kóborló/°XAŇŐĎFUÎQ
 kóborgó/XAŇŐĎFUÎQ
 kóbor/ŇŮFUÎmôKÖQk°
+kívülálló/°AŇŐĎFUÎQ
 kívüli/ąBÓŐĐGVËR	ívüliek
 kívánt/ŇŮFUÎmôKÖQk°
 kíváncsi/°AŇŐĎFUÎQ
@@ -72755,7 +72951,7 @@ kínos/ŇŮFUÎmôKÖSsk°
 kínai/°AŇŐĎFUÎQ
 kíméletlen/Ó×GVËnňLRlą
 kíméletes/Ó×GVËnňLTtlą
-kézzelfogható/°AŇŐĎFUÎQ
+kézzelfogható/°yAŇŐĎFUÎQ
 kézre_álló/°AŇŐĎFUÎQ	ézreállóbbanézreállóbb
 kézmeleg/Ó×GVËnňLRląy
 kézivezérelt/Ó×GVËnňLRląy
@@ -72778,12 +72974,12 @@ kétágú/°AŇŐĎFUÎQ
 kétvonalú/°AŇŐĎFUÎQ
 kétségtelen/Ó×GVËnňLRlą
 kétséges/Ó×GVËnňLTtlą
-kétségbevonó/°AŇŐĎFUÎQ
-kétségbevont/ŇŮFUÎmôKÖQk°
-kétségbevonható/°AŇŐĎFUÎQ
-kétségbevonhatatlan/ŇŮFUÎmôKÖQk°
-kétségbeesett/Ó×GVËnňLRlą
-kétségbeejtő/ąCÔŐŢHWĚR
+kétségbevonó/°yAŇŐĎFUÎQ
+kétségbevont/ŇŮFUÎmôKÖQk°y
+kétségbevonható/°yAŇŐĎFUÎQ
+kétségbevonhatatlan/ŇŮFUÎmôKÖQk°y
+kétségbeesett/Ó×GVËnňLRląy
+kétségbeejtő/ąyCÔŐŢHWĚR
 kétszínű/ąCÔŐŢHWĚR
 kétszoba-konyhás/ŇŮFUÎmôKÖSsk°
 kétszoba-hallos/ŇŮFUÎmôKÖSsk°
@@ -72840,7 +73036,7 @@ készfizető/ąCÔŐŢHWĚR
 kész/Ó×GVËnňLTtą
 kései/ąBÓŐĐGVËR
 késedelmes/Ó×GVËnňLTtlą
-kérészéletű/ąCÔŐŢHWĚR
+kérészéletű/ąyCÔŐŢHWĚR
 kérlelhetetlen/Ó×GVËnňLRlą
 kérges/Ó×GVËnňLTtlą
 kéretlen/Ó×GVËnňLRlą
@@ -72853,7 +73049,7 @@ képzett/Ó×GVËnňLRlą
 képzetlen/Ó×GVËnňLRlą
 képzelt/Ó×GVËnňLRlą
 képzelgő/ąXCÔŐŢHWĚR
-képzeletszőtte/ąBÓŐĐGVËR
+képzeletszőtte/ąyBÓŐĐGVËR
 képzeleti/ąBÓŐĐGVËR
 képzeletbeli/ąBÓŐĐGVËR
 képviseleti/ąBÓŐĐGVËR
@@ -72870,7 +73066,7 @@ kénytelen/Ó×GVËnňLRlą
 kényszerű/ąCÔŐŢHWĚR
 kényszerítetlen/Ó×GVËnňLRlą
 kényszerérett/Ó×GVËnňLRlą
-kényszervágott/ŇŮFUÎmôQk°sX
+kényszervágott/ŇŮFUÎmôQk°ysX
 kényszeredett/Ó×GVËnňLRlą
 kényeztetett/Ó×GVËnňLRlą
 kényes/Ó×GVËnňLTtlą
@@ -72885,14 +73081,14 @@ kékvérű/ąCÔŐŢHWĚR
 kéksisakos/ŇŮFUÎmôKÖSsk°
 kéknyelű/ąCÔŐŢHWĚR
 kékgalléros/ŇŮFUÎmôKÖSsk°
-kékeszöldes/Ó×GVËnňLTtląé-kes|zöl-des
+kékeszöldes/Ó×GVËnňLTtląyé-kes|zöl-desékes|zöldes
 kékeszöld/Ô×ÝňGVĚNMRląé-kes|zöld
-kékesszürkés/Ó×GVËnňLTtląé-kes|szür-kés
-kékesszürke/ąBÓŐĐGVËRé-kes|szür-ke
+kékesszürkés/Ó×GVËnňLTtląyé-kes|szür-késékes|szürkés
+kékesszürke/ąyBÓŐĐGVËRé-kes|szür-keékes|szürke
 kékeslilás/ŇŮFUÎmôKÖSsk°
 kékeslila/°AŇŐĎFUÎQ
-kékesfeketés/Ó×GVËnňLTtlą
-kékesfekete/ąBÓŐĐGVËR
+kékesfeketés/Ó×GVËnňLTtląy
+kékesfekete/ąyBÓŐĐGVËR
 kékesfehér/Ó×GVËnňLRlą
 kékes/Ó×GVËnňLTtlą
 kékeres/Ó×GVËnňLTtlą
@@ -73013,7 +73209,7 @@ kromatikus/ŇŮFUÎmôKÖSsk°
 kritikátlan/ŇŮFUÎmôKÖQk°
 kritikus/ŇŮFUÎmôKÖSsk°
 kritikai/°AŇŐĎFUÎQ
-kristálytiszta/°AŇŐĎFUÎQ
+kristálytiszta/°yAŇŐĎFUÎQ
 kristályos/ŇŮFUÎmôKÖSsk°
 kriminális/ŇŮFUÎmôKÖSsk°
 krezolvörös/Ô×ÝňGVĚNTtlą
@@ -73047,7 +73243,7 @@ kortyondi/°BÓŐĐGVËR
 kortalan/ŇŮFUÎmôKÖQk°
 korszerűtlen/Ó×GVËnňLRlą
 korszerű/ąyCÔŐŢHWĚR
-korszakalkotó/°AŇŐĎFUÎQ
+korszakalkotó/°yAŇŐĎFUÎQó
 korrózióálló/°AŇŐĎFUÎQ
 korrupt/ŇŮFUÎmôKÖQk°
 korrozív/ŇŮFUÎmôKÖSsk°
@@ -73064,7 +73260,7 @@ koros/ŇŮFUÎmôKÖSsk°
 koronázatlan/ŇŮFUÎmôKÖQk°
 koromsötét/Ó×GVËnňLRlą
 koromlepte/ąBÓŐĐGVËR
-koromfekete/ąBÓŐĐGVËR
+koromfekete/ąyBÓŐĐGVËR
 korombeli/ąBÓŐĐGVËR
 korodbeli/ąBÓŐĐGVËR
 kormányzó/XAŇŐĎFUÎQ
@@ -73116,6 +73312,7 @@ konvertibilis/Ó×GVËnňLTtlą
 konvergens/Ó×GVËnňLTtlą
 konvencionális/ŇŮFUÎmôKÖSsk°
 konvektív/Ó×GVËnňLTtlą
+kontrasztív/ŇŮFUÎmôKÖSsÓ×GVËnňLTtklą
 kontraszelektív/Ó×GVËnňLTtlą
 kontrapunktikus/ŇŮFUÎmôKÖSsk°
 kontraproduktív/ŇŮFUÎmôKÖSsk°
@@ -73230,7 +73427,7 @@ kobzos/ŇŮFUÎmôKÖSsk°
 kobozó/°AŇŐĎFUÎQ
 kobaltkék/Ó×GVËnňLRlą
 koaxiális/ŇŮFUÎmôKÖSsk°
-klímazonális/ŇŮFUÎmôKÖSsk°
+klímazonális/ŇŮFUÎmôKÖSsk°y
 klímasemleges/Ó×GVËnňLTtląy
 klonális/ŇŮFUÎmôKÖSsk°
 klimatizált/ŇŮFUÎmôQk°
@@ -73282,6 +73479,7 @@ kitartott/ŇŮFUÎmôQk°sX
 kitaposatlan/ŇŮFUÎmôKÖQk°
 kitalált/ŇŮFUÎmôQk°
 kitakarítatlan/ŇŮFUÎmôKÖQk°
+kisüveges/Ó×GVËnňLTtląy
 kisöreg/Ó×GVËnňLRlą
 kisöbű/ąCÔŐŢHWĚR
 kiszínezett/Ó×GVËnňLRlą
@@ -73310,7 +73508,7 @@ kisnyomású/°AŇŐĎFUÎQ
 kismérvű/ąCÔŐŢHWĚR
 kismértékű/ąCÔŐŢHWĚR
 kismilliónyi/°BÓŐĐGVËR
-kislátószögű/ąCÔŐŢHWĚR
+kislátószögű/ąyCÔŐŢHWĚRátó|szögű
 kislelkű/ąCÔŐŢHWĚR
 kiskorú/°AŇŐĎFUÎQ
 kiskapitalista/°AŇŐĎFUÎQ
@@ -73480,8 +73678,8 @@ kielégületlen/Ó×GVËnňLRlą
 kielégíthetetlen/Ó×GVËnňLRlą
 kielégítetlen/Ó×GVËnňLRlą
 kiejtetlen/Ó×GVËnňLRlą
-kiegyensúlyozott/ŇŮFUÎmôQk°sX
-kiegyensúlyozatlan/ŇŮFUÎmôKÖQk°
+kiegyensúlyozott/ŇŮFUÎmôQk°ysXúlyozott
+kiegyensúlyozatlan/ŇŮFUÎmôKÖQk°yúlyozatlan
 kiegyenlítetlen/Ó×GVËnňLRlą
 kidülledt/Ó×GVËnňLRlą
 kidolgozott/ŇŮFUÎmôQk°sX
@@ -73531,17 +73729,17 @@ kevély/Ó×GVËnňLTtlą
 keveslő/ąXYCÔŐŢHWĚR)Ó_PRESPART_adj
 keveslő/ąXYCÔŐŢHWĚR
 keveslendő/XCÔŐŢHWĚR)Ó_FUTPART_adj
-keverékfajú/°AŇŐĎFUÎQ
+keverékfajú/°yAŇŐĎFUÎQ
 kevert/Ó×GVËnňLRlą
 kevergő/ąXCÔŐŢHWĚR
 keveretlen/Ó×GVËnňLRlą
 kettős/Ô×ÝňGVĚNMTtlą
-kettévágott/ŇŮFUÎmôQk°sX
-kettéhasított/ŇŮFUÎmôQk°sX
+kettévágott/ŇŮFUÎmôQk°ysX
+kettéhasított/ŇŮFUÎmôQk°ysX
 keszekusza/°AŇŐĎFUÎQ
 kesze-kusza/°AŇŐĎFUÎQ
-keskenyvágányú/°AŇŐĎFUÎQ
-keskenylevelű/ąCÔŐŢHWĚR
+keskenyvágányú/°yAŇŐĎFUÎQ
+keskenylevelű/ąyCÔŐŢHWĚR
 keskeny/Ó×GVËnňLTtlą
 keshedt/Ó×GVËnňLRlą
 keserű/ąCÔŐŢHWĚR
@@ -73554,25 +73752,25 @@ kesehajú/°AŇŐĎFUÎQ
 kese/ąBÓŐĐGVËR
 kerületi/ąBÓŐĐGVËR
 kerítetlen/Ó×GVËnňLRlą
-kerékvágásos/ŇŮFUÎmôKÖSsk°
+kerékvágásos/ŇŮFUÎmôKÖSsk°y
 kerékcentrírozó/°AŇŐĎFUÎQ
-kertvárosias/ŇŮFUÎmôKÖSsk°
+kertvárosias/ŇŮFUÎmôKÖSsk°y
 kerge/ąBÓŐĐGVËR
 keretes/Ó×GVËnňLTtlą
-keresztülvihető/ąCÔŐŢHWĚR
-keresztülvihetetlen/Ó×GVËnňLRlą
+keresztülvihető/ąyCÔŐŢHWĚR
+keresztülvihetetlen/Ó×GVËnňLRląy
 keresztüli/ąBÓŐĐGVËR
 keresztényszocialista/°AŇŐĎFUÎQ
 keresztényietlen/Ó×GVËnňLRlą
 keresztényi/ąBÓŐĐGVËR
 keresztény/Ó×GVËnňLTtlą
-keresztmetszeti/ąBÓŐĐGVËR
+keresztmetszeti/ąyBÓŐĐGVËR
 keresztkódolt/ŇŮFUÎmôQk°
-keresztirányú/°AŇŐĎFUÎQ
-keresztféléves/Ó×GVËnňLTtlą
+keresztirányú/°yAŇŐĎFUÎQ
+keresztféléves/Ó×GVËnňLTtląy
 keresztezett/Ó×GVËnňLRlą
 kereszteletlen/Ó×GVËnňLRlą
-keresztcsonttáji/°AŇŐĎFUÎQ
+keresztcsonttáji/°yAŇŐĎFUÎQáji
 kereszt_alakú/°AŇŐĎFUÎQ
 kereskedelmi/ąBÓŐĐGVËR
 keresett/Ó×GVËnňLRlą
@@ -73582,13 +73780,13 @@ kereplő/XCÔŐŢHWĚR
 kerepelő/ąXCÔŐŢHWĚR
 kerekített/Ó×GVËnňLRlą
 kereknyergű/ąCÔŐŢHWĚR
-kereklevelű/ąCÔŐŢHWĚR
+kereklevelű/ąyCÔŐŢHWĚR
 kerekes/Ó×GVËnňLTtlą
 kerekded/Ó×GVËnňLRlą
 kerek/Ó×GVËnňLRlą
 kenti/ąBÓŐĐGVËR
 kennedys/Ó×GVËnňLTtl
-kenetteljes/Ó×GVËnňLTtlą
+kenetteljes/Ó×GVËnňLTtląy
 kenetes/Ó×GVËnňLTtlą
 kendőzetlen/Ó×GVËnňLRlą
 keményítetlen/Ó×GVËnňLRlą
@@ -73596,7 +73794,7 @@ keményvonalas/ŇŮFUÎmôKÖSsk°
 keménytökű/ąCÔŐŢHWĚR
 keményszívű/ąCÔŐŢHWĚR
 keménynyakú/°AŇŐĎFUÎQ
-keménykötésű/ąCÔŐŢHWĚR
+keménykötésű/ąyCÔŐŢHWĚR
 keménykezű/ąCÔŐŢHWĚR
 keményfejű/ąCÔŐŢHWĚR
 kemény/Ó×GVËnňLTtlą
@@ -73627,7 +73825,7 @@ kegyúri/°BÓŐĐGVËR
 kegyvesztett/Ó×GVËnňLRląy
 kegyetlen/Ó×GVËnňLRlą
 kegyes/Ó×GVËnňLTtlą
-kegyeletteljes/Ó×GVËnňLTtlą
+kegyeletteljes/Ó×GVËnňLTtląy
 kegyelettelen/Ó×GVËnňLRlą
 kedélytelen/Ó×GVËnňLRlą
 kedélyes/Ó×GVËnňLTtlą
@@ -73710,7 +73908,7 @@ karcolatlan/ŇŮFUÎmôKÖQk°
 karcinogén/Ó×GVËnňLRlą
 karbonsemleges/Ó×GVËnňLTtląy
 karbolos/ŇŮFUÎmôKÖSsk°
-karbantartott/ŇŮFUÎmôQk°sX
+karbantartott/ŇŮFUÎmôQk°ysX
 karakán/ŇŮFUÎmôKÖQk°
 karakterisztikus/ŇŮFUÎmôKÖSsk°
 karacsáj-cserkeszföldi/BÓŐĐGVËR
@@ -73760,7 +73958,7 @@ kalmükellenes/Ó×GVËnňLTtl
 kalmükcentrikus/ŇŮFUÎmôKÖSsk
 kalmükbarát/ŇŮFUÎmôKÖQk
 kalmük/ą
-kalmárszellemű/ąCÔŐŢHWĚR
+kalmárszellemű/ąyCÔŐŢHWĚR
 kallózik/ŇŮFUÎmôKÖQk°
 kalligrafikus/ŇŮFUÎmôKÖSsk°
 kalibrációs/ŇŮFUÎmôKÖSsk°
@@ -73801,8 +73999,8 @@ jóvátevő/ąXYCÔŐŢHWĚR
 jóvátett/Ó×GVËnňRlątX)óvátesz
 jóvátett/Ó×GVËnňRlątX
 jóvátehető/XCÔŐŢHWĚR)óváteszÓ_ABLE_(adj,present_part)
-jóvátehetetlen/Ó×GVËnňLRląX)óvátesz
-jóvátehetetlen/Ó×GVËnňLRląX
+jóvátehetetlen/Ó×GVËnňLRląyX)óvátesz
+jóvátehetetlen/Ó×GVËnňLRląyX
 jóváteendő/XCÔŐŢHWĚR)óváteszÓ_FUTPART_adj
 jóváhagyólagos/ŇŮFUÎmôKÖSsk°
 jóvágású/°AŇŐĎFUÎQ
@@ -73857,7 +74055,7 @@ járulékos/ŇŮFUÎmôKÖSsk°
 jártányi/°AŇŐĎFUÎQ
 jártas/ŇŮFUÎmôKÖSsk°
 járt/ŇŮFUÎmôKÖQ°
-járomcsonti/°AŇŐĎFUÎQ
+járomcsonti/°yAŇŐĎFUÎQ
 járhatatlan/ŇŮFUÎmôKÖQk°
 járatos/ŇŮFUÎmôKÖSsk°
 járatlan/ŇŮFUÎmôKÖQk°
@@ -73883,7 +74081,7 @@ jorubabarát/ŇŮFUÎmôKÖQk
 joruba/°AŇŐĎFUÎQ
 jojózik/ŇŮFUÎmôKÖQk°
 johannita/°AŇŐĎFUÎQ
-jogérvényes/Ó×GVËnňLTtlą
+jogérvényes/Ó×GVËnňLTtląy
 jogvégzett/Ó×GVËnňLRlą
 jogvégzetlen/Ó×GVËnňLRlą
 jogvédett/Ó×GVËnňRlątX
@@ -73903,10 +74101,10 @@ jogfosztott/ŇŮFUÎmôQk°sX
 jogfolytonos/ŇŮFUÎmôKÖSsk°
 jogerős/Ô×ÝňGVĚNMTtlą
 jogellenes/Ó×GVËnňLTtląy
-jobbösszekötő/ąCÔŐŢHWĚR
+jobbösszekötő/ąCÔŐŢHWĚRössze|kötő
 jobbsodrású/°AŇŐĎFUÎQ
 jobbos/ŇŮFUÎmôKÖSsk°
-jobboldali/°AŇŐĎFUÎQ
+jobboldali/°yAŇŐĎFUÎQ
 jobbmenetes/Ó×GVËnňLTtlą
 jobblábas/ŇŮFUÎmôKÖSsk°
 jobbkezes/Ó×GVËnňLTtlą
@@ -73924,7 +74122,7 @@ jelzetlen/Ó×GVËnňLRlą
 jeltelen/Ó×GVËnňLRlą
 jellemző/ąXCÔŐŢHWĚR
 jellemtelen/Ó×GVËnňLRlą
-jellemszilárd/ŇŮFUÎmôKÖQk°
+jellemszilárd/ŇŮFUÎmôKÖQk°y
 jellemező/ąXCÔŐŢHWĚR
 jellembeli/ąBÓŐĐGVËR
 jellegű/ąCÔŐŢHWĚR	ph:jelegű
@@ -73936,7 +74134,7 @@ jelező/ąXCÔŐŢHWĚR
 jeles/Ó×GVËnňLTtlą
 jelenvolt/ŇŮFUÎmôKÖQk°
 jelenvaló/°yAŇŐĎFUÎQ
-jelentőségteljes/Ó×GVËnňLTtlą
+jelentőségteljes/Ó×GVËnňLTtląy
 jelentős/Ô×ÝňGVĚNMTtlą
 jelentésteli/ąyBÓŐĐGVËR
 jelentéstani/°AŇŐĎFUÎQ
@@ -74020,7 +74218,7 @@ iszamós/ŇŮFUÎmôKÖSsk°
 istenáldott/ŇŮFUÎmôQk°sX
 istenverte/ąBÓŐĐGVËR
 istentelen/Ó×GVËnňLRlą
-istenkáromló/°AŇŐĎFUÎQ
+istenkáromló/°yAŇŐĎFUÎQ
 isteni/ąBÓŐĐGVËR
 istenfélő/ąCÔŐŢHWĚR
 istenes/Ó×GVËnňLTtlą
@@ -74035,9 +74233,9 @@ ismeretes/Ó×GVËnňLTtlą
 iskolázatlan/ŇŮFUÎmôKÖQk°
 iskolaérett/Ó×GVËnňLRlą
 iskolai/°AŇŐĎFUÎQ
-iskolahagyott/ŇŮFUÎmôKÖQk°
+iskolahagyott/ŇŮFUÎmôKÖQk°y
 irányítatlan/ŇŮFUÎmôKÖQk°
-irányérzékeny/Ó×GVËnňLTtlą
+irányérzékeny/Ó×GVËnňLTtląy
 irányzó/°XAŇŐĎFUÎQ
 irányzatos/ŇŮFUÎmôKÖSsk°
 irányult/ŇŮFUÎmôKÖQk°
@@ -74069,7 +74267,7 @@ irdatlan/ŇŮFUÎmôKÖQk°
 iratmegsemmisítő/ąCÔŐŢHWĚR
 iranista/°AŇŐĎFUÎQ
 ipodos/ŇŮFUÎmôKÖSsk
-iparműtani/°AŇŐĎFUÎQ
+iparműtani/°yAŇŐĎFUÎQű|tani
 ipari/°AŇŐĎFUÎQ
 ipades/Ó×GVËnňLTtl
 ioncserélt/Ó×GVËnňLRląy
@@ -74095,6 +74293,7 @@ interurbán/ŇŮFUÎmôKÖQk°
 intertextuális/ŇŮFUÎmôKÖSsk°
 intersztelláris/ŇŮFUÎmôKÖSsk°
 interszexuális/ŇŮFUÎmôKÖSsk°
+interszex/Ó×GVËnňLTtlą
 interstadiális/ŇŮFUÎmôKÖSsk°
 interregionális/ŇŮFUÎmôKÖSsk°
 interplanetáris/ŇŮFUÎmôKÖSsk°
@@ -74329,7 +74528,7 @@ időses/Ó×GVËnňLTtlą
 idős/Ô×ÝňGVĚNMTtlą	ősb
 időrendi/ąBÓŐĐGVËR
 időnkénti/ąBÓŐĐGVËR
-időmértékes/Ó×GVËnňLTtlą
+időmértékes/Ó×GVËnňLTtląy
 időleges/Ó×GVËnňLTtlą
 időközbeni/ąBÓŐĐGVËR
 időjárástani/°AŇŐĎFUÎQ
@@ -74359,10 +74558,10 @@ ideiglenes/Ó×GVËnňLTtlą
 idei/ąBÓŐĐGVËR
 idegőrlő/ąCÔŐŢHWĚR
 idegző/XCÔŐŢHWĚR
-idegzsábás/ŇŮFUÎmôKÖSsk°
-idegrendszeri/ąBÓŐĐGVËR
-idegkimerítő/ąCÔŐŢHWĚR
-ideggyönge/ąyBÓŐĐGVËRön-ge
+idegzsábás/ŇŮFUÎmôKÖSsk°y
+idegrendszeri/ąyBÓŐĐGVËR
+idegkimerítő/ąyCÔŐŢHWĚR
+ideggyönge/ąyBÓŐĐGVËRön-geönge
 ideggyenge/ąyBÓŐĐGVËR
 ideges/Ó×GVËnňLTtlą
 idegenszerű/ąCÔŐŢHWĚR
@@ -74383,7 +74582,7 @@ icike-picike/ąBÓŐĐGVËR	ét
 ibolyántúli/°AŇŐĎFUÎQ
 ibolyaszínű/ąCÔŐŢHWĚR
 ibolyakék/Ó×GVËnňLRlą
-ibolyaillatú/°AŇŐĎFUÎQ
+ibolyaillatú/°yAŇŐĎFUÎQ
 hüvelyes/Ó×GVËnňLTtlą
 hülyítő/ąCÔŐŢHWĚR
 hülye/ąBÓŐĐGVËR
@@ -74401,7 +74600,7 @@ húzódott/ŇŮFUÎmôQk°sX
 húszóránkénti/ąBÓŐĐGVËR
 húszórai/°BÓŐĐGVËR
 húszévi/ąBÓŐĐGVËR
-húszévenkénti/ąBÓŐĐGVËR
+húszévenkénti/ąyBÓŐĐGVËR
 húszrendbeli/ąBÓŐĐGVËR
 húszpercenkénti/ąBÓŐĐGVËR
 húsznaponkénti/ąBÓŐĐGVËR
@@ -74431,7 +74630,7 @@ hőleadó/°AŇŐĎFUÎQ
 hőlabilis/Ó×GVËnňLTtlą
 hőforrás/ŇŮFUÎmôKÖSsk°
 hőfejlesztő/ąCÔŐŢHWĚR
-hőerőművi/ąyBÓŐĐGVËR
+hőerőművi/ąyBÓŐĐGVËRő||erő|művi
 hőemelkedéses/Ó×GVËnňLTtlą
 hőelektromos/ŇŮFUÎmôKÖSsk°
 hőbörödött/Ô×ÝňGVĚNRlą
@@ -74519,7 +74718,7 @@ háziasított/ŇŮFUÎmôQk°sX
 házias/ŇŮFUÎmôKÖSsk°
 házi_kedvenc/Ó×GVËnňLTtlą
 házi/°AŇŐĎFUÎQ
-házhozszállítási/°AŇŐĎFUÎQázhoz|szállítási
+házhozszállítási/°yAŇŐĎFUÎQázhoz|szállítási
 házbeli/ąBÓŐĐGVËR
 házatlan/ŇŮFUÎmôKÖQk°
 házasuló/°AŇŐĎFUÎQ
@@ -74528,14 +74727,14 @@ házas/ŇŮFUÎmôKÖSsk°
 hátultesztelős/Ô×ÝňGVĚNMTtląy
 hátrányos/ŇŮFUÎmôKÖSsk°
 hátramenő/ąCÔŐŢHWĚR
-hátramaradt/ŇŮFUÎmôKÖQk°
+hátramaradt/ŇŮFUÎmôKÖQk°y
 hátralékos/ŇŮFUÎmôKÖSsk°
 hátralevő/ąCÔŐŢHWĚR
-hátrahagyott/ŇŮFUÎmôQk°sX
+hátrahagyott/ŇŮFUÎmôQk°ysX
 háti/°AŇŐĎFUÎQ
 hátborzongató/°AŇŐĎFUÎQ
 hárys/ŇŮFUÎmôKÖSs
-hártyásszárnyú/°AŇŐĎFUÎQártyás|szárnyú
+hártyásszárnyú/°yAŇŐĎFUÎQártyás|szárnyú
 hártyás/ŇŮFUÎmôKÖSsk°
 hártyavékony/ŇŮFUÎmôKÖSsk°
 háromóránkénti/ąBÓŐĐGVËR
@@ -74544,8 +74743,8 @@ háromévi/ąBÓŐĐGVËR
 háromévenkénti/ąBÓŐĐGVËR
 háromtagú/°AŇŐĎFUÎQ
 háromszögű/ąCÔŐŢHWĚR
-háromszögtani/°AŇŐĎFUÎQ
-háromszögletű/ąCÔŐŢHWĚR
+háromszögtani/°yAŇŐĎFUÎQ
+háromszögletű/ąyCÔŐŢHWĚR
 háromszög_alakú/°AŇŐĎFUÎQ
 háromszori/°AŇŐĎFUÎQ
 háromszoba-konyhás/ŇŮFUÎmôKÖSsk°
@@ -74554,19 +74753,19 @@ háromrészű/ąCÔŐŢHWĚR
 háromrendbeli/ąBÓŐĐGVËR
 hárompercenkénti/ąBÓŐĐGVËR
 háromnyolcados/ŇŮFUÎmôKÖSsk°
-háromnyelvű/ąCÔŐŢHWĚR
+háromnyelvű/ąyCÔŐŢHWĚR
 háromnegyedmilliós/ŇŮFUÎmôKÖSsk°
-háromnegyedes/Ó×GVËnňLTtlą
+háromnegyedes/Ó×GVËnňLTtląy
 háromnaponkénti/ąBÓŐĐGVËR
 háromlábú/°AŇŐĎFUÎQ
-háromkerekű/ąCÔŐŢHWĚR
+háromkerekű/ąyCÔŐŢHWĚR
 háromismeretlenes/Ó×GVËnňLTtlą
-háromirányú/°AŇŐĎFUÎQ
+háromirányú/°yAŇŐĎFUÎQ
 háromheti/ąBÓŐĐGVËR
-háromhetenkénti/ąBÓŐĐGVËR
+háromhetenkénti/ąyBÓŐĐGVËR
 háromhavonkénti/ąBÓŐĐGVËR
 háromhavi/°BÓŐĐGVËR
-háromhatalmi/°BÓŐĐGVËR
+háromhatalmi/°yBÓŐĐGVËR
 háromféle/ąBÓŐĐGVËR
 háromesztendei/ąBÓŐĐGVËR
 hármas/ŇŮFUÎmôKÖSsk°
@@ -74594,7 +74793,7 @@ huzamos/ŇŮFUÎmôKÖSsk°
 huzagolatlan/ŇŮFUÎmôKÖQk°
 huszáros/ŇŮFUÎmôKÖSsk°
 huszita/°AŇŐĎFUÎQ
-hurráoptimista/°AŇŐĎFUÎQ
+hurráoptimista/°yAŇŐĎFUÎQ
 huron-tói/°wAŇŐĎFUÎQ
 hurkos/ŇŮFUÎmôKÖSsk°
 hupikék/Ó×GVËnňLRlą
@@ -74630,21 +74829,21 @@ hulladékátvevő/ąCÔŐŢHWĚR
 hulladéklerakó/°AŇŐĎFUÎQ
 hugenotta/°AŇŐĎFUÎQ
 hucul/ŇŮFUÎmôKÖQk°
-hozzávetőleges/Ó×GVËnňLTtlą
-hozzászokott/ŇŮFUÎmôQk°sX
+hozzávetőleges/Ó×GVËnňLTtląy
+hozzászokott/ŇŮFUÎmôQk°ysX
 hozzámért/Ó×GVËnňLRlą
-hozzákapcsolt/ŇŮFUÎmôQk°
+hozzákapcsolt/ŇŮFUÎmôQk°y
 hozzáillő/ąCÔŐŢHWĚR
-hozzáfüggesztett/Ó×GVËnňLRlą
-hozzáférhető/ąCÔŐŢHWĚR
-hozzáférhetetlen/Ó×GVËnňLRlą
-hozzáerősített/Ó×GVËnňLRlą
+hozzáfüggesztett/Ó×GVËnňLRląy
+hozzáférhető/ąyCÔŐŢHWĚR
+hozzáférhetetlen/Ó×GVËnňLRląy
+hozzáerősített/Ó×GVËnňLRląy
 hosszúszárnyú/°AŇŐĎFUÎQ
 hosszúkás/ŇŮFUÎmôKÖSsk°
-hosszújáratú/°AŇŐĎFUÎQ
-hosszúhullámú/°AŇŐĎFUÎQ
+hosszújáratú/°yAŇŐĎFUÎQ
+hosszúhullámú/°yAŇŐĎFUÎQ
 hosszúdad/ŇŮFUÎmôKÖQk°
-hosszirányú/°AŇŐĎFUÎQ
+hosszirányú/°yAŇŐĎFUÎQ
 hosszas/ŇŮFUÎmôKÖSsk°
 hosszanti/°AŇŐĎFUÎQ
 hosszan_tartó/°AŇŐĎFUÎQ	óbbanóbb
@@ -74670,6 +74869,7 @@ horganyzott/ŇŮFUÎmôQk°sX
 horganyfehér/Ó×GVËnňLRlą
 hordképes/Ó×GVËnňLTtlą
 horderejű/ąCÔŐŢHWĚR
+honvédes/Ó×GVËnňLTtląy
 hontalan/ŇŮFUÎmôKÖQk°
 honosítatlan/ŇŮFUÎmôKÖQk°
 honi/°AŇŐĎFUÎQ
@@ -74697,14 +74897,14 @@ homeomorf/ŇŮFUÎmôKÖQk°
 holttányilvánítási/°BÓŐĐGVËR
 holtsápadt/ŇŮFUÎmôQk°
 holtrészeg/Ó×GVËnňLRlą
-holtfáradt/ŇŮFUÎmôKÖQk°
-holtbiztos/ŇŮFUÎmôSsk°
-holtbizonyos/ŇŮFUÎmôKÖSsk°
+holtfáradt/ŇŮFUÎmôKÖQk°y
+holtbiztos/ŇŮFUÎmôSsk°y
+holtbizonyos/ŇŮFUÎmôKÖSsk°y
 holt/ŇŮFUÎmôQ°
 holografikus/ŇŮFUÎmôKÖSsk°
 holnaputáni/°AŇŐĎFUÎQ
 holnapi/°AŇŐĎFUÎQ
-hollófekete/ąBÓŐĐGVËR
+hollófekete/ąyBÓŐĐGVËR
 hollandi/°AŇŐĎFUÎQ
 hollandgyűlölő/CÔŐŢHWĚR
 hollandellenes/Ó×GVËnňLTtl
@@ -74712,9 +74912,9 @@ hollandcentrikus/ŇŮFUÎmôKÖSsk
 hollandbarát/ŇŮFUÎmôKÖQk
 holland/°
 holisztikus/ŇŮFUÎmôKÖSsk°
-holdvilágtalan/ŇŮFUÎmôKÖQk°
+holdvilágtalan/ŇŮFUÎmôKÖQk°y
 holdkóros/ŇŮFUÎmôKÖSsk°
-holdfényes/Ó×GVËnňLTtlą
+holdfényes/Ó×GVËnňLTtląy
 hofis/ŇŮFUÎmôKÖSsk
 hoffmanni/AŇŐĎFUÎQ
 hiú/°AŇŐĎFUÎQ
@@ -74752,7 +74952,7 @@ hiteltérdemlő/ąwCÔŐŢHWĚR
 hiteltelen/Ó×GVËnňLRlą
 hitelt_érdemlő/ąCÔŐŢHWĚR
 hitelképes/Ó×GVËnňLTtlą
-hitelkárosult/ŇŮFUÎmôQk°
+hitelkárosult/ŇŮFUÎmôQk°y
 hiteles/Ó×GVËnňLTtlą
 hitehagyó/°AŇŐĎFUÎQ
 hitehagyott/ŇŮFUÎmôQk°ysX
@@ -74786,7 +74986,7 @@ hiperaktív/ŇŮFUÎmôKÖSsk°
 hindu/°AŇŐĎFUÎQ
 hindi/ąBÓŐĐGVËR
 himnikus/ŇŮFUÎmôKÖSsk°
-himlőhelyes/Ó×GVËnňLTtlą
+himlőhelyes/Ó×GVËnňLTtląy
 hiltonbeli/BÓŐĐGVËR
 hihető/ąXCÔŐŢHWĚR)Ó_ABLE_(adj,present_part)
 hihető/ąXCÔŐŢHWĚR
@@ -74879,7 +75079,7 @@ helyénvaló/°AŇŐĎFUÎQ
 helytálló/°yAŇŐĎFUÎQ
 helytelen/Ó×GVËnňLRlą
 helyszínelő/ąCÔŐŢHWĚR
-helyreállított/ŇŮFUÎmôQk°sX
+helyreállított/ŇŮFUÎmôQk°ysX
 helyrajzi/°AŇŐĎFUÎQ
 helyleíró/°AŇŐĎFUÎQ
 helyközi/ąBÓŐĐGVËR
@@ -74902,7 +75102,7 @@ hektikus/ŇŮFUÎmôKÖSsk°
 heinés/Ó×GVËnňLTtl
 hehezetes/Ó×GVËnňLTtlą
 hegyű/ąCÔŐŢHWĚR
-hegyvidéki/ąBÓŐĐGVËR
+hegyvidéki/ąyBÓŐĐGVËR
 hegyibeteg/Ó×GVËnňLRląy
 hegyetlen/Ó×GVËnňLRlą
 hegyesorrú/°AŇŐĎFUÎQ
@@ -74941,8 +75141,9 @@ hatásos/ŇŮFUÎmôKÖSsk°
 határtalan/ŇŮFUÎmôKÖQk°
 határozott/ŇŮFUÎmôQk°sX
 határozatlan/ŇŮFUÎmôKÖQk°
-határozatképtelen/Ó×GVËnňLRlą
+határozatképtelen/Ó×GVËnňLRląy
 határos/ŇŮFUÎmôKÖSsk°
+határközeli/ąyBÓŐĐGVËR
 határidős/Ô×ÝňGVĚNTtlą
 határidejű/ąCÔŐŢHWĚR
 határ_menti/ąBÓŐĐGVËR
@@ -74984,7 +75185,7 @@ hatalmas/ŇŮFUÎmôKÖSsk°
 hasüregi/ąBÓŐĐGVËR
 hasáb_alakú/°AŇŐĎFUÎQ
 hasztalan/ŇŮFUÎmôKÖQk°
-haszonélvező/ąCÔŐŢHWĚR
+haszonélvező/ąyCÔŐŢHWĚR
 haszontalan/ŇŮFUÎmôKÖQk°
 haszonleső/ąCÔŐŢHWĚR
 haszonelvű/ąCÔŐŢHWĚR
@@ -74995,9 +75196,9 @@ használatlan/ŇŮFUÎmôKÖQk°
 hasznot_hajtó/°AŇŐĎFUÎQ	óbbanóbb
 hasznosítatlan/ŇŮFUÎmôKÖQk°
 hasznos/ŇŮFUÎmôKÖSsk°
-hasznavehető/ąCÔŐŢHWĚR
-hasznavehetetlen/Ó×GVËnňLRlą
-hasraütésszerű/ąCÔŐŢHWĚR
+hasznavehető/ąyCÔŐŢHWĚR
+hasznavehetetlen/Ó×GVËnňLRląy
+hasraütésszerű/ąyCÔŐŢHWĚRütés||szerű
 hasonértékű/ąCÔŐŢHWĚR
 hasonszőrű/ąCÔŐŢHWĚR
 hasonszenvi/ąBÓŐĐGVËR
@@ -75006,7 +75207,7 @@ hasonnemű/ąCÔŐŢHWĚR
 hasonló/°AŇŐĎFUÎQ%
 hasonlíthatatlan/ŇŮFUÎmôKÖQk°
 hasonlatos/ŇŮFUÎmôKÖSsk°
-hasoneredetű/ąCÔŐŢHWĚR
+hasoneredetű/ąyCÔŐŢHWĚR
 hasonelvű/ąCÔŐŢHWĚR
 hasi/°AŇŐĎFUÎQ
 hashajtó/°AŇŐĎFUÎQ
@@ -75029,10 +75230,10 @@ harminchavi/°BÓŐĐGVËR
 harmincféle/ąBÓŐĐGVËR
 harmincesztendei/ąBÓŐĐGVËR
 harmatos/ŇŮFUÎmôKÖSsk°
-harmatgyenge/ąBÓŐĐGVËR
+harmatgyenge/ąyBÓŐĐGVËR
 harmadrendű/ąCÔŐŢHWĚR
 harmadrangú/°AŇŐĎFUÎQ
-harmadosztályú/°AŇŐĎFUÎQ
+harmadosztályú/°yAŇŐĎFUÎQ
 harmadlagos/ŇŮFUÎmôKÖSsk°
 harmadkorú/°AŇŐĎFUÎQ
 harmadikutas/ŇŮFUÎmôKÖSsk°
@@ -75069,24 +75270,24 @@ hangutánzó/°yAŇŐĎFUÎQ
 hangulatos/ŇŮFUÎmôKÖSsk°
 hangtani/°AŇŐĎFUÎQ
 hangtalan/ŇŮFUÎmôKÖQk°
-hangsúlytalan/ŇŮFUÎmôKÖQk°
-hangsúlyozott/ŇŮFUÎmôQk°sX
-hangsúlyozatlan/ŇŮFUÎmôKÖQk°
-hangsúlyos/ŇŮFUÎmôKÖSsk°
-hangszínezeti/ąBÓŐĐGVËR
-hangszigetelt/Ó×GVËnňLRlą
-hangszeres/Ó×GVËnňLTtlą
+hangsúlytalan/ŇŮFUÎmôKÖQk°y
+hangsúlyozott/ŇŮFUÎmôQk°ysX
+hangsúlyozatlan/ŇŮFUÎmôKÖQk°y
+hangsúlyos/ŇŮFUÎmôKÖSsk°y
+hangszínezeti/ąyBÓŐĐGVËR
+hangszigetelt/Ó×GVËnňLRląy
+hangszeres/Ó×GVËnňLTtląy
 hangrendű/ąCÔŐŢHWĚR
 hangos/ŇŮFUÎmôKÖSsk°
 hangnyelő/ąCÔŐŢHWĚR
-hanghűségű/ąCÔŐŢHWĚR
+hanghűségű/ąyCÔŐŢHWĚR
 hangfestő/ąCÔŐŢHWĚR
 hangadó/°AŇŐĎFUÎQ
 hamvaszöld/Ô×ÝňGVĚNRląöld
 hamvasszőke/ąBÓŐĐGVËRő-ke
 hamvaskék/Ó×GVËnňLRlą
 hamvas/ŇŮFUÎmôKÖSsk°
-hamuszürke/ąBÓŐĐGVËR
+hamuszürke/ąyBÓŐĐGVËR
 hamuszínű/ąCÔŐŢHWĚR
 hamupipőke/ąBÓŐĐGVËR
 hamisított/ŇŮFUÎmôQk°sX
@@ -75096,7 +75297,7 @@ hamiskás/ŇŮFUÎmôKÖSsk°
 hamis/ŇŮFUÎmôKÖSsk°
 halászati/°AŇŐĎFUÎQ
 halánték/Ó×GVËnňLRlą
-halálsápadt/ŇŮFUÎmôKÖQk°
+halálsápadt/ŇŮFUÎmôKÖQk°y
 halálraszánt/ŇŮFUÎmôKÖQk°
 halálpontos/ŇŮFUÎmôKÖSsk°
 halálos/ŇŮFUÎmôKÖSsk°
@@ -75157,14 +75358,14 @@ halasi/°AŇŐĎFUÎQ
 haladó_szellemű/ąCÔŐŢHWĚR	ószelleműbbenószelleműbb
 haladéktalan/ŇŮFUÎmôKÖQk°
 hajózhatatlan/ŇŮFUÎmôKÖQk°
-hajótörött/Ô×ÝňGVĚNRlą
+hajótörött/Ô×ÝňGVĚNRląy
 hajított/ŇŮFUÎmôQk°sX
 hajtott/ŇŮFUÎmôQk°sX
 hajthatatlan/ŇŮFUÎmôKÖQk°
-hajszálvékony/ŇŮFUÎmôKÖSsk°
-hajszálpontos/ŇŮFUÎmôKÖSsk°
+hajszálvékony/ŇŮFUÎmôKÖSsk°y
+hajszálpontos/ŇŮFUÎmôKÖSsk°y
 hajszálfinom/ŇŮFUÎmôKÖSsk°
-hajszálcsöves/Ó×GVËnňLTtlą
+hajszálcsöves/Ó×GVËnňLTtląy
 hajszolt/ŇŮFUÎmôQk°
 hajporzó/XAŇŐĎFUÎQ
 hajnali/°AŇŐĎFUÎQ
@@ -75195,10 +75396,10 @@ haditett/Ó×GVËnňRlątX
 hadiszállító/°AŇŐĎFUÎQ
 hadikikötő/ąCÔŐŢHWĚR
 hadigondozó/°AŇŐĎFUÎQ
-hadigondozott/ŇŮFUÎmôKÖQk°
-hadifontosságú/°AŇŐĎFUÎQ
+hadigondozott/ŇŮFUÎmôKÖQk°y
+hadifontosságú/°yAŇŐĎFUÎQ
 hadi/°AŇŐĎFUÎQ
-hadbavonult/ŇŮFUÎmôKÖQk°
+hadbavonult/ŇŮFUÎmôKÖQk°y
 habókos/ŇŮFUÎmôKÖSsk°
 habzó/XAŇŐĎFUÎQ
 habzsi/°AŇŐĎFUÎQ
@@ -75214,8 +75415,8 @@ gúla_alakú/°AŇŐĎFUÎQ
 göthös/Ô×ÝňGVĚNMTtlą
 göröngyös/Ô×ÝňGVĚNMTtlą
 görögös/Ô×ÝňGVĚNMTtlą
-görögkeleti/ąBÓŐĐGVËR
-görögkatolikus/ŇŮFUÎmôKÖSsk°
+görögkeleti/ąyBÓŐĐGVËR
+görögkatolikus/ŇŮFUÎmôKÖSsk°y
 göröggyűlölő/CÔŐŢHWĚR
 görögellenes/Ó×GVËnňLTtl
 görögcentrikus/ŇŮFUÎmôKÖSsk
@@ -75294,13 +75495,13 @@ gyönyörteli/ąyBÓŐĐGVËR
 gyönyörittas/ŇŮFUÎmôKÖSsk°
 gyöngédtelen/Ó×GVËnňLRlą
 gyöngéd/Ó×GVËnňLRlą
-gyöngyszürke/ąBÓŐĐGVËR
-gyöngyházszínű/ąCÔŐŢHWĚRöngy|ház||színű
-gyöngyházszín/Ó×GVËnňLRląy
-gyöngyházfényű/ąCÔŐŢHWĚR
+gyöngyszürke/ąyBÓŐĐGVËR
+gyöngyházszínű/ąyCÔŐŢHWĚRöngy|ház||színű
+gyöngyházszín/Ó×GVËnňLRląyöngy|ház||szín
+gyöngyházfényű/ąyCÔŐŢHWĚRöngy|ház||fényű
 gyöngekezű/ąCÔŐŢHWĚR
 gyönge/ąBÓŐĐGVËR
-gyökértömött/Ô×ÝňGVĚNRlą
+gyökértömött/Ô×ÝňGVĚNRląy
 gyökértelen/Ó×GVËnňLRlą
 gyökkitevő/ąCÔŐŢHWĚR
 gyökeres/Ó×GVËnňLTtlą
@@ -75314,7 +75515,7 @@ gyógyíthatatlan/ŇŮFUÎmôKÖQk°
 gyógyítatlan/ŇŮFUÎmôKÖQk°
 gyógyászati/°AŇŐĎFUÎQ
 gyógyult/ŇŮFUÎmôQk°
-gyógyszerérzékeny/Ó×GVËnňLTtlą
+gyógyszerérzékeny/Ó×GVËnňLTtląy
 gyógyszertári/°AŇŐĎFUÎQ
 gyógyhatású/°AŇŐĎFUÎQ
 gyógyerejű/ąCÔŐŢHWĚR
@@ -75323,7 +75524,7 @@ gyér/Ó×GVËnňLRą
 gyáva/°AŇŐĎFUÎQ
 gyászvitéz/Ó×GVËnňLTtlą
 gyászos/ŇŮFUÎmôKÖSsk°
-gyászhangulatú/°AŇŐĎFUÎQ
+gyászhangulatú/°yAŇŐĎFUÎQ
 gyártósemleges/Ó×GVËnňLTtląy
 gyári/°AŇŐĎFUÎQ
 gyámolítatlan/ŇŮFUÎmôKÖQk°
@@ -75334,12 +75535,12 @@ gyulladásos/ŇŮFUÎmôKÖSsk°
 gyulladt/ŇŮFUÎmôKÖQk°
 gyulays/ŇŮFUÎmôKÖSsk
 gyorsváltó/°AŇŐĎFUÎQ
-gyorstüzelő/ąCÔŐŢHWĚR
+gyorstüzelő/ąyCÔŐŢHWĚR
 gyorsmaró/°AŇŐĎFUÎQ
 gyorslövő/ąCÔŐŢHWĚR
 gyorskiszolgáló/°AŇŐĎFUÎQ
 gyorshegesztő/ąCÔŐŢHWĚR
-gyorsforgalmi/°AŇŐĎFUÎQ
+gyorsforgalmi/°yAŇŐĎFUÎQ
 gyorsfonó/°AŇŐĎFUÎQ
 gyorsfelvonó/°AŇŐĎFUÎQ
 gyorsfagyasztott/ŇŮFUÎmôQk°sX
@@ -75369,7 +75570,7 @@ gyengéd/Ó×GVËnňLRlą
 gyengécske/ąBÓŐĐGVËR
 gyengus/ŇŮFUÎmôKÖSsk°
 gyengekezű/ąCÔŐŢHWĚR
-gyengeelméjű/ąCÔŐŢHWĚR
+gyengeelméjű/ąyCÔŐŢHWĚR
 gyengeagyú/°AŇŐĎFUÎQ
 gyenge/ąBÓŐĐGVËR
 gyatra/°AŇŐĎFUÎQ
@@ -75429,7 +75630,7 @@ granulált/ŇŮFUÎmôQk°
 grandiózus/ŇŮFUÎmôKÖSsk°
 grammatikus/ŇŮFUÎmôKÖSsk°
 grafomán/ŇŮFUÎmôKÖQk°
-grafitszürke/ąBÓŐĐGVËR
+grafitszürke/ąyBÓŐĐGVËR
 grafikus/ŇŮFUÎmôKÖSsk°
 graduális/ŇŮFUÎmôKÖSsk°
 graciőz/Ô×ÝňGVĚNMTtlą
@@ -75439,9 +75640,9 @@ goromba/°AŇŐĎFUÎQ
 gordiuszi/°BÓŐĐGVËR
 gonosztevő/ąCÔŐŢHWĚR
 gonosz/ŇŮFUÎmôKÖSsk°
-gondviselő/ąCÔŐŢHWĚR
+gondviselő/ąyCÔŐŢHWĚR
 gondvert/Ó×GVËnňLRlą
-gondterhelt/Ó×GVËnňLRlą
+gondterhelt/Ó×GVËnňLRląy
 gondtelt/Ó×GVËnňLRlą
 gondtalan/ŇŮFUÎmôKÖQk°
 gondozott/ŇŮFUÎmôQk°sX
@@ -75504,7 +75705,7 @@ geci/ąBÓŐĐGVËR=
 gebines/Ó×GVËnňLTtlą
 gazos/ŇŮFUÎmôKÖSsk°
 gazdátlan/ŇŮFUÎmôKÖQk°
-gazdaságtudományi/°AŇŐĎFUÎQ
+gazdaságtudományi/°yAŇŐĎFUÎQ
 gazdaságtani/°AŇŐĎFUÎQ
 gazdaságtalan/ŇŮFUÎmôKÖQk°
 gazdaságos/ŇŮFUÎmôKÖSsk°
@@ -75526,8 +75727,9 @@ gallcentrikus/ŇŮFUÎmôKÖSsk
 gallbarát/ŇŮFUÎmôKÖQk
 gall/ŇŮFUÎmôKÖQ°
 galibaszerző/ąCÔŐŢHWĚR
+galerista/°AŇŐĎFUÎQ
 galambősz/Ô×ÝňGVĚNMTtlą
-galambszürke/ąBÓŐĐGVËR
+galambszürke/ąyBÓŐĐGVËR
 galaktikus/ŇŮFUÎmôKÖSsk°
 gagyi/°AŇŐĎFUÎQ
 gaboronei/BÓŐĐGVËR
@@ -75592,23 +75794,22 @@ fölfedhetetlen/Ó×GVËnňLRlą
 földöntúli/°AŇŐĎFUÎQ
 földtelen/Ó×GVËnňLRlą
 földtani/°AŇŐĎFUÎQ
-földszintes/Ó×GVËnňLTtlą
-földnélküli/ąBÓŐĐGVËR
-földművelődésügyi/ąBÓŐĐGVËR
-földművelő/ąCÔŐŢHWĚR
+földszintes/Ó×GVËnňLTtląy
+földnélküli/ąyBÓŐĐGVËR
+földművelő/ąyCÔŐŢHWĚR
 földmíves/Ó×GVËnňLTtlą
 földmívelő/ąCÔŐŢHWĚR
-földméréstani/°AŇŐĎFUÎQ
-földközépkori/°AŇŐĎFUÎQ
+földméréstani/°yAŇŐĎFUÎQöld|mérés||tani
+földközépkori/°yAŇŐĎFUÎQöld||közép|kori
 földközi/ąBÓŐĐGVËR
 földies/Ó×GVËnňLTtlą
 földi/ąBÓŐĐGVËR
-földhöztapadt/ŇŮFUÎmôKÖQk°
+földhöztapadt/ŇŮFUÎmôKÖQk°y
 földhözragadt/ŇŮFUÎmôKÖQk°
 földhözjuttatott/ŇŮFUÎmôQk°sX
 földetlen/Ó×GVËnňLRlą
 földesúri/°AŇŐĎFUÎQ
-földalatti/°AŇŐĎFUÎQ
+földalatti/°yAŇŐĎFUÎQ
 födetlen/Ó×GVËnňLRlą
 föderális/ŇŮFUÎmôKÖSsk°
 föderatív/ŇŮFUÎmôKÖSsk°
@@ -75624,7 +75825,7 @@ főtelen/Ó×GVËnňLRlą
 főrangú/°AŇŐĎFUÎQ
 főpapi/°AŇŐĎFUÎQ
 főnemesi/ąBÓŐĐGVËR
-főmegbízott/ŇŮFUÎmôQk°sX
+főmegbízott/ŇŮFUÎmôQk°sXő||meg|bízott
 főiskolai/°AŇŐĎFUÎQ
 főhető/XCÔŐŢHWĚR)őÓ_ABLE_(adj,present_part)
 főbeszámoló/°AŇŐĎFUÎQő||be|számoló
@@ -75644,19 +75845,19 @@ férfiúi/°BÓŐĐGVËR
 férfiatlan/ŇŮFUÎmôKÖQk°
 férfias/ŇŮFUÎmôKÖSsk°
 féregrágta/°AŇŐĎFUÎQ
-féregrágott/ŇŮFUÎmôQk°sX
+féregrágott/ŇŮFUÎmôQk°ysX
 fényűző/ąCÔŐŢHWĚR
-fényérzékeny/Ó×GVËnňLTtlą
+fényérzékeny/Ó×GVËnňLTtląy
 fényátnemeresztő/ąCÔŐŢHWĚR
 fénytörő/ąCÔŐŢHWĚR
-fénytompító/°AŇŐĎFUÎQ
+fénytompító/°yAŇŐĎFUÎQ
 fénytelen/Ó×GVËnňLRlą
-fényigényes/Ó×GVËnňLTtlą
+fényigényes/Ó×GVËnňLTtląy
 fénygazdag/ŇŮFUÎmôKÖQk°
 fényezetlen/Ó×GVËnňLRlą
 fényes/Ó×GVËnňLTtlą
 fényelnyelő/ąCÔŐŢHWĚR
-fényelektromos/ŇŮFUÎmôKÖSsk°
+fényelektromos/ŇŮFUÎmôKÖSsk°y
 fémzárolt/ŇŮFUÎmôQk°
 fémtartalmú/°AŇŐĎFUÎQ
 fémműves/Ó×GVËnňLTtlą
@@ -75670,13 +75871,13 @@ félötös/Ô×ÝňGVĚNMTtlą
 félórás/ŇŮFUÎmôKÖSsk°
 félóránkénti/ąBÓŐĐGVËR
 félórai/°AŇŐĎFUÎQ
-félévszázados/ŇŮFUÎmôKÖSsk°
+félévszázados/ŇŮFUÎmôKÖSsk°yél||év|százados
 félévi/ąBÓŐĐGVËR
 félévenkénti/ąBÓŐĐGVËR
 félérett/Ó×GVËnňLRlą
 félénk/Ó×GVËnňLRlą
 félédes/Ó×GVËnňLTtlą
-félárú/°AŇŐĎFUÎQ
+félárú/°yAŇŐĎFUÎQ
 félárva/°AŇŐĎFUÎQ
 félállati/°AŇŐĎFUÎQ
 félájult/ŇŮFUÎmôQk°
@@ -75691,10 +75892,10 @@ félszemű/ąCÔŐŢHWĚR
 félszeg/Ó×GVËnňLRTtlą
 félstabil/ŇŮFUÎmôKÖQk°y
 félrészeg/Ó×GVËnňLRTtlą
-félreérthetetlen/Ó×GVËnňLRlą
-félrevezetett/Ó×GVËnňLRlą
+félreérthetetlen/Ó×GVËnňLRląy
+félrevezetett/Ó×GVËnňLRląy
 félreugró/°AŇŐĎFUÎQ
-félreismerhetetlen/Ó×GVËnňLRlą
+félreismerhetetlen/Ó×GVËnňLRląy
 félreeső/ąCÔŐŢHWĚR
 félpuha/°AŇŐĎFUÎQ
 félprofi/°AŇŐĎFUÎQ
@@ -75765,8 +75966,8 @@ féldomború/°AŇŐĎFUÎQ
 félcédulás/ŇŮFUÎmôKÖSsk°
 félcolos/ŇŮFUÎmôKÖSsk°
 félbolond/ŇŮFUÎmôKÖQk°
-félbeszakított/ŇŮFUÎmôQk°sX
-félbemaradt/ŇŮFUÎmôKÖQk°
+félbeszakított/ŇŮFUÎmôQk°ysX
+félbemaradt/ŇŮFUÎmôKÖQk°y
 félbarna/°AŇŐĎFUÎQ
 félbarbár/ŇŮFUÎmôKÖQk°
 félautonóm/ŇŮFUÎmôKÖQk°y
@@ -75776,7 +75977,7 @@ félakkora/°AŇŐĎFUÎQ
 féktelen/Ó×GVËnňLRlą
 fékezhetetlen/Ó×GVËnňLRlą
 fékevesztett/Ó×GVËnňLRlą
-fékeveszett/Ó×GVËnňLRlą
+fékeveszett/Ó×GVËnňLRląy
 fázékony/ŇŮFUÎmôKÖSsk°
 fáys/ŇŮFUÎmôKÖSs
 fáyas/ŇŮFUÎmôKÖSsk
@@ -75798,9 +75999,9 @@ fáradságos/ŇŮFUÎmôKÖSsk°
 fáradhatatlan/ŇŮFUÎmôKÖQk°
 fáradatlan/ŇŮFUÎmôKÖQk°
 fájintos/ŇŮFUÎmôKÖSsk°
-fájdalomokozó/°AŇŐĎFUÎQ
-fájdalommentes/Ó×GVËnňLTtlą
-fájdalomcsillapító/°AŇŐĎFUÎQ
+fájdalomokozó/°yAŇŐĎFUÎQ
+fájdalommentes/Ó×GVËnňLTtląy
+fájdalomcsillapító/°yAŇŐĎFUÎQ
 fájdalmatlan/ŇŮFUÎmôKÖQk°
 fájdalmas/ŇŮFUÎmôKÖSsk°
 fád/ŇŮFUÎmôKÖQ°
@@ -75826,7 +76027,7 @@ fullánkos/ŇŮFUÎmôKÖSsk°
 fuldokló/XAŇŐĎFUÎQ
 fukar/ŇŮFUÎmôKÖQk°
 fröcskölt/Ô×ÝňGVĚNRlą
-fröccsöntött/Ô×ÝňGVĚNMRlą
+fröccsöntött/Ô×ÝňGVĚNMRląy
 fránya/°AŇŐĎFUÎQ
 frusztrált/ŇŮFUÎmôQk°
 frontérzékeny/Ó×GVËnňLTtlą
@@ -75891,7 +76092,7 @@ formagazdag/ŇŮFUÎmôKÖQk°y
 forgó/°XAŇŐĎFUÎQ
 forgásszimmetrikus/ŇŮFUÎmôKÖSsk°ás|szim-met-ri-kus
 forgandó/°AŇŐĎFUÎQ
-forgalomképtelen/Ó×GVËnňLRlą
+forgalomképtelen/Ó×GVËnňLRląy
 forgalombahozatali/°yAŇŐĎFUÎQ
 forgalombahelyezési/ąyBÓŐĐGVËR
 forgalmi/°AŇŐĎFUÎQ
@@ -75924,8 +76125,8 @@ folytatólagos/ŇŮFUÎmôKÖSsk°
 folyami/°AŇŐĎFUÎQ
 folyamatvezérelt/Ó×GVËnňLRląy
 folyamatos/ŇŮFUÎmôKÖSsk°
-folyamatorientált/ŇŮFUÎmôQk°
-folyadéknyomásos/ŇŮFUÎmôKÖSsk°
+folyamatorientált/ŇŮFUÎmôQk°y
+folyadéknyomásos/ŇŮFUÎmôKÖSsk°y
 foltozott/ŇŮFUÎmôQk°sX
 foltos/ŇŮFUÎmôKÖSsk°
 folklorisztikus/ŇŮFUÎmôKÖSsk°
@@ -75987,7 +76188,7 @@ fizikális/ŇŮFUÎmôKÖSsk°
 fizikai/°AŇŐĎFUÎQ
 fizetőképes/Ó×GVËnňLTtlą
 fizetéstelen/Ó×GVËnňLRlą
-fizetésképtelen/Ó×GVËnňLRlą
+fizetésképtelen/Ó×GVËnňLRląy
 fizetett/Ó×GVËnňLRlą
 fizetetlen/Ó×GVËnňLRlą
 fix/Ó×GVËnňLTtą
@@ -75998,8 +76199,8 @@ fintorgó/XAŇŐĎFUÎQ
 finomított/ŇŮFUÎmôQk°sX
 finomítatlan/ŇŮFUÎmôKÖQk°
 finomszűrő/ąCÔŐŢHWĚR
-finomszemcsés/Ó×GVËnňLTtlą
-finommotorikus/ŇŮFUÎmôKÖSsk°
+finomszemcsés/Ó×GVËnňLTtląy
+finommotorikus/ŇŮFUÎmôKÖSsk°y
 finom/ŇŮFUÎmôKÖSsk°
 finnyás/ŇŮFUÎmôKÖSsk°
 finnugorgyűlölő/CÔŐŢHWĚR
@@ -76065,7 +76266,7 @@ feslő/XCÔŐŢHWĚR
 feslett/Ó×GVËnňLRlą
 feselő/ąXCÔŐŢHWĚR
 fertőzött/Ô×ÝňGVĚNRlą
-fertőzésmentes/Ó×GVËnňLTtlą
+fertőzésmentes/Ó×GVËnňLTtląy
 fertőtavi/°wAŇŐĎFUÎQ
 fertő-tavi/°wAŇŐĎFUÎQ
 fertilis/Ó×GVËnňLTtlą
@@ -76085,20 +76286,20 @@ fenső/ąCÔŐŢHWĚR
 fenséges/Ó×GVËnňLTtlą
 fenomenális/ŇŮFUÎmôKÖSsk°
 fenomenologikus/ŇŮFUÎmôKÖSsk°
-fenntartott/ŇŮFUÎmôQk°sX
+fenntartott/ŇŮFUÎmôQk°ysX
 fennkölt/Ô×ÝňGVĚNRlą
 fenekű/ąCÔŐŢHWĚR
 feneketlen/Ó×GVËnňLRlą
 feneette/ąBÓŐĐGVËR
 feminista/°AŇŐĎFUÎQ
 feminin/Ó×GVËnňLRlą
-felülmúlhatatlan/ŇŮFUÎmôKÖQk°
+felülmúlhatatlan/ŇŮFUÎmôKÖQk°y
 felüli/ąBÓŐĐGVËR	üliek
-felületkezelt/Ó×GVËnňLRlą
+felületkezelt/Ó×GVËnňLRląy
 felületi/ąBÓŐĐGVËR
 felületes/Ó×GVËnňLTtlą
 felületaktív/ŇŮFUÎmôKÖSsk°y
-felülbélyegzett/Ó×GVËnňLRlą
+felülbélyegzett/Ó×GVËnňLRląy
 felügyeleti/ąBÓŐĐGVËR
 felüdítetlen/Ó×GVËnňLRlą
 felőrlő/ąCÔŐŢHWĚR
@@ -76194,14 +76395,14 @@ felemás/ŇŮFUÎmôKÖSsk°
 felemelő/ąCÔŐŢHWĚR
 felemelt/Ó×GVËnňLRlą
 felelőtlen/Ó×GVËnňLRlą
-felelősségteljes/Ó×GVËnňLTtlą
-felekezetnélküli/ąBÓŐĐGVËR
+felelősségteljes/Ó×GVËnňLTtląy
+felekezetnélküli/ąyBÓŐĐGVËR
 felekezeti/ąBÓŐĐGVËR
 felekezetenkívüli/ąBÓŐĐGVËR
 felejthetetlen/Ó×GVËnňLRlą
 feleekkora/°AŇŐĎFUÎQ
 feledékeny/Ó×GVËnňLTtlą
-felebaráti/°AŇŐĎFUÎQ
+felebaráti/°yAŇŐĎFUÎQ
 feleakkora/°AŇŐĎFUÎQ
 feldíszített/Ó×GVËnňLRlą
 feldolgozott/ŇŮFUÎmôQk°sX
@@ -76217,7 +76418,7 @@ felbontatlan/ŇŮFUÎmôKÖQk°
 felbecsülhetetlen/Ó×GVËnňLRlą
 felajzott/ŇŮFUÎmôQk°sX
 feladott/ŇŮFUÎmôQk°sX
-feladatcentrikus/ŇŮFUÎmôKÖSsk°
+feladatcentrikus/ŇŮFUÎmôKÖSsk°y
 fekélyes/Ó×GVËnňLTtlą
 fekvő/ąXYCÔŐŢHWĚR)Ó_PRESPART_adj
 fekvő/ąXYCÔŐŢHWĚR
@@ -76245,9 +76446,9 @@ fehérmájú/°AŇŐĎFUÎQ
 fehérkarmú/°AŇŐĎFUÎQ
 fehérjedús/ŇŮFUÎmôKÖSsk°y
 fehérhátú/°AŇŐĎFUÎQ
-fehérgalléros/ŇŮFUÎmôKÖSsk°
+fehérgalléros/ŇŮFUÎmôKÖSsk°y
 fehérfarkú/°AŇŐĎFUÎQ
-fehéresbarnás/ŇŮFUÎmôKÖSsk°
+fehéresbarnás/ŇŮFUÎmôKÖSsk°y
 fehéres/Ó×GVËnňLTtlą
 fehérbárány/ŇŮFUÎmôKÖSsk°
 fehérarany/ŇŮFUÎmôKÖSsk°	éraranyak
@@ -76297,7 +76498,7 @@ famózus/ŇŮFUÎmôKÖSsk°
 familiáris/ŇŮFUÎmôKÖSsk°
 famegmunkáló/°AŇŐĎFUÎQ
 falánk/ŇŮFUÎmôKÖQk°
-falutokbeli/ąBÓŐĐGVËR
+falutokbeli/ąyBÓŐĐGVËR
 falusias/ŇŮFUÎmôKÖSsk°
 falusi/°AŇŐĎFUÎQ
 falunkbeli/ąBÓŐĐGVËR
@@ -76315,7 +76516,7 @@ falcsonti/°AŇŐĎFUÎQ
 falburkolatú/°AŇŐĎFUÎQ
 falangista/°AŇŐĎFUÎQ
 fakózöld/Ô×ÝňGVĚNMRlą
-fakószürke/ąBÓŐĐGVËR
+fakószürke/ąyBÓŐĐGVËR
 fakó/°AŇŐĎFUÎQ
 fakultációvezető/ąCÔŐŢHWĚR
 fakultatív/ŇŮFUÎmôKÖSsk°
@@ -76323,9 +76524,9 @@ faktoriális/ŇŮFUÎmôKÖSsk°
 faksznis/ŇŮFUÎmôKÖSsk°
 fakitermelő/ąCÔŐŢHWĚR
 fajtiszta/°AŇŐĎFUÎQ
-fajtatiszta/°AŇŐĎFUÎQ
+fajtatiszta/°yAŇŐĎFUÎQ
 fajtalan/ŇŮFUÎmôKÖQk°
-fajtaazonos/ŇŮFUÎmôKÖSsk°
+fajtaazonos/ŇŮFUÎmôKÖSsk°y
 fajsúlytalan/ŇŮFUÎmôKÖQk°
 fajlagos/ŇŮFUÎmôKÖSsk°
 faji/°AŇŐĎFUÎQ
@@ -76341,11 +76542,11 @@ facér/ŇŮFUÎmôKÖQk°
 f-spotos/ŇŮFUÎmôKÖSsk
 ezüstözött/Ô×ÝňGVĚNRlą
 ezüstös/Ô×ÝňGVĚNMTtlą
-ezüstszürke/ąBÓŐĐGVËR
+ezüstszürke/ąyBÓŐĐGVËR
 ezüstrózsaszín/Ó×GVËnňLRląy
-ezüstkeretes/Ó×GVËnňLTtlą
-ezüstgombos/ŇŮFUÎmôKÖSsk°
-ezüstfoglalatú/°AŇŐĎFUÎQ
+ezüstkeretes/Ó×GVËnňLTtląy
+ezüstgombos/ŇŮFUÎmôKÖSsk°y
+ezüstfoglalatú/°yAŇŐĎFUÎQ
 ezüstfehér/Ó×GVËnňLRlą
 ezópusi/°AŇŐĎFUÎQ
 ezredéves/Ó×GVËnňLTtlą
@@ -76381,7 +76582,7 @@ extremofil/ŇŮFUÎmôKÖQk°
 extravagáns/ŇŮFUÎmôKÖSsk°
 extrapolált/ŇŮFUÎmôQk°
 extrakromoszomális/ŇŮFUÎmôKÖSsk°
-extragalaktikus/ŇŮFUÎmôKÖSsk°
+extragalaktikus/ŇŮFUÎmôKÖSsk°y
 extracelluláris/ŇŮFUÎmôKÖSsk°
 extra/°AŇŐĎFUÎQ
 exterritoriális/ŇŮFUÎmôKÖSsk°
@@ -76390,7 +76591,7 @@ externális/ŇŮFUÎmôKÖSsk°
 extenzív/Ó×GVËnňLTtlą
 expresszív/Ó×GVËnňLTtlą
 expresszionista/°AŇŐĎFUÎQ
-exportvezérelt/Ó×GVËnňLRlą
+exportvezérelt/Ó×GVËnňLRląy
 exportorientált/ŇŮFUÎmôQk°
 exponenciális/ŇŮFUÎmôKÖSsk°
 explozív/Ó×GVËnňLTtlą
@@ -76463,9 +76664,9 @@ eszlingeni/ąBÓŐĐGVËR
 eszközölő/ąXCÔŐŢHWĚR
 eszköztelen/Ó×GVËnňLRlą
 eszközlő/XCÔŐŢHWĚR
-eszközigényes/Ó×GVËnňLTtlą
+eszközigényes/Ó×GVËnňLTtląy
 eszkatologikus/ŇŮFUÎmôKÖSsk°
-eszeveszett/Ó×GVËnňLRlą
+eszeveszett/Ó×GVËnňLRląy
 eszetlen/Ó×GVËnňLRlą
 eszes/Ó×GVËnňLTtlą
 eszement/Ó×GVËnňLRlą
@@ -76505,7 +76706,7 @@ erélyes/Ó×GVËnňLTtlą
 eruptív/ŇŮFUÎmôKÖSsk°
 erotikus/ŇŮFUÎmôKÖSsk°
 erogén/Ó×GVËnňLRlą
-ernyővirágzatú/°AŇŐĎFUÎQ
+ernyővirágzatú/°yAŇŐĎFUÎQ
 ernyősvirágú/°AŇŐĎFUÎQ
 ernyősvirágzatú/°AŇŐĎFUÎQ
 ernyedt/Ó×GVËnňLRlą
@@ -76519,7 +76720,7 @@ erezett/Ó×GVËnňLRlą
 eres/Ó×GVËnňLTtlą
 erektilis/Ó×GVËnňLTtlą
 eredménytelen/Ó×GVËnňLRlą
-eredményorientált/ŇŮFUÎmôQk°
+eredményorientált/ŇŮFUÎmôQk°y
 eredményes/Ó×GVËnňLTtlą
 eredetieskedő/ąCÔŐŢHWĚR
 eredeti/ąBÓŐĐGVËR
@@ -76560,8 +76761,8 @@ engedetlen/Ó×GVËnňLRlą
 engedelmes/Ó×GVËnňLTtlą
 enervált/ŇŮFUÎmôQk°
 energikus/ŇŮFUÎmôKÖSsk°
-energiaigényes/Ó×GVËnňLTtlą
-energiagazdag/ŇŮFUÎmôKÖQk°
+energiaigényes/Ó×GVËnňLTtląy
+energiagazdag/ŇŮFUÎmôKÖQk°y
 energiadús/ŇŮFUÎmôKÖSsk°
 energetikus/ŇŮFUÎmôKÖSsk°
 enemű/ąCÔŐŢHWĚR
@@ -76585,7 +76786,7 @@ említetlen/Ó×GVËnňLRlą
 emlékművi/ąBÓŐĐGVËR
 emlékezetreméltó/°AŇŐĎFUÎQ
 emlékezetes/Ó×GVËnňLTtlą
-emlékezeterősítő/ąCÔŐŢHWĚR
+emlékezeterősítő/ąyCÔŐŢHWĚR
 eminens/Ó×GVËnňLTtlą
 eminenciás/ŇŮFUÎmôKÖSsk°
 emilyen/Ó×GVËnňLRlą
@@ -76603,18 +76804,18 @@ embertani/°AŇŐĎFUÎQ
 emberségtudó/°AŇŐĎFUÎQ
 emberséges/Ó×GVËnňLTtlą
 emberszerű/ąCÔŐŢHWĚR
-emberszerető/ąCÔŐŢHWĚR
-emberszabású/°AŇŐĎFUÎQ
+emberszerető/ąyCÔŐŢHWĚR
+emberszabású/°yAŇŐĎFUÎQ
 embermagas/ŇŮFUÎmôKÖSsk°
 emberlakta/°AŇŐĎFUÎQ
-emberkerülő/ąCÔŐŢHWĚR
+emberkerülő/ąyCÔŐŢHWĚR
 emberietlen/Ó×GVËnňLRlą
 emberies/Ó×GVËnňLTtlą
 emberi/ąBÓŐĐGVËR
-embergyűlölő/ąCÔŐŢHWĚR
-emberfölötti/ąBÓŐĐGVËR
+embergyűlölő/ąyCÔŐŢHWĚR
+emberfölötti/ąyBÓŐĐGVËR
 emberfeletti/ąBÓŐĐGVËR
-emberbaráti/°AŇŐĎFUÎQ
+emberbaráti/°yAŇŐĎFUÎQ
 emancipatorikus/ŇŮFUÎmôKÖSsk°
 elölülő/ąCÔŐŢHWĚR
 elöltesztelős/Ô×ÝňGVĚNMTtląy
@@ -76633,8 +76834,8 @@ elővigyázatos/ŇŮFUÎmôKÖSsk°
 elővigyázatlan/ŇŮFUÎmôKÖQk°
 előtti/ąBÓŐĐGVËR	őttiek
 előrejelzett/Ó×GVËnňLRląw
-előrehaladott/ŇŮFUÎmôQk°sX
-előrehajlott/ŇŮFUÎmôQk°sX
+előrehaladott/ŇŮFUÎmôQk°ysX
+előrehajlott/ŇŮFUÎmôQk°ysX
 előre_jelzett/Ó×GVËnňLRlą
 előnyös/Ô×ÝňGVĚNTtlą
 előnytelen/Ó×GVËnňLRlą
@@ -76699,16 +76900,16 @@ elsüllyeszthetetlen/Ó×GVËnňLRlą
 elsüllyedt/Ó×GVËnňLRlą
 elsöprő/ąCÔŐŢHWĚR
 elsőéves/Ó×GVËnňLTtlą
-elsőszülött/Ô×ÝňGVĚNRlą
+elsőszülött/Ô×ÝňGVĚNRląy
 elsőrendű/ąCÔŐŢHWĚR
 elsőrangú/°AŇŐĎFUÎQ
-elsőosztályú/°AŇŐĎFUÎQ
-elsőkötetes/Ó×GVËnňLTtlą
-elsőkönyves/Ó×GVËnňLTtlą
+elsőosztályú/°yAŇŐĎFUÎQ
+elsőkötetes/Ó×GVËnňLTtląy
+elsőkönyves/Ó×GVËnňLTtląy
 elsőkerék-meghajtású/°AŇŐĎFUÎQ
 elsőhetes/Ó×GVËnňLTtlą
 elsőfokú/°AŇŐĎFUÎQ
-elsőfilmes/Ó×GVËnňLTtlą
+elsőfilmes/Ó×GVËnňLTtląy
 elsőfajú/°AŇŐĎFUÎQ
 elsődleges/Ó×GVËnňLTtlą
 elsőbálozó/°yAŇŐĎFUÎQ
@@ -76759,7 +76960,7 @@ elmeszesedett/Ó×GVËnňLRlą
 elmerült/Ô×ÝňGVĚNRlą
 elmenő/ąCÔŐŢHWĚR
 elmentetlen/Ó×GVËnňLRlą
-elmekórtani/°AŇŐĎFUÎQ
+elmekórtani/°yAŇŐĎFUÎQ
 elmebeteg/Ó×GVËnňLRlą
 elmebeli/ąBÓŐĐGVËR
 elmebajos/ŇŮFUÎmôKÖSsk°
@@ -76772,19 +76973,19 @@ ellipszoid/ŇŮFUÎmôKÖQk°
 ellenőrzött/Ô×ÝňGVĚNMRlą
 ellenőrző/XCÔŐŢHWĚR
 ellenőrzendő/ąCÔŐŢHWĚR
-ellenőrizetlen/Ó×GVËnňLRlą
+ellenőrizetlen/Ó×GVËnňLRląy
 ellenálló/°AŇŐĎFUÎQ
-ellenállhatatlan/ŇŮFUÎmôKÖQk°
+ellenállhatatlan/ŇŮFUÎmôKÖQk°y
 ellenző/ąXCÔŐŢHWĚR
 ellenzéki/ąBÓŐĐGVËR
 ellentétes/Ó×GVËnňLTtlą
 ellentett/Ó×GVËnňLRlą
 ellenséges/Ó×GVËnňLTtlą
 ellenszenves/Ó×GVËnňLTtlą
-ellenpontos/ŇŮFUÎmôKÖSsk°
+ellenpontos/ŇŮFUÎmôKÖSsk°y
 ellenkulturális/ŇŮFUÎmôKÖSsk°y
 ellenkező/ąCÔŐŢHWĚR
-ellenirányú/°AŇŐĎFUÎQ
+ellenirányú/°yAŇŐĎFUÎQ
 ellenes/Ó×GVËnňLTtląx
 elkülönült/Ô×ÝňGVĚNMRlą
 elkülönített/Ó×GVËnňLRlą
@@ -76876,14 +77077,15 @@ elektromechanikus/ŇŮFUÎmôKÖSsk°
 elektrolitikus/ŇŮFUÎmôKÖSsk°
 elektrokinetikus/ŇŮFUÎmôKÖSsk°
 elektrohidraulikus/ŇŮFUÎmôKÖSsk°
-elektrofil/ŇŮFUÎmôKÖQk°
+elektrofil/ŇŮFUÎnňKÖQÓ×GVËmôLRkl°
 elektrodinamikus/ŇŮFUÎmôKÖSsk°
+elektroakusztikus/ŇŮFUÎmôKÖSsk°y
 elektori/°AŇŐĎFUÎQ
 eleji/ąBÓŐĐGVËR
 elegáns/ŇŮFUÎmôKÖSsk°
 elegendő/ąCÔŐŢHWĚR
-elefántcsontszínű/ąCÔŐŢHWĚR
-elefántcsontfehér/Ó×GVËnňLRTtląy
+elefántcsontszínű/ąyCÔŐŢHWĚRánt|csont||színű
+elefántcsontfehér/Ó×GVËnňLRTtląyánt|csont||fehér
 eldöntetlen/Ó×GVËnňLRlą
 eldugott/ŇŮFUÎmôQk°sX
 elcsüggedt/Ó×GVËnňLRlą
@@ -76923,11 +77125,11 @@ egésztandíjmentes/Ó×GVËnňLTtlą
 egészségügyi/ąBÓŐĐGVËR
 egészségtelen/Ó×GVËnňLRlą
 egészséges/Ó×GVËnňLTtlą
-egészpályás/ŇŮFUÎmôKÖSsk°
+egészpályás/ŇŮFUÎmôKÖSsk°y
 egészleges/Ó×GVËnňLTtlą
 egész_napos/ŇŮFUÎmôKÖSsk°
 egész/Ó×GVËnňLTtlą
-egérszürke/ąBÓŐĐGVËR
+egérszürke/ąyBÓŐĐGVËR
 egál/ŇŮFUÎmôKÖQk°
 egzotikus/ŇŮFUÎmôKÖSsk°
 egzisztenciális/ŇŮFUÎmôKÖSsk°
@@ -76976,7 +77178,7 @@ egyirányú/°AŇŐĎFUÎQ
 egyiptomi/°BÓŐĐGVËR
 egyidős/Ô×ÝňGVĚNMTtlą
 egyidejű/ąCÔŐŢHWĚR
-egyházmegyei/ąBÓŐĐGVËR
+egyházmegyei/ąyBÓŐĐGVËR
 egyházias/ŇŮFUÎmôKÖSsk°
 egyházi/°AŇŐĎFUÎQ
 egyházellenes/Ó×GVËnňLTtlą
@@ -76998,7 +77200,7 @@ egyetemes/Ó×GVËnňLTtlą
 egyesült/Ô×ÝňGVĚNRlą
 egyesített/Ó×GVËnňLRlą
 egyes/Ó×GVËnňLTtlą
-egyenértékű/ąCÔŐŢHWĚR
+egyenértékű/ąyCÔŐŢHWĚR
 egyenszilárdságú/°AŇŐĎFUÎQ
 egyenruházati/°BÓŐĐGVËR
 egyenruhás/ŇŮFUÎmôKÖSsk°
@@ -77015,7 +77217,7 @@ egyenetlen/Ó×GVËnňLRlą
 egyenes/Ó×GVËnňLTtlą
 egyedülálló/°AŇŐĎFUÎQ
 egyedüli/ąBÓŐĐGVËR
-egyeduralmi/°AŇŐĎFUÎQ
+egyeduralmi/°yAŇŐĎFUÎQ
 egyedi/ąBÓŐĐGVËR
 egycsövű/ąCÔŐŢHWĚR
 egybehangzó/°AŇŐĎFUÎQ
@@ -77082,7 +77284,7 @@ dögletes/Ó×GVËnňLTtlą
 dög_meleg/Ó×GVËnňLRlą
 dög_fáradt/ŇŮFUÎmôQk°
 dög_erős/Ô×ÝňGVĚNMTtlą
-döccenőmentes/Ó×GVËnňLTtlą
+döccenőmentes/Ó×GVËnňLTtląy
 dőre/ąBÓŐĐGVËR
 dőlt/Ô×ÝňGVĚNRą
 dízelmotoros/ŇŮFUÎmôKÖSsk°
@@ -77138,13 +77340,13 @@ duzzadt/ŇŮFUÎmôKÖQk°
 dusanbei/BÓŐĐGVËR
 duránci/°BÓŐĐGVËR
 durvavitorlájú/°AŇŐĎFUÎQ
-durvaszemcsés/Ó×GVËnňLTtlą
-durvarostos/ŇŮFUÎmôKÖSsk°
+durvaszemcsés/Ó×GVËnňLTtląy
+durvarostos/ŇŮFUÎmôKÖSsk°y
 durva/°AŇŐĎFUÎQ
 durcás/ŇŮFUÎmôKÖSsk°
-duplaszéles/Ó×GVËnňLTtlą
-duplaszálas/ŇŮFUÎmôKÖSsk°
-duplafedelű/ąCÔŐŢHWĚR
+duplaszéles/Ó×GVËnňLTtląy
+duplaszálas/ŇŮFUÎmôKÖSsk°y
+duplafedelű/ąyCÔŐŢHWĚR
 dupla/°AŇŐĎFUÎQ
 dunányi/°AŇŐĎFUÎQ
 dunántúli/°BÓŐĐGVËR
@@ -77155,13 +77357,14 @@ dumcsi/°AŇŐĎFUÎQ
 duhaj/ŇŮFUÎmôKÖSsk°
 dudoros/ŇŮFUÎmôKÖSsk°
 duci/°AŇŐĎFUÎQ
+dubaji/°BÓŐĐGVËR	ph:dubai
 dualisztikus/ŇŮFUÎmôKÖSsk°
 dualista/°AŇŐĎFUÎQ
 dsidás/ŇŮFUÎmôKÖSsk
 drúz/ŇŮFUÎmôKÖSs°
 dróttalan/ŇŮFUÎmôKÖQk°
 drótszőrű/ąCÔŐŢHWĚR
-drótnélküli/ąBÓŐĐGVËR
+drótnélküli/ąyBÓŐĐGVËR
 drámai/°AŇŐĎFUÎQ
 drákói/°BÓŐĐGVËR
 drága/°AŇŐĎFUÎQ
@@ -77180,7 +77383,7 @@ domborműves/Ó×GVËnňLTtlą
 dologi/°AŇŐĎFUÎQ
 dolgaértő/ąCÔŐŢHWĚR
 dolgavégezetlen/Ó×GVËnňLRlą
-dolgafelejtő/ąCÔŐŢHWĚR
+dolgafelejtő/ąyCÔŐŢHWĚR
 dokumentatív/ŇŮFUÎmôKÖSsÓ×GVËnňLTtklą
 dokumentarista/°AŇŐĎFUÎQ
 doktrinális/ŇŮFUÎmôKÖSsk°
@@ -77205,7 +77408,7 @@ divergens/Ó×GVËnňLTtlą
 divatos/ŇŮFUÎmôKÖSsk°
 divatmúlt/ŇŮFUÎmôQk°
 divatjamúlt/ŇŮFUÎmôQk°
-divathóbortos/ŇŮFUÎmôKÖSsk°
+divathóbortos/ŇŮFUÎmôKÖSsk°y
 disztális/ŇŮFUÎmôKÖSsk°
 disztributív/ŇŮFUÎmôKÖSsk°
 disztingvált/ŇŮFUÎmôQk°
@@ -77345,7 +77548,7 @@ debussys/ŇŮFUÎmôKÖSsk
 debilis/Ó×GVËnňLTtlą
 debil/Ó×GVËnňLRlą
 davosi/AŇŐĎFUÎQ
-darázsderekú/°AŇŐĎFUÎQ
+darázsderekú/°yAŇŐĎFUÎQ
 darált/ŇŮFUÎmôQk°
 darvas/ŇŮFUÎmôKÖSsk°
 dardanelláki/°AŇŐĎFUÎQ
@@ -77391,7 +77594,7 @@ céltudatos/ŇŮFUÎmôKÖSsk°
 céltalan/ŇŮFUÎmôKÖQk°
 célszerűtlen/Ó×GVËnňLRlą
 célszerű/ąCÔŐŢHWĚR
-célravezető/ąCÔŐŢHWĚR
+célravezető/ąyCÔŐŢHWĚR
 célratörő/ąCÔŐŢHWĚR
 célozó/°XAŇŐĎFUÎQ
 célorientált/ŇŮFUÎmôQk°
@@ -77411,7 +77614,7 @@ csüggedetlen/Ó×GVËnňLRlą
 csücsöri/ąBÓŐĐGVËR
 csúzos/ŇŮFUÎmôKÖSsk°
 csúszómászó/°AŇŐĎFUÎQ
-csúszásmentes/Ó×GVËnňLTtlą
+csúszásmentes/Ó×GVËnňLTtląy
 csúszásgátló/°AŇŐĎFUÎQ
 csúnyácska/°AŇŐĎFUÎQ
 csúnya/°AŇŐĎFUÎQ
@@ -77435,10 +77638,10 @@ csökkentett/Ó×GVËnňLRlą
 csónak_alakú/°AŇŐĎFUÎQ
 csókálló/°AŇŐĎFUÎQ
 csírátlan/ŇŮFUÎmôKÖQk°
-csíramentes/Ó×GVËnňLTtlą
+csíramentes/Ó×GVËnňLTtląy
 csíraképes/Ó×GVËnňLTtlą
-csípőficamos/ŇŮFUÎmôKÖSsk°
-csípmentes/Ó×GVËnňLTtlą
+csípőficamos/ŇŮFUÎmôKÖSsk°y
+csípmentes/Ó×GVËnňLTtląy
 csínos/ŇŮFUÎmôKÖSsk°w
 csíndús/ŇŮFUÎmôKÖSsk°
 csíkosfejű/ąCÔŐŢHWĚR
@@ -77470,7 +77673,7 @@ csuklyás/ŇŮFUÎmôKÖSsk°
 csukható/XAŇŐĎFUÎQ)Ó_ABLE_(adj,present_part)
 csukhatatlan/ŇŮFUÎmôKÖQkX)
 csukcs/ŇŮFUÎmôKÖSs°
-csukaszürke/ąBÓŐĐGVËR
+csukaszürke/ąyBÓŐĐGVËR
 csukandó/XAŇŐĎFUÎQ)Ó_FUTPART_adj
 csudálatos/ŇŮFUÎmôKÖSsk°
 csuda/°AŇŐĎFUÎQ
@@ -77481,8 +77684,8 @@ csoportos/ŇŮFUÎmôKÖSsk°
 csontvárys/ŇŮFUÎmôKÖSsk
 csontszínű/ąCÔŐŢHWĚR
 csontszáraz/ŇŮFUÎmôKÖSsk°
-csontsovány/ŇŮFUÎmôKÖSsk°
-csontrészeg/Ó×GVËnňLRlą
+csontsovány/ŇŮFUÎmôKÖSsk°y
+csontrészeg/Ó×GVËnňLRląy
 csontos/ŇŮFUÎmôKÖSsk°
 csontkemény/Ó×GVËnňLTtlą
 csonthéjas/ŇŮFUÎmôKÖSsk°
@@ -77522,8 +77725,8 @@ csillapítatlan/ŇŮFUÎmôKÖQk°
 csillagászati/°AŇŐĎFUÎQ
 csillagtalan/ŇŮFUÎmôKÖQk°
 csillagos/ŇŮFUÎmôKÖSsk°
-csillagfényes/Ó×GVËnňLTtlą
-csillagdíszes/Ó×GVËnňLTtlą
+csillagfényes/Ó×GVËnňLTtląy
+csillagdíszes/Ó×GVËnňLTtląy
 csillag_alakú/°AŇŐĎFUÎQ
 csilivili/ąBÓŐĐGVËR
 csili-vili/ąBÓŐĐGVËR
@@ -77531,8 +77734,8 @@ csikorogó/°XAŇŐĎFUÎQ
 csikorgós/ŇŮFUÎmôKÖSsk°
 csikorgó/°XAŇŐĎFUÎQ
 csikasz/ŇŮFUÎmôKÖSsk°
-csigavonalú/°AŇŐĎFUÎQ
-csigavonalas/ŇŮFUÎmôKÖSsk°
+csigavonalú/°yAŇŐĎFUÎQ
+csigavonalas/ŇŮFUÎmôKÖSsk°y
 csicsergő/XCÔŐŢHWĚR
 csibész/Ó×GVËnňLTtlą
 csetres/Ó×GVËnňLTtlą
@@ -77540,6 +77743,11 @@ cserző/XCÔŐŢHWĚR
 cserzetlen/Ó×GVËnňLRlą
 cserszínű/ąCÔŐŢHWĚR
 csersavas/ŇŮFUÎmôKÖSsk°
+cserokigyűlölő/CÔŐŢHWĚR
+cserokiellenes/Ó×GVËnňLTtl
+cserokicentrikus/ŇŮFUÎmôKÖSsk
+cserokibarát/ŇŮFUÎmôKÖQk
+cseroki/°BÓŐĐGVËR
 cserjés/Ó×GVËnňLTtlą
 cserfes/Ó×GVËnňLTtlą
 cseresznyeszínű/ąCÔŐŢHWĚR
@@ -77548,7 +77756,7 @@ cseres/Ó×GVËnňLTtlą
 cserepes/Ó×GVËnňLTtlą
 cseremisz/Ó×GVËnňLTtlą
 cseprő/ąCÔŐŢHWĚR
-cseppfolyós/ŇŮFUÎmôKÖSsk°
+cseppfolyós/ŇŮFUÎmôKÖSsk°y
 csepp_alakú/°AŇŐĎFUÎQ
 csepergős/Ô×ÝňGVĚNMTtlą
 csepergő/XCÔŐŢHWĚR
@@ -77557,14 +77765,14 @@ csenevész/Ó×GVËnňLTtlą
 csendes/Ó×GVËnňLTtlą
 csempézett/Ó×GVËnňLRlą
 csempészett/Ó×GVËnňLRlą
-cselekvőképtelen/Ó×GVËnňLRlą
+cselekvőképtelen/Ó×GVËnňLRląy
 cselekvő/ąXYCÔŐŢHWĚR)Ó_PRESPART_adj
 cselekvő/ąXYCÔŐŢHWĚR
 cselekvésképtelen/Ó×GVËnňLRląy
 csekélyke/ąBÓŐĐGVËR
 csekélyes/Ó×GVËnňLTtlą
 csekély/Ó×GVËnňLTtlą
-csehszlovák/ŇŮFUÎmôKÖQk°
+csehszlovák/ŇŮFUÎmôKÖQk°y
 csehgyűlölő/CÔŐŢHWĚR
 csehellenes/Ó×GVËnňLTtl
 csehcentrikus/ŇŮFUÎmôKÖSsk
@@ -77596,7 +77804,7 @@ csalárd/ŇŮFUÎmôKÖQk°
 családtalan/ŇŮFUÎmôKÖQk°
 családias/ŇŮFUÎmôKÖSsk°
 családi/°AŇŐĎFUÎQ
-családcentrikus/ŇŮFUÎmôKÖSsk°
+családcentrikus/ŇŮFUÎmôKÖSsk°y
 csalhatatlan/ŇŮFUÎmôKÖQk°
 csalfa/°AŇŐĎFUÎQ
 csalatkozhatatlan/ŇŮFUÎmôKÖQk°
@@ -77619,6 +77827,7 @@ citromsárga/°AŇŐĎFUÎQ
 citotoxikus/ŇŮFUÎmôKÖSsk°
 citosztatikus/ŇŮFUÎmôKÖSsk°
 ciszterci/ąBÓŐĐGVËR
+cisznemű/ąCÔŐŢHWĚR
 cirádás/ŇŮFUÎmôKÖSsk°
 cirmos/ŇŮFUÎmôKÖSsk°
 cirkumpoláris/ŇŮFUÎmôKÖSsk°
@@ -77755,7 +77964,7 @@ béna/°AŇŐĎFUÎQ
 bélű/ąCÔŐŢHWĚR
 bélyegző/XCÔŐŢHWĚR
 bélyegzett/Ó×GVËnňLRlą
-bélyeggyűjtő/ąCÔŐŢHWĚRélyeg|gyűjtő
+bélyeggyűjtő/ąyCÔŐŢHWĚRélyeg|gyűjtő
 bélyegező/ąXCÔŐŢHWĚR
 bélyeges/Ó×GVËnňLTtlą
 bélpoklos/ŇŮFUÎmôKÖSsk°
@@ -77766,7 +77975,7 @@ békétlen/Ó×GVËnňLRlą
 békés/Ó×GVËnňLTtlą
 békászó/°AŇŐĎFUÎQ
 béketűrő/ąCÔŐŢHWĚR
-békeszerető/ąCÔŐŢHWĚR
+békeszerető/ąyCÔŐŢHWĚR
 békebeli/ąBÓŐĐGVËR
 bázikus/ŇŮFUÎmôKÖSsk°
 bávatag/ŇŮFUÎmôKÖQk°
@@ -77776,7 +77985,7 @@ báthorys/ŇŮFUÎmôKÖSsk
 bárói/°AŇŐĎFUÎQ
 bársonypuha/°AŇŐĎFUÎQ
 bársonyos/ŇŮFUÎmôKÖSsk°
-bársonyfekete/ąBÓŐĐGVËR
+bársonyfekete/ąyBÓŐĐGVËR
 bárgyú/°AŇŐĎFUÎQ
 bárdolatlan/ŇŮFUÎmôKÖQk°
 bányászati/°AŇŐĎFUÎQ
@@ -77819,9 +78028,11 @@ bunyevácellenes/Ó×GVËnňLTtl
 bunyeváccentrikus/ŇŮFUÎmôKÖSsk
 bunyevácbarát/ŇŮFUÎmôKÖQk
 bunyevác/°
+bunkó/°AŇŐĎFUÎQ
 bundázott/ŇŮFUÎmôQk°sX
 bumfordi/°AŇŐĎFUÎQ
 bumburnyák/ŇŮFUÎmôKÖQk°
+bulvár/ŇŮFUÎmôKÖQk°
 bukés/Ó×GVËnňLTtlą
 bukolikus/ŇŮFUÎmôKÖSsk°
 buja/°AŇŐĎFUÎQ
@@ -77857,7 +78068,7 @@ botanikus/ŇŮFUÎmôKÖSsk°
 boszorkányos/ŇŮFUÎmôKÖSsk°
 bosszúálló/°AŇŐĎFUÎQ
 bosszúvágyó/°AŇŐĎFUÎQ
-bosszúszomjas/ŇŮFUÎmôKÖSsk°
+bosszúszomjas/ŇŮFUÎmôKÖSsk°y
 bosszús/ŇŮFUÎmôKÖSsk°
 bosszulatlan/ŇŮFUÎmôKÖQk°
 bosszantott/ŇŮFUÎmôQk°sX
@@ -77910,18 +78121,18 @@ bomló/XAŇŐĎFUÎQ
 bomlékony/ŇŮFUÎmôKÖSsk°
 bombasérült/Ô×ÝňGVĚNRlą
 bombasztikus/ŇŮFUÎmôKÖSsk°
-bombabiztos/ŇŮFUÎmôSsk°
+bombabiztos/ŇŮFUÎmôSsk°y
 bolyhos/ŇŮFUÎmôKÖSsk°
 bolygóközi/ąBÓŐĐGVËR
 bolygatott/ŇŮFUÎmôQk°sX
 boltozatos/ŇŮFUÎmôKÖSsk°
 boltos/ŇŮFUÎmôKÖSsk°
 bolti/°AŇŐĎFUÎQ
-bolthajtásos/ŇŮFUÎmôKÖSsk°
+bolthajtásos/ŇŮFUÎmôKÖSsk°y
 bolondos/ŇŮFUÎmôKÖSsk°
 bolondforma/°AŇŐĎFUÎQ
 bolond/ŇŮFUÎmôKÖQk°
-bolhacsípett/Ó×GVËnňLRlą
+bolhacsípett/Ó×GVËnňLRląy
 bolgárgyűlölő/CÔŐŢHWĚR
 bolgárellenes/Ó×GVËnňLTtl
 bolgárcentrikus/ŇŮFUÎmôKÖSsk
@@ -77934,7 +78145,7 @@ bojtos/ŇŮFUÎmôKÖSsk°
 bohókás/ŇŮFUÎmôKÖSsk°
 bohó/°AŇŐĎFUÎQ
 bohém/ŇŮFUÎmôKÖQÓ×GVËnňLRklą
-bogárfekete/ąBÓŐĐGVËR
+bogárfekete/ąyBÓŐĐGVËR
 bogyósgyümölcsű/ąCÔŐŢHWĚR
 bogumil/ŇŮFUÎmôKÖQk°
 boglyas/ŇŮFUÎmôKÖSsk°
@@ -77960,7 +78171,7 @@ bizonyítatlan/ŇŮFUÎmôKÖQk°
 bizonytalan/ŇŮFUÎmôKÖQk°
 bizonyos/ŇŮFUÎmôKÖSsk°
 bizarr/ŇŮFUÎmôKÖQk°
-bizalomteljes/Ó×GVËnňLTtlą
+bizalomteljes/Ó×GVËnňLTtląy
 bizalomteli/ąyBÓŐĐGVËR
 bizalomraméltó/°AŇŐĎFUÎQ
 bizalmi/°AŇŐĎFUÎQ
@@ -78102,11 +78313,11 @@ bepityókázott/ŇŮFUÎmôQk°sX
 bepiszkított/ŇŮFUÎmôQk°sX
 benőtt/Ô×ÝňGVĚNRlą
 benépesített/Ó×GVËnňLRlą
-bentlakásos/ŇŮFUÎmôKÖSsk°
+bentlakásos/ŇŮFUÎmôKÖSsk°y
 bentikus/ŇŮFUÎmôKÖSsk°
 bensőséges/Ó×GVËnňLTtlą
 benső/ąCÔŐŢHWĚR	őő
-bennszülött/Ô×ÝňGVĚNMRlą
+bennszülött/Ô×ÝňGVĚNMRląy
 bennfentes/Ó×GVËnňLTtlą
 benemavatkozási/°BÓŐĐGVËR
 benediktinus/ŇŮFUÎmôKÖSsk°
@@ -78134,17 +78345,22 @@ belgabarát/ŇŮFUÎmôKÖQk
 belga/°AŇŐĎFUÎQ
 belföldi/ąBÓŐĐGVËR
 beleértődő/ąCÔŐŢHWĚR
-beleértett/Ó×GVËnňLRlą
+beleértett/Ó×GVËnňLRląy
 belevaló/°AŇŐĎFUÎQ
 beleszőtt/Ô×ÝňGVĚNMRlą
-beleszámított/ŇŮFUÎmôQk°sX
-belepistult/ŇŮFUÎmôQk°
-belemélyedt/Ó×GVËnňLRlą
-belekevert/Ó×GVËnňLRlą
-beleivódott/ŇŮFUÎmôQk°sX
-beledolgozott/ŇŮFUÎmôQk°sX
-belebonyolódott/ŇŮFUÎmôQk°sX
-belebolondult/ŇŮFUÎmôQk°
+beleszámított/ŇŮFUÎmôQk°ysX
+belepistult/ŇŮFUÎmôQk°y
+belemélyedt/Ó×GVËnňLRląy
+belekevert/Ó×GVËnňLRląy
+beleivódott/ŇŮFUÎmôQk°ysX
+beledolgozott/ŇŮFUÎmôQk°ysX
+belebonyolódott/ŇŮFUÎmôQk°ysX
+belebolondult/ŇŮFUÎmôQk°y
+belaruszgyűlölő/CÔŐŢHWĚR
+belaruszellenes/Ó×GVËnňLTtl
+belaruszcentrikus/ŇŮFUÎmôKÖSsk
+belaruszbarát/ŇŮFUÎmôKÖQk
+belarusz/ŇŮFUÎmôKÖSsk°
 bekötetlen/Ó×GVËnňLRlą
 beképzelt/Ó×GVËnňLRlą
 bekerített/Ó×GVËnňLRlą
@@ -78218,11 +78434,11 @@ barnásvöröses/Ó×GVËnňLTtlą
 barnásvörös/Ô×ÝňGVĚNMTtlą
 barnássárgás/ŇŮFUÎmôKÖSsk°
 barnássárga/°AŇŐĎFUÎQ
-barnásszürkés/Ó×GVËnňLTtląás|szür-kés
-barnásszürke/ąBÓŐĐGVËRás|szür-ke
+barnásszürkés/Ó×GVËnňLTtląyás|szür-késás|szürkés
+barnásszürke/ąyBÓŐĐGVËRás|szür-keás|szürke
 barnáspiros/ŇŮFUÎmôKÖSsk°
 barnáslila/°AŇŐĎFUÎQ
-barnásfekete/ąBÓŐĐGVËR
+barnásfekete/ąyBÓŐĐGVËR
 barnásfehér/Ó×GVËnňLRlą
 barnás/ŇŮFUÎmôKÖSsk°
 barnapirosas/ŇŮFUÎmôKÖSsk°
@@ -78258,7 +78474,7 @@ balhitű/ąCÔŐŢHWĚR
 balhiedelmű/ąCÔŐŢHWĚR
 balga/°AŇŐĎFUÎQ
 balfasz/ŇŮFUÎmôKÖSsk°
-balesetveszélyes/Ó×GVËnňLTtląy
+balesetveszélyes/Ó×GVËnňLTtląyélyes
 baldachinos/ŇŮFUÎmôKÖSsk°
 balcsavarodású/°AŇŐĎFUÎQ
 balatonnyi/°AŇŐĎFUÎQ
@@ -78280,7 +78496,7 @@ bajcsy-zsilinszkys/Ó×GVËnňLTtl
 bagatell/Ó×GVËnňLRlą
 bagaria/°AŇŐĎFUÎQ
 badar/ŇŮFUÎmôKÖQk°
-babérkoszorús/ŇŮFUÎmôKÖSsk°
+babérkoszorús/ŇŮFUÎmôKÖSsk°y
 babrás/ŇŮFUÎmôKÖSsk°
 babos/ŇŮFUÎmôKÖSsk°
 babonás/ŇŮFUÎmôKÖSsk°
@@ -78340,9 +78556,9 @@ attraktív/ŇŮFUÎmôKÖQÓ×GVËnňLRklą
 attikai/°AŇŐĎFUÎQ
 atoxikus/ŇŮFUÎmôKÖSsk°
 atonális/ŇŮFUÎmôKÖSsk°
-atomvédelmi/ąBÓŐĐGVËR
+atomvédelmi/ąyBÓŐĐGVËR
 atomisztikus/ŇŮFUÎmôKÖSsk°
-atomerőművi/ąBÓŐĐGVËRő|művi
+atomerőművi/ąyBÓŐĐGVËRő|művi
 atom/ŇŮFUÎmôKÖSsk°
 atmoszferikus/ŇŮFUÎmôKÖSsk°
 atlétikai/°AŇŐĎFUÎQ
@@ -78419,13 +78635,13 @@ archimédeszi/ąBÓŐĐGVËR
 archetipikus/ŇŮFUÎmôKÖSsk°
 archeológiai/°AŇŐĎFUÎQ
 archaikus/ŇŮFUÎmôKÖSsk°
-aranytartalmú/°AŇŐĎFUÎQ
+aranytartalmú/°yAŇŐĎFUÎQ
 aranysárga/°AŇŐĎFUÎQ
 aranyszájú/°AŇŐĎFUÎQ
 aranyozott/ŇŮFUÎmôQk°sX
 aranyos/ŇŮFUÎmôKÖSsk°
 aranyló/°AŇŐĎFUÎQ
-aranykeretes/Ó×GVËnňLTtlą
+aranykeretes/Ó×GVËnňLTtląy
 aranygyapjas/ŇŮFUÎmôKÖSsk°
 aranyfényű/ąCÔŐŢHWĚR
 aranybarna/°AŇŐĎFUÎQ
@@ -78445,7 +78661,7 @@ apróka/°AŇŐĎFUÎQ
 aprófejű/ąCÔŐŢHWĚR
 aprófalvas/ŇŮFUÎmôKÖSsk°
 aprócseprő/ąCÔŐŢHWĚR
-apró_betűs/Ô×ÝňGVĚNMTtląy
+apró_betűs/Ô×ÝňGVĚNMTtląyó_betűs
 apró/°AŇŐĎFUÎQ
 apriorisztikus/ŇŮFUÎmôKÖSsk°
 approximatív/ŇŮFUÎmôKÖSsk°
@@ -78470,15 +78686,16 @@ anális/ŇŮFUÎmôKÖSsk°
 anyátlan/ŇŮFUÎmôKÖQk°
 anyaszülte/ąBÓŐĐGVËR
 anyaszült/Ô×ÝňGVĚNRlą
-anyakönyvezett/Ó×GVËnňLRlą
+anyakönyvezett/Ó×GVËnňLRląy
 anyajogú/°AŇŐĎFUÎQ
 anyajogi/°AŇŐĎFUÎQ
 anyai/°AŇŐĎFUÎQ
 anyagtalan/ŇŮFUÎmôKÖQk°
-anyagtakarékos/ŇŮFUÎmôKÖSsk°
+anyagtakarékos/ŇŮFUÎmôKÖSsk°y
 anyaglerakó/°AŇŐĎFUÎQ
 anyagias/ŇŮFUÎmôKÖSsk°
 anyagi/°AŇŐĎFUÎQ
+anyagerős/Ô×ÝňGVĚNMTtląy
 antropomorf/ŇŮFUÎmôKÖQk°
 antropológiai/°AŇŐĎFUÎQ
 antropogén/Ó×GVËnňLRlą
@@ -78526,7 +78743,7 @@ antagonisztikus/ŇŮFUÎmôKÖSsk°
 antagonista/°AŇŐĎFUÎQ
 anschlussszerű/ąwCÔŐŢHWĚR
 anorganikus/ŇŮFUÎmôKÖSsk°
-anonim/ŇŮFUÎmôKÖSsk°
+anonim/ŇŮFUÎnňKÖSsÓ×GVËmôLTtkl°
 anomális/ŇŮFUÎmôKÖSsk°
 anna-pannás/ŇŮFUÎmôKÖSsk
 anizotrop/ŇŮFUÎmôKÖQk°
@@ -78609,20 +78826,20 @@ aluszékony/ŇŮFUÎmôKÖSsk°
 aluminotermikus/ŇŮFUÎmôKÖSsk°
 alulírt/ŇŮFUÎmôQk°
 alulírott/ŇŮFUÎmôQk°sX
-alultőkésített/Ó×GVËnňLRlą
+alultőkésített/Ó×GVËnňLRląy
 alultáplált/ŇŮFUÎmôQk°
-alultervezett/Ó×GVËnňLRlą
+alultervezett/Ó×GVËnňLRląy
 alulmaradt/ADFQU)
-alulképzett/Ó×GVËnňLRlą
+alulképzett/Ó×GVËnňLRląy
 alulkormányzott/ŇŮFUÎmôQSsk°yX
 alulkormányozott/ŇŮFUÎmôQSsk°yX
-aluliskolázott/ŇŮFUÎmôQk°sX
-alulinformált/ŇŮFUÎmôQk°
-alulfizetett/Ó×GVËnňLRlą
-alulfinanszírozott/ŇŮFUÎmôQk°sX
-alulfejlett/Ó×GVËnňLRlą
-alulexponált/ŇŮFUÎmôQk°
-alulcsapott/ŇŮFUÎmôQk°sX
+aluliskolázott/ŇŮFUÎmôQk°ysX
+alulinformált/ŇŮFUÎmôQk°y
+alulfizetett/Ó×GVËnňLRląy
+alulfinanszírozott/ŇŮFUÎmôQk°ysX
+alulfejlett/Ó×GVËnňLRląy
+alulexponált/ŇŮFUÎmôQk°y
+alulcsapott/ŇŮFUÎmôQk°ysX
 alulbecsült/Ô×ÝňGVĚNMRlą
 altáji/°AŇŐĎFUÎQ
 altruisztikus/ŇŮFUÎmôKÖSsk°
@@ -78630,7 +78847,7 @@ altruista/°AŇŐĎFUÎQ
 alternáló/°AŇŐĎFUÎQ
 alternatív/ŇŮFUÎmôKÖSsk°
 alsóéves/Ó×GVËnňLTtlą
-alsószárnyas/ŇŮFUÎmôKÖSsk°
+alsószárnyas/ŇŮFUÎmôKÖSsk°y
 alsórendű/ąCÔŐŢHWĚR
 alsófokú/°AŇŐĎFUÎQ
 alsóbbrendű/ąCÔŐŢHWĚR
@@ -78661,10 +78878,10 @@ alkotmányellenes/Ó×GVËnňLTtląy
 alkonyi/°AŇŐĎFUÎQ
 alkonyati/°AŇŐĎFUÎQ
 alkoholos/ŇŮFUÎmôKÖSsk°
-alkoholmentes/Ó×GVËnňLTtlą
+alkoholmentes/Ó×GVËnňLTtląy
 alkoholelvonó/°AŇŐĎFUÎQ
 alkirályi/°AŇŐĎFUÎQ
-alkalomszerű/ąCÔŐŢHWĚR
+alkalomszerű/ąyCÔŐŢHWĚR
 alkalofil/ŇŮFUÎmôKÖQk°
 alkalmi/°AŇŐĎFUÎQ
 alkalmazotti/°AŇŐĎFUÎQ
@@ -78743,13 +78960,13 @@ akarattalan/ŇŮFUÎmôKÖQk°
 akaratos/ŇŮFUÎmôKÖSsk°
 akaratlan/ŇŮFUÎmôKÖQk°
 akaratlagos/ŇŮFUÎmôKÖSsk°
-akaratgyenge/ąBÓŐĐGVËR
+akaratgyenge/ąyBÓŐĐGVËR
 akadémikus/ŇŮFUÎmôKÖSsk°
 akadémiai/°AŇŐĎFUÎQ
 akadékos/ŇŮFUÎmôKÖSsk°
 akadálytalan/ŇŮFUÎmôKÖQk°
 akadályozatlan/ŇŮFUÎmôKÖQk°
-akadálymentes/Ó×GVËnňLTtlą
+akadálymentes/Ó×GVËnňLTtląy
 ajánlott/ŇŮFUÎmôQk°sX
 ajánlatos/ŇŮFUÎmôKÖSsk°
 ajakos/ŇŮFUÎmôKÖSsk°
@@ -78762,14 +78979,14 @@ ainubarát/ŇŮFUÎmôKÖQk
 ainu/°AŇŐĎFUÎQ
 ahistorikus/ŇŮFUÎmôKÖSsk°
 ahidrált/ŇŮFUÎmôQk°
-agyonhasznált/ŇŮFUÎmôQk°
-agyondolgozott/ŇŮFUÎmôQk°sX
+agyonhasznált/ŇŮFUÎmôQk°y
+agyondolgozott/ŇŮFUÎmôQk°ysX
 agymosott/ŇŮFUÎmôQk°sX
 agykárosodott/ŇŮFUÎmôQk°sX
 agybéli/ąBÓŐĐGVËR
 agyatlan/ŇŮFUÎmôKÖQk°
 agyament/Ó×GVËnňLRlą
-agyalágyult/ŇŮFUÎmôQk°
+agyalágyult/ŇŮFUÎmôQk°y
 agyalapi/°AŇŐĎFUÎQ
 agyagsárga/°AŇŐĎFUÎQ
 agyagos/ŇŮFUÎmôKÖSsk°
@@ -78831,10 +79048,10 @@ addiktív/Ó×GVËnňLTtlą
 addicionális/ŇŮFUÎmôKÖSsk°
 adatvezérelt/Ó×GVËnňLRląy
 adatlekérdező/ąyCÔŐŢHWĚR
-adatgazdag/ŇŮFUÎmôKÖQk°
+adatgazdag/ŇŮFUÎmôKÖQk°y
 adaptív/ŇŮFUÎmôKÖSsk°
 acélvázas/ŇŮFUÎmôKÖSsk°
-acélszürke/ąBÓŐĐGVËR
+acélszürke/ąyBÓŐĐGVËR
 acélszívű/ąCÔŐŢHWĚR
 acélozott/ŇŮFUÎmôQk°sX
 acélos/ŇŮFUÎmôKÖSsk°
@@ -79053,7 +79270,7 @@ Zsanettól/w
 Zsanettá/w
 Zsanettel/w
 Zsanettal/w
-Zsanett/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Zsanett/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Zsana/ŐAUQĘŽiĎŇqľ,ˇ
 Zsakula/ŐAUQĘŽiĎŇqÇżß,ˇ
 Zsadányi
@@ -79270,7 +79487,7 @@ Xgl	é
 Xerxész/VËŻj×LÓnňqČŔŕTt,¸l
 Xenophón/UĘŽiÖKŇmôqÇżßQ,ˇk
 Xen/VËŻj×LÓnňqČŔŕR,¸
-Xavér/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Xavér/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Xantus/UĘŽiÖKŇmôqÇżßSs,ˇk
 XXXL-lé/)
 XXXL-lel/)
@@ -79501,6 +79718,12 @@ WWW-vel/)
 WWW-s/Ó×nBGVLR)
 WWW-/BVRĐŃŐj&)
 WWW	é
+WWF-fé/)
+WWF-fel/)
+WWF-es/Ó×nBGVLR)
+WWF-beli/ŃĐŐBGVLTt)
+WWF-/LVÓ×nRTtj&)
+WWF	é
 WMA-vá/)
 WMA-val/)
 WMA-os/ŇŮmAFUKQ)
@@ -79720,6 +79943,7 @@ Vizaknai/ŐAUQĘŽiĎŇqÇżß,ˇ
 Vivien/VËŻj×LÓnňqČŔŕR,¸lř
 Vivaldi/ŐAUQĘŽiĎŇqÇżß,ˇ
 Vitány/UĘŽiÖKŇmôqľSs,ˇk
+Vitya/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Vitnyéd/VËŻj×LÓnňqśR,¸l
 Vitkovics/UĘŽiÖKŇmôqÇżßSs,ˇk
 Vitkay/UĘŽiŐAĎŃqÇżßQ,ˇk
@@ -80024,7 +80248,7 @@ Vancouver/VËŻj×LÓnňqśR,¸l
 Valéry/VËŻjŐBĐŃqŕR,¸l
 Valéria/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Valér/VËŻj×LÓnňqČŔŕR,¸lř
-Valter/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Valter/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Valla/ŐAUQĘŽiĎŇqľ,ˇ
 Valkó/ŐAUQĘŽiĎŇqľ,ˇ
 Valkonya/ŐAUQĘŽiĎŇqľ,ˇ
@@ -80437,6 +80661,7 @@ Trípolisz/VËŻj×LÓnňqśTt,¸l
 Trákia/ŐAUQĘŽiĎŇqľ,ˇ
 Trunk/UĘŽiÖKŇmôqľQ,ˇ
 Truner/VËŻj×LÓnňqČŔŕR,¸l
+Trump/UĘŽiÖKŇmôqÇżßQ,ˇ	ph:trámp
 Trummer/VËŻj×LÓnňqČŔŕR,¸l
 Trostler/VËŻj×LÓnňqČŔŕR,¸l
 Troján/UĘŽiÖKŇmôqÇżßQ,ˇk
@@ -80685,6 +80910,7 @@ Tiles/VËŻj×LÓnňqČŔŕTt,¸l
 Tilda/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Tilaj/UĘŽiÖKŇmôqľSs,ˇk
 Tikos/UĘŽiÖKŇmôqľSs,ˇk
+TikTok/UĘŽiÖKŇmôqÇżßQ,ˇk
 Tihi/ŐBVRËŻjĐÓqČŔŕ,¸ř
 Tihany/UĘŽiÖKŇmôqľSs,ˇk
 Tihamér/VËŻj×LÓnňqČŔŕR,¸lř
@@ -80746,7 +80972,7 @@ Tharzó/ŐAUQĘŽiĎŇqÇżß,ˇ
 Thanhoffer/VËŻj×LÓnňqČŔŕR,¸l
 Than/UĘŽiÖKŇmôqÇżßQ,ˇ
 Thamm/UĘŽiÖKŇmôqÇżßSs,ˇ
-Thalész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl
+Thalész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl
 Thaly/UĘŽiŐAĎŃqÇżßQ,ˇ
 Thallóczy/UĘŽiŐAĎŃqÇżßQ,ˇk
 Thallmayer/VËŻj×LÓnňqČŔŕR,¸l
@@ -80806,7 +81032,7 @@ Tengelic/VËŻj×LÓnňqśTt,¸l
 Tenczer/VËŻj×LÓnňqČŔŕR,¸l
 Temze/ŐBVRËŻjĐÓqś,¸
 Tempis/VËŻj×LÓnňqČŔŕTt,¸l
-Temminck-partfutó/ŐAUQĘŽiĎŇáyÇżßYcť
+Temminck-partfutó/ŐAUQĘŽiĎŇáyÇżßYcťó
 Temesváry/UĘŽiŐAĎŃqÇżßQ,ˇk
 Temesvár/UĘŽiÖKŇmôqľQ,ˇk
 Temesköz/WĚŻjŘMÝňÔqśTt,¸l
@@ -81170,7 +81396,7 @@ Sándorfi/ŐAUQĘŽiĎŇqÇżß,ˇ
 Sándorffi/ŐAUQĘŽiĎŇqÇżß,ˇ
 Sándorfalva/ŐAUQĘŽiĎŇqľ,ˇ
 Sándor/UĘŽiÖKŇmôqÇżßQ,ˇk÷
-Sámuel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl÷ř
+Sámuel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl÷ř
 Sámsonháza/ŐAUQĘŽiĎŇqľ,ˇ
 Sámson/UĘŽiÖKŇmôqÇżßQ,ˇk
 Sámod/UĘŽiÖKŇmôqľQ,ˇk
@@ -81235,7 +81461,7 @@ Szőce/ŐBVRËŻjĐÓqś,¸
 Szőc/WĚŻjŘMÝňÔqśTt,¸
 Szórády/UĘŽiŐAĎŃqÇżßQ,ˇk
 Szólád/UĘŽiÖKŇmôqľQ,ˇk
-Szókratész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl
+Szókratész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl
 Szóka/ŐAUQĘŽiĎŇqľ,ˇ
 Szófia/ŐAUQĘŽiĎŇqľ,ˇ
 Szíriusz/UĘŽiÖKŇmôqľSs,ˇk
@@ -81318,7 +81544,7 @@ Szálka/ŐAUQĘŽiĎŇqľ,ˇ
 Száleresi/ŐBVRËŻjĐÓqČŔŕ,¸
 Szákszend/VËŻj×LÓnňqśR,¸l
 Szákfy/UĘŽiŐAĎŃqÇżßQ,ˇ
-Szájer/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl
+Szájer/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl
 Száhlender/VËŻj×LÓnňqČŔŕR,¸l
 Száhil_öv/VNËŻj×LÝňÔqśTt,¸l
 Száhel-övezet/VËŻj×LÓnňqśR,¸l
@@ -81400,7 +81626,7 @@ Szotscsal/)
 Szots/UĘŽiÖKŇmôqÇżßSs,ˇ	á
 Szorosad/UĘŽiÖKŇmôqľQ,ˇk
 Szorgalmatos/UĘŽiÖKŇmôqľSs,ˇk
-Szophoklész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl
+Szophoklész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl
 Szontágh/UĘŽiÖKŇmôqÇżßSs,ˇk
 Szontagh/UĘŽiÖKŇmôqÇżßSs,ˇk
 Szonja/ŐAUQĘŽiĎŇqÇżß,ˇ÷
@@ -82434,7 +82660,7 @@ Schuller/VËŻj×LÓnňqČŔŕR,¸l
 Schulhof/UĘŽiÖKŇmôqÇżßQ,ˇk
 Schulek/VËŻj×LÓnňqČŔŕR,¸l
 Schuchbauer/VËŻj×LÓnňqČŔŕR,¸l
-Schubert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl
+Schubert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl
 Schrödinger/VËŻj×LÓnňqČŔŕR,¸l
 Schréter/VËŻj×LÓnňqČŔŕR,¸l
 Schréder/VËŻj×LÓnňqČŔŕR,¸l
@@ -82454,7 +82680,7 @@ Schoretitscsal/)
 Schoretits/VËŻj×LÓnňqČŔŕTt,¸l	á
 Schordann/UĘŽiÖKŇmôqÇżßQ,ˇk
 Schopper/VËŻj×LÓnňqČŔŕR,¸l
-Schopenhauer/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl
+Schopenhauer/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl
 Schomer/VËŻj×LÓnňqČŔŕR,¸l
 Scholtz/UĘŽiÖKŇmôqÇżßSs,ˇ
 Schoepf/VËŻj×LÓnňqČŔŕR,¸l
@@ -82806,7 +83032,7 @@ Rómeó/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Rómer/VËŻj×LÓnňqČŔŕR,¸l
 Róma/ŐAUQĘŽiĎŇqľ,ˇ
 Rókus/UĘŽiÖKŇmôqßSs,ˇk
-Róbert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Róbert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Révy/VËŻjŐBĐŃqČŔŕR,¸
 Révleányvár/UĘŽiÖKŇmôqľQ,ˇk
 Révkomárom/UĘŽiÖKŇmôqľSs,ˇk
@@ -82923,7 +83149,7 @@ Ruzitska/ŐAUQĘŽiĎŇqÇżß,ˇ
 Ruttkay/UĘŽiŐAĎŃqÇżßQ,ˇk
 Ruttka/ŐAUQĘŽiĎŇqľ,ˇ
 Rusói/ŐAUQĘŽiĎŇqÇżß,ˇ
-Rusztem/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl÷ř
+Rusztem/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl÷ř
 Ruszkiczay/UĘŽiŐAĎŃqÇżßQ,ˇk
 Ruszka/ŐAUQĘŽiĎŇqľ,ˇ
 Ruszinföld/VNËŻj×LÝňÔqśR,¸l
@@ -83036,7 +83262,7 @@ Rolls-Royce	á	ph:rolsz-rojsz	ph:rolsz-rojs
 Rolla/ŐAUQĘŽiĎŇqÇżß,ˇ
 Rolika/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Roli/ŐAUQĘŽiĎŇqÇżß,ˇ÷
-Rolex/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl
+Rolex/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl
 Roland/UĘŽiÖKŇmôqÇżßQ,ˇk÷
 Rohringer/VËŻj×LÓnňqČŔŕR,¸l
 Rohonyi/ŐAUQĘŽiĎŇqÇżß,ˇ
@@ -83158,7 +83384,7 @@ Rezső/ŐCWRĚŻjŢÔqČÁ˙,¸ů
 Rezsny/VËŻjŐBĐŃqČŔŕR,¸
 Reznák/UĘŽiÖKŇmôqÇżßQ,ˇk
 Rezi/ŐBVRËŻjĐÓqś,¸
-Reykjavík/VËŻj×LÓnňqśR,¸l
+Reykjavík/UĘŽiÖKŇmôqľQ,ˇk
 Rexa/ŐAUQĘŽiĎŇqÇżß,ˇ
 Rex/VËŻj×LÓnňqČŔŕTt,¸
 Reviczky/VËŻjŐBĐŃqŕR,¸l
@@ -83270,7 +83496,7 @@ Ransanus/UĘŽiÖKŇmôqÇżßSs,ˇk
 Ranolder/VËŻj×LÓnňqČŔŕR,¸l
 Rangoni/ŐAUQĘŽiĎŇqÇżß,ˇ
 Ramóna/ŐAUQĘŽiĎŇqÇżß,ˇ÷
-Ramszesz/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl
+Ramszesz/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl
 Ramocsaháza/ŐAUQĘŽiĎŇqľ,ˇ
 Ramocsa/ŐAUQĘŽiĎŇqľ,ˇ
 Rama/ŐAUQĘŽiĎŇqÇżß,ˇ
@@ -83657,7 +83883,7 @@ Poznań/UĘŽiÖKŇmôqľQ,ˇk	ńnyáńnyal
 Povolny/UĘŽiŐAĎŃqÇżßQ,ˇk
 Potyond/UĘŽiÖKŇmôqľQ,ˇk
 Potyomkin/UĘŽiÖKŇmôqÇżßQ,ˇk
-Potter/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl
+Potter/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl
 Potsdam/UĘŽiÖKŇmôqľSs,ˇk
 Potony/UĘŽiÖKŇmôqľSs,ˇk
 Potok/UĘŽiÖKŇmôqľQ,ˇk
@@ -84420,12 +84646,15 @@ Oracle-lá/)	ph:orákllá
 Oracle-lal/)	ph:orákllal
 Oracle-/KUŇÖmQSsi&)	ph:orákl
 Oracle	á	ph:orákl
+Oppenheimer/VËŻj×LÓnňqČŔŕR,¸l
 Opos/UĘŽiÖKŇmôqÇżßSs,ˇk
 OpenVPN-né/)
 OpenVPN-nel/)
 OpenVPN-es/Ó×nBGVLR)
 OpenVPN-/LVÓ×nRTtj&)
 OpenVPN	é
+OpenStreetMapes/w
+OpenStreetMap/VËŻj×LnÓňqŕR,¸l
 OpenPGP-vé/)
 OpenPGP-vel/)
 OpenPGP-s/Ó×nBGVLR)
@@ -84453,7 +84682,7 @@ OpenBSD-vel/)
 OpenBSD-s/Ó×nBGVLR)
 OpenBSD-/BVRĐŃŐj&)
 OpenBSD	é
-Opel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl
+Opel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl
 Opata/ŐAUQĘŽiĎŇqÇżß,ˇ
 Onyega-tó/UĎÖŇyiYcÇ
 Ontario-tó/UĎÖŇyiYcÇ
@@ -84840,7 +85069,7 @@ Noseda/ŐAUQĘŽiĎŇqÇżß,ˇ
 Norvégia/ŐAUQĘŽiĎŇqľ,ˇ
 Normandia/ŐAUQĘŽiĎŇqľ,ˇ
 Norbi/ŐAUQĘŽiĎŇqÇżß,ˇ÷
-Norbert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Norbert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Nopcsa/ŐAUQĘŽiĎŇqÇżß,ˇ
 Nonn/UĘŽiÖKŇmôqÇżßQ,ˇ
 Noll
@@ -84849,7 +85078,7 @@ Nokia/ŐAUQĘŽiĎŇqÇżß,ˇ
 Nohrer/VËŻj×LÓnňqČŔŕR,¸l
 Nogáll/UĘŽiÖKŇmôqÇżßQ,ˇk
 Noffry/UĘŽiŐAĎŃqÇżßQ,ˇ
-Nobel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl
+Nobel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl
 Nizza/ŐAUQĘŽiĎŇqľ,ˇ
 Nizsalovszky/UĘŽiŐAĎŃqÇżßQ,ˇk
 Nissan/UĘŽiÖKŇmôqÇżßQ,ˇk	ph:nisszan
@@ -84917,7 +85146,7 @@ Neuhold/UĘŽiÖKŇmôqÇżßQ,ˇk
 Neugebauer/VËŻj×LÓnňqČŔŕR,¸l
 Neufeld/VËŻj×LÓnňqČŔŕR,¸l
 Neuber/VËŻj×LÓnňqČŔŕR,¸l
-Neubauer/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl
+Neubauer/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl
 Netti/ŐBVRËŻjĐÓqČŔŕ,¸ř
 Netscape-pé/)
 Netscape-pel/)
@@ -84996,6 +85225,7 @@ Nebbien/VËŻj×LÓnňqČŔŕR,¸l
 Neander-völgy/WĚŻjŘMÝňÔqČÁ˙Tt,¸l
 Navratil/UĘŽiÖKŇmôqÇżßQ,ˇk
 Navigator/UĘŽiÖKŇmôqÇżßQ,ˇk
+Navalnij/UĘŽiÖKŇmôqÇżßSs,ˇk
 Nautilus/UĘŽiÖKŇmöqÇżßSs,ˇk
 Naumann-rigó/ŐAUQĘŽiĎŇáyÇżßYcť
 Natália/ŐAUQĘŽiĎŇqÇżß,ˇ÷
@@ -85264,7 +85494,7 @@ Möller/VËŻj×LÓnňqČŔŕR,¸l
 Möhling/VËŻj×LÓnňqČŔŕTt,¸l
 Möbius/UĘŽiÖKŇmöqÇżßSs,ˇk
 Mőcsény/VËŻj×LÓnňqśTt,¸l
-Mózes/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl÷ř
+Mózes/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl÷ř
 Mózer/VËŻj×LÓnňqČŔŕR,¸l
 Mórágy/UĘŽiÖKŇmôqľSs,ˇk
 Mórocz/UĘŽiÖKŇmôqÇżßSs,ˇk
@@ -85686,7 +85916,7 @@ Milos/UĘŽiÖKŇmôqÇżßSs,ˇk
 Milloss/UĘŽiÖKŇmôqÇżßSs,ˇk
 Millok/UĘŽiÖKŇmôqÇżßQ,ˇk
 Millner/VËŻj×LÓnňqČŔŕR,¸l
-Miller-vízicickány/UĘŽiÖKŇmôáyÇżßSsYcť
+Miller-vízicickány/UĘŽiÖKŇmôáyÇżßSsYcťízi|cickány
 Miller/VËŻj×LÓnňqČŔŕR,¸l
 Milleker/VËŻj×LÓnňqČŔŕR,¸l
 Mille/ŐBVRËŻjĐÓqČŔŕ,¸
@@ -86156,7 +86386,7 @@ Marcellá/w
 Marcellel/w
 Marcellal/w
 Marcella/ŐAUQĘŽiĎŇqÇżß,ˇ÷
-Marcell/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl÷ř
+Marcell/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl÷ř
 Marcaltő/ŐCWRĚŻjŢÔqś,¸
 Marcali/ŐAUQĘŽiĎŇqľ,ˇ
 Marcalgergelyi/ŐBVRËŻjĐÓqś,¸
@@ -86189,7 +86419,7 @@ Manlius/UĘŽiÖKŇmôqÇżßSs,ˇk
 Manila/ŐAUQĘŽiĎŇqľ,ˇ
 Manhattan/UĘŽiÖKŇmôqľQ,ˇk
 Manga/ŐAUQĘŽiĎŇqÇżß,ˇ
-Manfréd/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Manfréd/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Manet-vá/)	ph:manévá
 Manet-val/)	ph:manéval
 Manet-/AUQĎŃŐi&)	ph:mané
@@ -86214,7 +86444,7 @@ Manardus/UĘŽiÖKŇmôqÇżßSs,ˇk
 Managua/ŐAUQĘŽiĎŇqľ,ˇ
 Mamusich/UĘŽiÖKŇmôqÇżßSs,ˇk
 Mambriny/VËŻj×LÓnňqČŔŕTt,¸l
-Malév/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl
+Malév/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl
 Maléter/VËŻj×LÓnňqČŔŕR,¸l
 Malán/UĘŽiÖKŇmôqÇżßQ,ˇk
 Malájföld/VNËŻj×LÝňÔqśR,¸l
@@ -86283,7 +86513,7 @@ Maine-/LVÓ×nRTtj&)	ph:méjn
 Maine	é	ph:méjn
 Mailáth/UĘŽiÖKŇmôqÇżßSs,ˇk
 Mailand/UĘŽiÖKŇmôqÇżßQ,ˇk
-Mahler/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl
+Mahler/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl
 Magyaróvár/UĘŽiÖKŇmôqľQ,ˇk
 Magyary/UĘŽiŐAĎŃqÇżßQ,ˇk
 Magyartés/VËŻj×LÓnňqśTt,¸l
@@ -86681,7 +86911,7 @@ Luxembourg/UĘŽiÖKŇmôqľSs,ˇk
 Lux/UĘŽiÖKŇmôqÇżßSs,ˇ
 Luttor/UĘŽiÖKŇmôqÇżßQ,ˇk
 Lutter/VËŻj×LÓnňqČŔŕR,¸l
-Luther/UVĘŽËŻijÖ×KLŇÓnňmôqßQR,ˇ¸kl
+Luther/UVĘŽËŻijÖ×KLŇÓnňmôqßŕQR,ˇ¸kl
 Lusaka/ŐAUQĘŽiĎŇqľ,ˇ
 Luppis/UĘŽiÖKŇmôqÇżßSs,ˇk
 Luppa/ŐAUQĘŽiĎŇqÇżß,ˇ
@@ -86812,7 +87042,7 @@ Loczka/ŐAUQĘŽiĎŇqÇżß,ˇ
 Lobmayer/VËŻj×LÓnňqČŔŕR,¸l
 Lobl/UĘŽiÖKŇmôqÇżßQ,ˇ
 Lobkowitz/UĘŽiÖKŇmôqÇżßSs,ˇk
-Lobacsevszkij/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl
+Lobacsevszkij/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl
 Ljubljana/ŐAUQĘŽiĎŇqľ,ˇ
 Livius/UĘŽiÖKŇmöqÇżßSs,ˇk
 Livingstone-ná/)	ph:livingsztonná
@@ -87188,6 +87418,12 @@ LMP-s/Ó×nBGVLR)
 LMP-et/w)
 LMP-/BVRĐŃŐj&)
 LMP	é
+LMBTQI-vé/)
+LMBTQI-vel/)
+LMBTQI-s/Ó×nBGVLR)
+LMBTQI-beli/ŃĐŐBGVLTt)
+LMBTQI-/LVÓ×nRTtj&)
+LMBTQI	é
 LMBTQ-vá/)
 LMBTQ-val/)
 LMBTQ-s/ŇŮmAFUKQ)
@@ -87259,7 +87495,7 @@ Kühne/ŐBVRËŻjĐÓqČŔŕ,¸
 Kübekháza/ŐAUQĘŽiĎŇqľ,ˇ
 Kún/UĘŽiÖKŇmôqÇżßQ,ˇ
 Középessy/VËŻjŐBĐŃqČŔŕR,¸l
-Közép-szibériai-fennsík/UĘŽiÖKŇmôqľQ,ˇ
+Közép-szibériai-fennsík/UĘŽiÖKŇmôqľQ,ˇözép-szibériai-fenn|sík
 Közép-Európa/ŐAUQĘŽiĎŇq,ˇ
 Közgazdaságtudományi
 Kövy/WĚŻjŐBĐŃqČÁ˙R,¸
@@ -87627,7 +87863,7 @@ Krivátsy/UĘŽiŐAĎŃqÇżßQ,ˇk
 Kriván/UĘŽiÖKŇmôqľQ,ˇk
 Krisztus-hívő/ŐCWRĚŻjŢÔíčłĹĺc¸˝	ph:krisztushívő
 Krisztus/UĘŽiÖKŇmôqÇżßSs,ˇk
-Krisztofer/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Krisztofer/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Krisztián/UĘŽiÖKŇmôqÇżßQ,ˇk÷
 Krisztinkovich/UĘŽiÖKŇmôqÇżßSs,ˇk
 Krisztinaváros/UĘŽiÖKŇmôqÇżßSs,ˇk
@@ -88426,8 +88662,9 @@ Karl/UĘŽiÖKŇmôqÇżßQ,ˇ
 Karintia/ŐAUQĘŽiĎŇqľ,ˇ
 Karinthy/UĘŽiŐAĎŃqßQ,ˇk
 Karina/ŐAUQĘŽiĎŇqÇżß,ˇ÷
+Karikó/ŐAUQĘŽiĎŇqÇżß,ˇ
 Karib-tenger/VËŻj×LÓnňqśR,¸l
-Karesz/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl÷ř
+Karesz/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl÷ř
 Kardoss/UĘŽiÖKŇmôqÇżßSs,ˇk
 Kardoskút/UĘŽiÖKŇmôqľQ,ˇk
 Kardos/UĘŽiÖKŇmôqľSs,ˇk
@@ -88488,7 +88725,7 @@ Kanyó/ŐAUQĘŽiĎŇqÇżß,ˇ
 Kanyák/UĘŽiÖKŇmôqÇżßQ,ˇk
 Kanyurszky/UĘŽiŐAĎŃqÇżßQ,ˇk
 Kant/UĘŽiÖKŇmôqÇżßQ,ˇ
-Kansas/UĘŽiÖKŇmöqľSs,ˇk
+Kansas/UVĘŽËŻijÖ×KLŇÓnőmöqľśTt,ˇ¸kl
 Kankovszky/UĘŽiŐAĎŃqÇżßQ,ˇk
 Kanizsa/ŐAUQĘŽiĎŇqľ,ˇ
 Kanitz/UĘŽiÖKŇmôqÇżßSs,ˇk
@@ -88823,7 +89060,7 @@ Jobaháza/ŐAUQĘŽiĎŇqľ,ˇ
 Joannovics/UĘŽiÖKŇmôqÇżßSs,ˇk
 Joannovich/UĘŽiÖKŇmôqÇżßSs,ˇk
 Joachim/UĘŽiÖKŇmôqÇżßSs,ˇk
-Jimmy/VËŻjŐBĐŃqČŔŕR,¸ř
+Jimmy/VËŻjŐBĐŃqČŔŕR,¸ř	ph:dzsimi
 Jeszenák/UĘŽiÖKŇmôqÇżßQ,ˇk
 Jeszenszky/VËŻjŐBĐŃqČŔŕR,¸l
 Jeruzsálem/VËŻj×LÓnňqśTt,¸l
@@ -88982,7 +89219,7 @@ Izsák/UĘŽiÖKŇmôqÇżßQ,ˇk÷ľ
 Izrael/VËŻj×LÓnňqśR,¸l
 Izolda/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Izmény/VËŻj×LÓnňqśTt,¸l
-Izmael/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl÷ř
+Izmael/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl÷ř
 Izland/UĘŽiÖKŇmôqľQ,ˇk
 Izidor/UĘŽiÖKŇmôqÇżßQ,ˇk÷
 Izdenczy/VËŻjŐBĐŃqČŔŕR,¸l
@@ -89191,7 +89428,7 @@ Ibériai-félsziget/VËŻj×LÓnňqśR,¸l
 Ibéria/ŐAUQĘŽiĎŇqľ,ˇ
 Ibsen/VËŻj×LÓnňqČŔŕR,¸l
 Ibrány/UĘŽiÖKŇmôqľSs,ˇk
-Ibrahim/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Ibrahim/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Ibos/UĘŽiÖKŇmôqÇżßSs,ˇk
 Iborfia/ŐAUQĘŽiĎŇqľ,ˇ
 Ibolya/ŐAUQĘŽiĎŇqÇżß,ˇ÷
@@ -89628,7 +89865,7 @@ Hirics/VËŻj×LÓnňqśTt,¸l
 Hirgeist/VËŻj×LÓnňqČŔŕR,¸l
 Hird/VËŻj×LÓnňqśR,¸
 Hir/VËŻj×LÓnňqČŔŕR,¸
-Hippokratész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl
+Hippokratész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl
 Hintz/VËŻj×LÓnňqČŔŕTt,¸
 Hindusztán/UĘŽiÖKŇmôqľQ,ˇk
 Hindenburg/UĘŽiÖKŇmôqÇżßSs,ˇk
@@ -89851,7 +90088,7 @@ Heathrow-/AUQĎŃŐi&)	ph:híthró	ph:hítró
 Heathrow	á	ph:híthró	ph:hítró
 Haáz/UĘŽiÖKŇmôqÇżßSs,ˇk
 Haász/UĘŽiÖKŇmôqÇżßSs,ˇk
-Hašek/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl	ph:hacsek
+Hašek/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl	ph:hacsek
 Hazucha/ŐAUQĘŽiĎŇqÇżß,ˇ
 Hazslinszky/VËŻjŐBĐŃqČŔŕR,¸l
 Hazay/UĘŽiŐAĎŃqÇżßQ,ˇk
@@ -89956,6 +90193,7 @@ Hanauer/VËŻj×LÓnňqČŔŕR,¸l
 Hanaman/UĘŽiÖKŇmôqÇżßQ,ˇk
 Hamza/ŐAUQĘŽiĎŇqÇżß,ˇ
 Hamvay/UĘŽiŐAĎŃqÇżßQ,ˇk
+Hamvas/UĘŽiÖKŇmôqÇżßSs,ˇk
 Hamupipőke/ŐBVRËŻjĐÓqČŔŕ,¸
 Hampshire-t/)	ph:hempsört
 Hampshire-ré/)	ph:hempsörré
@@ -90227,6 +90465,7 @@ Gánóczy/UĘŽiŐAĎŃqÇżßQ,ˇk
 Gánt/UĘŽiÖKŇmôqľQ,ˇ
 Gámán/UĘŽiÖKŇmôqÇżßQ,ˇk
 Gálócsy/UĘŽiŐAĎŃqÇżßQ,ˇk
+Gálvölgyi/ŐBVRËŻjĐÓqČŔŕ,¸
 Gálosfa/ŐAUQĘŽiĎŇqľ,ˇ
 Gálos/UĘŽiÖKŇmôqľSs,ˇk
 Gállik/UĘŽiÖKŇmôqÇżßQ,ˇk
@@ -90403,7 +90642,7 @@ Guszti/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Guszmann/UĘŽiÖKŇmôqÇżßQ,ˇk
 Guoth/UĘŽiÖKŇmôqÇżßSs,ˇk
 Gundelfinger/VËŻj×LÓnňqČŔŕR,¸l
-Gundel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl
+Gundel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl
 Gunaras/UĘŽiÖKŇmôqľSs,ˇk
 Gulácsy/UĘŽiŐAĎŃqÇżßQ,ˇk
 Gulács/UĘŽiÖKŇmôqľSs,ˇk
@@ -90597,6 +90836,7 @@ GmbH-val/)
 GmbH-s/ŇŮmAFUKQ)
 GmbH-/AUQĎŃŐi&)
 GmbH	á
+Gmail/VËŻj×LÓnňqČŔŕR,¸l
 Glücklich/VËŻj×LÓnňqČŔŕTt,¸l
 Glück/WĚŻjŘMÝňÔqČÁ˙R,¸
 Glykais/UĘŽiÖKŇmôqÇżßSs,ˇk
@@ -91576,6 +91816,7 @@ Evita/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Evetke/ŐBVRËŻjĐÓqČŔŕ,¸ř
 Evelin/VËŻj×LÓnňqČŔŕR,¸lř
 Eustach-kürt/WĚŻjŘMÝňÔíyČÁ˙Rc˝
+Európa-szerte	ph:európaszerte*
 Európa/ŐAUQĘŽiĎŇqľ,ˇ
 Eurázsia/ŐAUQĘŽiĎŇqľ,ˇ
 Eurovízió/ŐAUQĘŽiĎŇqÇżß,ˇ
@@ -91685,6 +91926,7 @@ Erdőalja/ŐAUQĘŽiĎŇqľ,ˇ
 Erdélyszky/VËŻjŐBĐŃqČŔŕR,¸l
 Erdély/VËŻj×LÓnňqśTt,¸l
 Erdy/VËŻjŐBĐŃqČŔŕR,¸
+Erdo&gbreve;an/UĘŽiÖKŇmôqÇżßQ,ˇk	ph:Erdogan
 Erdey/VËŻjŐBĐŃqČŔŕR,¸l
 Ercsi/ŐBVRËŻjĐÓqś,¸
 Ercsey/VËŻjŐBĐŃqČŔŕR,¸l
@@ -91737,7 +91979,7 @@ Emődi/ŐBVRËŻjĐÓqČŔŕ,¸
 Emőd/WĚŻjŘMÝňÔqČÁ˙R,¸lůś
 Emő/ŐCWRĚŻjŢÔqČÁ˙,¸ů
 Emília/ŐAUQĘŽiĎŇqÇżß,ˇ÷
-Emánuel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl÷ř
+Emánuel/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl÷ř
 Emszt/VËŻj×LÓnňqČŔŕR,¸
 Emmer/VËŻj×LÓnňqČŔŕR,¸l
 Emma/ŐAUQĘŽiĎŇqÇżß,ˇ÷
@@ -92056,7 +92298,7 @@ Dusnok/UĘŽiÖKŇmôqľQ,ˇk
 Duschek/VËŻj×LÓnňqČŔŕR,¸l
 Dusanbé/ŐAUQĘŽiĎŇß,ˇu)
 Dusanbe	é
-Duronelly/UVĘŽËŻijŐABĎĐŃqÇżßČQR,ˇ¸kl
+Duronelly/UVĘŽËŻijŐABĎĐŃqÇżßČŔŕQR,ˇ¸kl
 Durigó/ŐAUQĘŽiĎŇqÇżß,ˇ
 Durazzói/ŐAUQĘŽiĎŇqÇżß,ˇ
 Duray/UĘŽiŐAĎŃqÇżßQ,ˇk
@@ -92132,7 +92374,7 @@ Dubravszky/UĘŽiŐAĎŃqÇżßQ,ˇk
 Dubovitz/UĘŽiÖKŇmôqÇżßSs,ˇk
 Dublin/UVĘŽËŻijÖ×KLŇÓnňmôqľśQR,ˇ¸kl
 Dubicsány/UĘŽiÖKŇmôqľSs,ˇk
-Dubaj/UĘŽiÖKŇmôqľSs,ˇk
+Dubaj/UĘŽiÖKŇmôqľSs,ˇk	ph:dubai
 Dualszky/UĘŽiŐAĎŃqÇżßQ,ˇk
 Dsida/ŐAUQĘŽiĎŇqß,ˇ
 Dréhr/VËŻj×LÓnňqČŔŕR,¸
@@ -92485,7 +92727,7 @@ Dandi/ŐAUQĘŽiĎŇqÇżß,ˇ
 Danczi/ŐBVRËŻjĐÓqČŔŕ,¸
 Dancz/UĘŽiÖKŇmôqÇżßSs,ˇ
 Dancs/UĘŽiÖKŇmôqÇżßSs,ˇ
-Damoklész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl
+Damoklész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl
 Damo/ŐAUQĘŽiĎŇqÇżß,ˇ
 Damkó/ŐAUQĘŽiĎŇqÇżß,ˇ
 Damjanichhá/w
@@ -92510,7 +92752,7 @@ Dajbukát/UĘŽiÖKŇmôqÇżßQ,ˇk
 Dajaszászy/UĘŽiŐAĎŃqÇżßQ,ˇk
 Daihatsu/ŐAUQĘŽiĎŇqÇżß,ˇ	ph:dajhacu
 Daidalosz/UĘŽiÖKŇmôqÇżßSs,ˇk
-Dagobert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Dagobert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Dagesztán/UĘŽiÖKŇmôqľQ,ˇk
 Daewoo/ŐAUQĘŽiĎŇqÇżß,ˇ	ph:dévu	ph:dévó
 Daday/UĘŽiŐAĎŃqÇżßQ,ˇk
@@ -92783,6 +93025,7 @@ Csókás/UĘŽiÖKŇmôqľSs,ˇk
 Csókakő/ŐCWRĚŻjŢÔqś,¸
 Csíkszereda/ŐAUQĘŽiĎŇqľ,ˇ
 Csíkszentmárton/UĘŽiÖKŇmôqľQ,ˇk
+Csíkszentmihályi/ŐAUQĘŽiĎŇqÇżß,ˇ
 Csíkszentdomokos/UĘŽiÖKŇmôqľSs,ˇk
 Csíksomlyó/ŐAUQĘŽiĎŇqľ,ˇ
 Csévharaszt/UĘŽiÖKŇmôqľQ,ˇk
@@ -93065,6 +93308,11 @@ Covid19-cel/)
 Covid19-/LVÓ×nRTtj&)
 Covid19	é
 Covid-járvány/UĘŽiÖKŇmôqÇżßSs,ˇk
+Covid&ndash;19-es/Ó×nBGVLR)
+Covid&ndash;19-cé/)
+Covid&ndash;19-cel/)
+Covid&ndash;19-/LVÓ×nRTtj&)
+Covid&ndash;19	é
 Covid/UĘŽiÖKŇmôqÇżßQ,ˇk
 Cousteau-vá/)	ph:kusztóvá
 Cousteau-val/)	ph:kusztóval
@@ -93255,7 +93503,7 @@ Casanova/ŐAUQĘŽiĎŇqß,ˇ
 Casablanca/ŐAUQĘŽiĎŇqľ,ˇ
 Caruso/ŐAUQĘŽiĎŇqÇżß,ˇ
 Carrara/ŐAUQĘŽiĎŇqľ,ˇ
-Carmen/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl	ph:kármen
+Carmen/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl	ph:kármen
 Carlói/w
 Carina/ŐAUQĘŽiĎŇqÇżß,ˇ
 Caracas/UĘŽiÖKŇmöqľSs,ˇk
@@ -93265,7 +93513,7 @@ Capa/ŐAUQĘŽiĎŇqÇżß,ˇ
 Caola/ŐAUQĘŽiĎŇqÇżß,ˇ	ph:kaola*
 Canzi/ŐAUQĘŽiĎŇqÇżß,ˇ
 Canossa/ŐAUQĘŽiĎŇqÇżß,ˇ
-Canon/UĘŽiÖKŇmôqÇżßQ,ˇk	ph:kenon
+Canon/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl	ph:kenon
 Cannes-ná/)	ph:kanná	ph:kánná
 Cannes-nal/)	ph:kannal	ph:kánnal
 Cannes-/KUŇÖmQSsi&)	ph:kann	ph:kánn
@@ -93837,7 +94085,7 @@ Borsfa/ŐAUQĘŽiĎŇqľ,ˇ
 Borsay/UĘŽiŐAĎŃqÇżßQ,ˇk
 Borsa/ŐAUQĘŽiĎŇqľ,ˇ
 Borovszky/UĘŽiŐAĎŃqÇżßQ,ˇk
-Boroviczény/UVĘŽËŻijŐABĎĐŃqÇżßČQR,ˇ¸kl
+Boroviczény/UVĘŽËŻijŐABĎĐŃqÇżßČŔŕQR,ˇ¸kl
 Borota/ŐAUQĘŽiĎŇqľ,ˇ
 Boroszló/ŐAUQĘŽiĎŇqľ,ˇ
 Borostyánkői/ŐBVRËŻjĐÓqČŔŕ,¸
@@ -94102,6 +94350,7 @@ Bieliczki/ŐBVRËŻjĐÓqČŔŕ,¸
 Bielek/VËŻj×LÓnňqČŔŕR,¸l
 Biedermann/UĘŽiÖKŇmôqÇżßQ,ˇk
 Bieberauer/VËŻj×LÓnňqČŔŕR,¸l
+Biden/VËŻj×LÓnňqČŔŕR,¸l	ph:bájden
 Biczó/ŐAUQĘŽiĎŇqÇżß,ˇ
 Bicsérd/VËŻj×LÓnňqśR,¸l
 Bicske/ŐBVRËŻjĐÓqś,¸
@@ -94344,6 +94593,7 @@ Beleg/VËŻj×LÓnňqśTt,¸l
 Beled/VËŻj×LÓnňqśR,¸l
 Belecska/ŐAUQĘŽiĎŇqľ,ˇ
 Belatiny/VËŻjŐBĐŃqČŔŕR,¸l
+Belarusz/UĘŽiÖKŇmôqľSs,ˇk
 Bekölce/ŐBVRËŻjĐÓqś,¸
 Bekényi/ŐBVRËŻjĐÓqČŔŕ,¸
 Beksics/VËŻj×LÓnňqČŔŕTt,¸l
@@ -94390,7 +94640,7 @@ Bebrits/VËŻj×LÓnňqČŔŕTt,¸l	é
 Bebo/ŐAUQĘŽiĎŇqÇżß,ˇ
 Bebek/VËŻj×LÓnňqČŔŕR,¸l
 Beaufort-skála/ŐAUQĘŽiĎŇáyÇżßYcť
-Beatrix/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl÷ř
+Beatrix/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl÷ř
 Beatricé/ŐAUBVLQRĘŽËŻijĎĐÓß,ˇ¸u)
 Beatrice/q	é
 Beatles/VËŻj×LÓnőqČŔŕTt,¸l	ph:bitlisz	ph:bitlis
@@ -94652,13 +94902,13 @@ Balatonalmádi/ŐAUQĘŽiĎŇqľ,ˇ
 Balatonaliga/ŐAUQĘŽiĎŇqľ,ˇ
 Balatonakarattya/ŐAUQĘŽiĎŇqľ,ˇ
 Balatonakali/ŐAUQĘŽiĎŇqľ,ˇ
-Balaton-felvidék/VËŻj×LÓnňqśTt,¸
+Balaton-felvidék/VËŻj×LÓnňqśTt,¸ék
 Balaton/UĘŽiÖKŇmôqľQ,ˇk
 Balassi/ŐAUQĘŽiĎŇqß,ˇ
 Balassagyarmat/UĘŽiÖKŇmôqľQ,ˇk
 Balassa/ŐAUQĘŽiĎŇqÇżß,ˇ
 Balanyi/ŐAUQĘŽiĎŇqÇżß,ˇ
-Balambér/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Balambér/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Balajthy/UĘŽiŐAĎŃqÇżßQ,ˇk
 Balajt/UĘŽiÖKŇmôqľQ,ˇk
 Balabán/UĘŽiÖKŇmôqÇżßQ,ˇk
@@ -94793,12 +95043,12 @@ Babettól/w
 Babettá/w
 Babettel/w
 Babettal/w
-Babett/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Babett/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Babe&0219;sé/)
 Babe&0219;sá/)
 Babe&0219;sel/)
 Babe&0219;sal/)
-Babe&0219;/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl	éá	ph:babes
+Babe&0219;/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl	éá	ph:babes
 Babay/UĘŽiŐAĎŃqÇżßQ,ˇk
 Babarcszőlős/WĚŻjŘMÝňÔqśTt,¸lő-lős
 Babarc/UĘŽiÖKŇmôqľSs,ˇk
@@ -94944,7 +95194,7 @@ Ausfeldt/VËŻj×LÓnňqČŔŕR,¸l
 Auschwitz/UVĘŽËŻijÖ×KLŇÓnňmôqľśTt,ˇ¸kl	ph:ausvic
 Auróra/ŐAUQĘŽiĎŇqÇżß,ˇ
 Aurélia/ŐAUQĘŽiĎŇqÇżß,ˇ÷
-Aurél/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl÷ř
+Aurél/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl÷ř
 Aulich/UĘŽiÖKŇmôqÇżßSs,ˇk
 Aujeszky/VËŻjŐBĐŃqČŔŕR,¸l
 Aujerszky/VËŻjŐBĐŃqČŔŕR,¸l
@@ -95015,7 +95265,7 @@ Arkansas/UĘŽiÖKŇmöqľSs,ˇk
 Arka/ŐAUQĘŽiĎŇqľ,ˇ
 Arizona/ŐAUQĘŽiĎŇqľ,ˇ
 Arisztotelész/VËŻj×LÓnňqČŔŕTt,¸l
-Arisztophanész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl
+Arisztophanész/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl
 Arisztid/UĘŽiÖKŇmôqÇżßQ,ˇk÷
 Ariadné/ŐAUQĘŽiĎŇqÇżß,ˇ
 Arhangelszk/VËŻj×LÓnňqśR,¸l
@@ -95099,7 +95349,7 @@ Apache-csá/)	ph:apacscs	ph:apacscá
 Apache-csal/)	ph:apacscsal
 Apache-/BVRĐŃŐj&AUQĎi)	ph:apacs	ph:apac
 Apache	éá	ph:apacs	ph:apac
-Anyegin/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl
+Anyegin/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl
 Antónia/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Antwerpen/VËŻj×LÓnňqśR,¸l
 Antos/UĘŽiÖKŇmôqľSs,ˇk
@@ -95161,7 +95411,7 @@ Anettá/w
 Anettka/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Anettel/w
 Anettal/w
-Anett/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Anett/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Andrássyak/UŇmŮ)ássy
 Andrássy/UĘŽiŐAĎŃqÇżßQ,ˇk	ássyak
 Andrásofszky/UĘŽiŐAĎŃqÇżßQ,ˇk
@@ -95213,7 +95463,7 @@ Anarcs/UĘŽiÖKŇmôqľSs,ˇk
 Anakreón/UĘŽiÖKŇmôqÇżßQ,ˇk
 Amálka/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Amália/ŐAUQĘŽiĎŇqÇżß,ˇ÷
-Amundsen/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl
+Amundsen/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl
 Amtmann/UĘŽiÖKŇmôqÇżßQ,ˇk
 Amszterdam/UĘŽiÖKŇmôqľSs,ˇk
 Amsel/VËŻj×LÓnňqČŔŕR,¸l
@@ -95328,7 +95578,7 @@ Alexandria/ŐAUQĘŽiĎŇqľ,ˇ
 Alexandra/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Alexander/VËŻj×LÓnňqČŔŕR,¸l
 Alexa/ŐAUQĘŽiĎŇqÇżß,ˇ÷
-Alex/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČTt,ˇ¸kl÷ř
+Alex/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕTt,ˇ¸kl÷ř
 Aletta/ŐAUQĘŽiĎŇqÇżß,ˇ÷
 Alekszej/VËŻj×LÓnňqČŔŕTt,¸lř
 Alekszandr/UĘŽiÖKŇmôqÇżßQ,ˇk÷
@@ -95345,7 +95595,7 @@ Albin/UĘŽiÖKŇmôqÇżßQ,ˇk÷
 Albertirsa/ŐAUQĘŽiĎŇqľ,ˇ
 Alberti/ŐBVRËŻjĐÓqś,¸
 Albertfalva/ŐAUQĘŽiĎŇqľ,ˇ
-Albert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Albert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Alber/VËŻj×LÓnňqČŔŕR,¸l
 Albeni/ŐBVRËŻjĐÓqČŔŕ,¸
 Albely/VËŻj×LÓnňqČŔŕTt,¸l
@@ -95383,7 +95633,7 @@ Aires/VËŻj×LÓnőqTt,¸l
 Air/VËŻj×LÓnňqČŔŕR,¸l
 Aigner/VËŻj×LÓnňqČŔŕR,¸l
 Aida/ŐAUQĘŽiĎŇqÇżß,ˇ÷
-Ahmed/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Ahmed/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Agárd/UĘŽiÖKŇmôqľQ,ˇk
 Agyagosszergény/VËŻj×LÓnňqśTt,¸lény
 Aguszta/ŐAUQĘŽiĎŇqÇżß,ˇ÷
@@ -95398,7 +95648,7 @@ Agamemnón/UĘŽiÖKŇmôqÇżßQ,ˇk
 Afrika/ŐAUQĘŽiĎŇqľ,ˇ
 Afganisztán/UĘŽiÖKŇmôqľQ,ˇk
 Aeneas/UĘŽiÖKŇmöqÇżßSs,ˇk	ph:éneász	ph:éneás
-Adél/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl÷ř
+Adél/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl÷ř
 Adásztevel/VËŻj×LÓnňqśR,¸l
 Adács/UĘŽiÖKŇmôqľSs,ˇk
 Adyak/UŇmŮ)
@@ -95428,7 +95678,7 @@ Adigeföld/VNËŻj×LÝňÔqśR,¸l
 Adidas/UĘŽiÖKŇmöqÇżßSs,ˇk
 Addisz-Abeba/ŐAUQĘŽiĎŇq,ˇ
 Adami/ŐAUQĘŽiĎŇqÇżß,ˇ
-Adalbert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl÷ř
+Adalbert/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl÷ř
 Ada/ŐAUQĘŽiĎŇqľ,ˇ
 Aczél/UĘŽiÖKŇmôqÇżßQ,ˇk
 ActiveX-szé/)
@@ -95441,7 +95691,7 @@ Acsád/UĘŽiÖKŇmôqľQ,ˇk
 Acsay/UĘŽiŐAĎŃqÇżßQ,ˇk
 Acsalag/UĘŽiÖKŇmôqľSs,ˇk
 Acsa/ŐAUQĘŽiĎŇqľ,ˇ
-Ackner/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQR,ˇ¸kl
+Ackner/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQR,ˇ¸kl
 Achilles-ín-szakadás/UĘŽiÖKŇmôáyÇżßSscť	ph:Achilles-ínszakadás
 Achilles-ín/VÓnňcČ
 Achilles-sarok/UmôyiYcŽ
@@ -95461,7 +95711,7 @@ Abrudbánya/ŐAUQĘŽiĎŇqľ,ˇ
 Abony/UĘŽiÖKŇmôqľSs,ˇk
 Abody/UĘŽiŐAĎŃqÇżßQ,ˇk
 Abod/UĘŽiÖKŇmôqľQ,ˇk
-Abigél/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČQRTt,ˇ¸kl÷ř
+Abigél/UVĘŽËŻijÖ×KLŇÓnňmôqÇżßČŔŕQRTt,ˇ¸kl÷ř
 Abet/VËŻj×LÓnňqČŔŕR,¸l
 Abesszínia/ŐAUQĘŽiĎŇqÇżß,ˇ
 Abelovszki/ŐAUQĘŽiĎŇqÇżß,ˇ

--- a/dictionaries/hu/license
+++ b/dictionaries/hu/license
@@ -1,7 +1,7 @@
 * Szabad magyar szótár (Magyar Ispell) –
   Hungarian spelling and morphological dictionary for Hunspell *
 
- Copyright 2008-2023, László Németh & Ferenc Godó
+ Copyright 2008-2024, László Németh & Ferenc Godó
 
  Copyright 2002-2007, László Németh <nemeth@numbertext.org>
 
@@ -191,6 +191,8 @@ http://almos.vein.hu/~vonyoa
 History
 =======
 
+2024-03-27 Magyar Ispell 1.8.1
+2023-05-17 Magyar Ispell 1.8
 2018-05-17 Magyar Ispell 1.7
 2017–18    Magyar Ispell 1.7 beta 2–5
 2015-10-27 Magyar Ispell 1.7 beta

--- a/script/crawl.sh
+++ b/script/crawl.sh
@@ -288,7 +288,7 @@ crawl "hebrew" \
 # copy/paste the URL of the latest `.zip` file.
 crawl "hungarian" \
   "https://github.com/laszlonemeth/magyarispell" \
-  "https://github.com/crash5/mozilla-hungarian-spellchecker/releases/download/2023.05.22.12.31/MagyarIspell_adf496c.zip"
+  "https://github.com/crash5/mozilla-hungarian-spellchecker/releases/download/2024.03.28.01.14/MagyarIspell_3aa21cc.zip"
 # Hasn’t updated in 8 years.
 # Go to <https://addons.thunderbird.net/en-US/thunderbird/addon/dict-ia/>,
 # copy/paste the URL for “Download Now” (but clean it).


### PR DESCRIPTION
Update the Hungarian dictionary to [the latest release](https://github.com/crash5/mozilla-hungarian-spellchecker/releases/tag/2024.03.28.01.14).

I'm not able to verify the dictionary changes; this just updates the dictionary to the latest version.

Sadly #63 is still not fixed; I made [an attempt](https://github.com/laszlonemeth/magyarispell/pull/84) but abandoned it as the wrong approach.